### PR TITLE
feat: Add support for generic records in `createUseVariable`

### DIFF
--- a/.changeset/early-tires-change.md
+++ b/.changeset/early-tires-change.md
@@ -1,0 +1,7 @@
+---
+"@styleframe/cli": patch
+"@styleframe/theme": patch
+"styleframe": patch
+---
+
+feat: add support for generic records in createUseVariable

--- a/theme/src/types.ts
+++ b/theme/src/types.ts
@@ -1,4 +1,4 @@
-import type { TokenValue, Variable } from "@styleframe/core";
+import type { Variable } from "@styleframe/core";
 import type { CamelCase } from "scule";
 
 /**
@@ -23,7 +23,7 @@ type ExportKeyVariableName<
  */
 export type ExportKeys<
 	Prefix extends string,
-	T extends Record<string, TokenValue>,
+	T extends Record<string, unknown>,
 	Separator extends string = "--",
 > = {
 	[K in keyof T as CamelCase<

--- a/theme/src/utils/createUseVariable.ts
+++ b/theme/src/utils/createUseVariable.ts
@@ -46,8 +46,9 @@ export function isKeyReferenceValue(value: unknown): value is string {
  */
 export function createUseVariable<
 	PropertyName extends string,
+	PropertyType extends TokenValue,
 	Delimiter extends string = "--",
-	Defaults extends Record<string, TokenValue> = Record<string, TokenValue>,
+	Defaults extends Record<string, PropertyType> = Record<string, PropertyType>,
 	MergeDefaults extends boolean = false,
 >(
 	propertyName: PropertyName,
@@ -59,13 +60,15 @@ export function createUseVariable<
 	}: {
 		defaults?: Defaults;
 		mergeDefaults?: MergeDefaults;
-		transform?: (value: TokenValue) => TokenValue;
+		transform?: (value: PropertyType) => PropertyType;
 		delimiter?: Delimiter;
 	} = {},
 ) {
 	type WithDefaults<T> = MergeDefaults extends true ? Defaults & T : T;
 
-	return function useVariable<T extends Record<string, TokenValue> = Defaults>(
+	return function useVariable<
+		T extends Record<string, PropertyType> = Defaults,
+	>(
 		s: Styleframe,
 		tokens?: T,
 	): ExportKeys<PropertyName, WithDefaults<T>, Delimiter> {

--- a/tooling/cli/src/package.ts
+++ b/tooling/cli/src/package.ts
@@ -1,2 +1,2 @@
-export const version = "1.0.2";
+export const version = "1.0.4";
 export const description = "A command-line interface for styleframe.";


### PR DESCRIPTION
This pull request adds support for generic record types in the `createUseVariable` utility, making it more flexible and allowing usage with arbitrary value types instead of being restricted to `TokenValue`. The changes also update type definitions and the CLI package version accordingly.

#### Generic record support and type improvements

* Updated the `ExportKeys` type in `theme/src/types.ts` to allow `Record<string, unknown>` instead of requiring `TokenValue`, enabling broader use cases for exported variable keys.
* Refactored the `createUseVariable` function in `theme/src/utils/createUseVariable.ts` to accept a generic `PropertyType`, allowing defaults and transformations to work with any value type, not just `TokenValue`. [[1]](diffhunk://#diff-2fc82452c52bcc4adaa2423869928633d9df9fdae6ec4f750139d7d9793fd11dR49-R51) [[2]](diffhunk://#diff-2fc82452c52bcc4adaa2423869928633d9df9fdae6ec4f750139d7d9793fd11dL62-R71)

#### Package version and metadata

* Bumped the CLI package version from `1.0.2` to `1.0.4` in `tooling/cli/src/package.ts` to reflect the new feature.
* Added a changeset file documenting the new feature and affected packages. (.changeset/early-tires-change.md)