### PR TITLE
fix: include reference and CSS tokens in isTokenValue

### DIFF
--- a/core/src/typeGuards.test.ts
+++ b/core/src/typeGuards.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { isTokenValue } from "./typeGuards";
+import type { Reference, CSS } from "./types";
+
+describe("isTokenValue", () => {
+	it("should return true for primitive token values", () => {
+		expect(isTokenValue("string")).toBe(true);
+		expect(isTokenValue(42)).toBe(true);
+		expect(isTokenValue(true)).toBe(true);
+		expect(isTokenValue(null)).toBe(true);
+	});
+
+	it("should return true for Reference objects", () => {
+		const ref: Reference = { type: "reference", name: "color" };
+		expect(isTokenValue(ref)).toBe(true);
+	});
+
+	it("should return true for CSS objects", () => {
+		const css: CSS = { type: "css", value: ["color", "red"] };
+		expect(isTokenValue(css)).toBe(true);
+	});
+
+	it("should return true for arrays of token values", () => {
+		const ref: Reference = { type: "reference", name: "size" };
+		const css: CSS = { type: "css", value: ["margin", "0"] };
+		expect(isTokenValue(["foo", ref, css])).toBe(true);
+	});
+
+	it("should return false for invalid values", () => {
+		expect(isTokenValue({})).toBe(false);
+		expect(isTokenValue(["foo", {}])).toBe(false);
+	});
+});

--- a/core/src/typeGuards.ts
+++ b/core/src/typeGuards.ts
@@ -75,6 +75,8 @@ export function isPrimitiveTokenValue(
 export function isTokenValue(value: unknown): value is TokenValue {
 	return (
 		isPrimitiveTokenValue(value) ||
+		isRef(value) ||
+		isCSS(value) ||
 		(Array.isArray(value) && value.every(isTokenValue))
 	);
 }


### PR DESCRIPTION
## Summary
- ensure `isTokenValue` returns true for `reference` and `css` token objects
- add unit tests for `isTokenValue`

## Testing
- `pnpm lint core/src/typeGuards.test.ts core/src/typeGuards.ts`
- `pnpm --filter @styleframe/core test`


------
https://chatgpt.com/codex/tasks/task_b_6896238d47ec8331b8ee15c33658b670