### PR TITLE
fix(cli): update install version

### DIFF
--- a/.changeset/silly-tools-leave.md
+++ b/.changeset/silly-tools-leave.md
@@ -1,0 +1,16 @@
+---
+"@styleframe/cli": patch
+"@styleframe/app": patch
+"@styleframe/docs": patch
+"@styleframe/app-shared": patch
+"@styleframe/config-typescript": patch
+"@styleframe/config-vite": patch
+"@styleframe/core": patch
+"@styleframe/loader": patch
+"styleframe": patch
+"@styleframe/transpiler": patch
+"@styleframe/theme": patch
+"@styleframe/plugin": patch
+---
+
+fix(cli): update install version

--- a/tooling/cli/src/commands/init.ts
+++ b/tooling/cli/src/commands/init.ts
@@ -35,9 +35,9 @@ export async function addPackageJsonDependencies(cwd: string) {
 		const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8"));
 
 		if (!packageJson.devDependencies) packageJson.devDependencies = {};
-		packageJson.devDependencies["styleframe"] = "^1.0.0";
-		packageJson.devDependencies["@styleframe/theme"] = "^1.0.0";
-		packageJson.devDependencies["@styleframe/pro"] = "^1.0.0";
+		packageJson.devDependencies["styleframe"] = "^2.0.0";
+		packageJson.devDependencies["@styleframe/theme"] = "^2.0.0";
+		packageJson.devDependencies["@styleframe/pro"] = "^2.0.0";
 
 		await writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2));
 


### PR DESCRIPTION
This pull request updates the install version for several Styleframe packages to ensure users get the latest features and fixes. The main change is bumping the dependency versions from `^1.0.0` to `^2.0.0` in the CLI initialization process.

Dependency version updates:

* The `addPackageJsonDependencies` function in `tooling/cli/src/commands/init.ts` now adds `styleframe`, `@styleframe/theme`, and `@styleframe/pro` as devDependencies with version `^2.0.0` instead of `^1.0.0`.

Release notes:

* A new changeset was added to `.changeset/silly-tools-leave.md` to document the patch updates across multiple Styleframe packages, including CLI, app, docs, and core modules.