### PR TITLE
docs: capitalize TypeScript in description

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "styleframe",
 	"version": "0.0.1",
-	"description": "Write modern, clean, composable CSS using Typescript, with a focus on simplicity and performance.",
+	"description": "Write modern, clean, composable CSS using TypeScript, with a focus on simplicity and performance.",
 	"author": "Alex Grozav <alex@styleframe.dev>",
 	"scripts": {
 		"build": "turbo run build",


### PR DESCRIPTION
## Summary
- capitalize TypeScript in package description

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_b_68963fd1acac83318d12995875472c42