### PR TITLE
feat: Add initial `@styleframe/plugin` release with Vite support

### DIFF
--- a/.changeset/popular-onions-cough.md
+++ b/.changeset/popular-onions-cough.md
@@ -1,0 +1,18 @@
+---
+"@styleframe/plugin": major
+---
+
+feat: Initial release. Add `unplugin` instance with dedicated Vite support
+
+---
+"@styleframe/transpiler": patch
+---
+
+feat: Add support for custom transpile functions
+refactor: Separate CSS and TS transpilation
+
+---
+"@styleframe/loader": patch
+---
+
+feat: Add support for loading configuration from path


### PR DESCRIPTION
Initial release includes Vite support and custom transpile functions. Added support for loading configuration from a path.