### PR TITLE
Include media in styleframe return

### DIFF
--- a/core/src/styleframe.ts
+++ b/core/src/styleframe.ts
@@ -46,7 +46,7 @@ export function styleframe(config?: StyleframeConfig): Styleframe {
 		// recipe,
 		// theme,
 		// keyframes,
-		// media,
+		media,
 		ref,
 		css,
 	};


### PR DESCRIPTION
## Summary
- include `media` in `styleframe` return object so it aligns with the `Styleframe` interface

## Testing
- `pnpm --filter @styleframe/core typecheck`
- `pnpm --filter @styleframe/core test`
- `pnpm lint core/src/styleframe.ts`


------
https://chatgpt.com/codex/tasks/task_b_68963fcf90f08331a9632ce21e8bbd0f