### PR TITLE
fix: resolve icon loading warnings during docs build

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -35,7 +35,10 @@
 		"zod": "catalog:"
 	},
 	"devDependencies": {
+		"@iconify-json/devicon": "1.2.62",
 		"@iconify-json/lucide": "1.2.69",
+		"@iconify-json/material-symbols": "1.2.65",
+		"@iconify-json/mdi": "1.2.3",
 		"@iconify-json/simple-icons": "1.2.54",
 		"@iconify-json/vscode-icons": "1.2.31",
 		"@nuxt/kit": "catalog:nuxt",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -33,7 +33,10 @@
 		"zod": "catalog:"
 	},
 	"devDependencies": {
+		"@iconify-json/devicon": "1.2.62",
 		"@iconify-json/lucide": "1.2.69",
+		"@iconify-json/material-symbols": "1.2.65",
+		"@iconify-json/mdi": "1.2.3",
 		"@iconify-json/simple-icons": "1.2.54",
 		"@iconify-json/vscode-icons": "1.2.31",
 		"@nuxt/kit": "catalog:nuxt",

--- a/apps/shared/nuxt.config.ts
+++ b/apps/shared/nuxt.config.ts
@@ -18,6 +18,7 @@ export default defineNuxtConfig({
 		"nuxt-llms",
 	],
 	icon: {
-		provider: "iconify",
+		serverBundle: "local",
+		fetchTimeout: 10000,
 	},
 });

--- a/apps/shared/package.json
+++ b/apps/shared/package.json
@@ -22,7 +22,10 @@
 		"zod": "catalog:"
 	},
 	"devDependencies": {
+		"@iconify-json/devicon": "1.2.62",
 		"@iconify-json/lucide": "1.2.69",
+		"@iconify-json/material-symbols": "1.2.65",
+		"@iconify-json/mdi": "1.2.3",
 		"@iconify-json/simple-icons": "1.2.54",
 		"@iconify-json/vscode-icons": "1.2.31",
 		"@nuxt/kit": "catalog:nuxt",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,9 +238,18 @@ importers:
         specifier: 'catalog:'
         version: 4.1.12
     devDependencies:
+      '@iconify-json/devicon':
+        specifier: 1.2.62
+        version: 1.2.62
       '@iconify-json/lucide':
         specifier: 1.2.69
         version: 1.2.69
+      '@iconify-json/material-symbols':
+        specifier: 1.2.65
+        version: 1.2.65
+      '@iconify-json/mdi':
+        specifier: 1.2.3
+        version: 1.2.3
       '@iconify-json/simple-icons':
         specifier: 1.2.54
         version: 1.2.54
@@ -347,9 +356,18 @@ importers:
         specifier: 'catalog:'
         version: 4.1.12
     devDependencies:
+      '@iconify-json/devicon':
+        specifier: 1.2.62
+        version: 1.2.62
       '@iconify-json/lucide':
         specifier: 1.2.69
         version: 1.2.69
+      '@iconify-json/material-symbols':
+        specifier: 1.2.65
+        version: 1.2.65
+      '@iconify-json/mdi':
+        specifier: 1.2.3
+        version: 1.2.3
       '@iconify-json/simple-icons':
         specifier: 1.2.54
         version: 1.2.54
@@ -435,9 +453,18 @@ importers:
         specifier: 'catalog:'
         version: 4.1.12
     devDependencies:
+      '@iconify-json/devicon':
+        specifier: 1.2.62
+        version: 1.2.62
       '@iconify-json/lucide':
         specifier: 1.2.69
         version: 1.2.69
+      '@iconify-json/material-symbols':
+        specifier: 1.2.65
+        version: 1.2.65
+      '@iconify-json/mdi':
+        specifier: 1.2.3
+        version: 1.2.3
       '@iconify-json/simple-icons':
         specifier: 1.2.54
         version: 1.2.54
@@ -1848,8 +1875,17 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@iconify-json/devicon@1.2.62':
+    resolution: {integrity: sha512-X0o0+fOJL2t5JTbDCGLRzrmvf8Pv5q8dr86+fW+F/VJ9qvXTtny6lqGIwjE9AY4VTLm3i8f/N+VtRheSW6OkEg==}
+
   '@iconify-json/lucide@1.2.69':
     resolution: {integrity: sha512-xOhNf74m+C+nSCObfEqYi34dXk1GMfMUcOB+gfqKY/bn0RcsPLinGfgouOvrUFEreDEFbCti7sdheTf5HESLTA==}
+
+  '@iconify-json/material-symbols@1.2.65':
+    resolution: {integrity: sha512-0kGO7z+yuWjn4de2gAz1hrOpDHN1rvnb1Lr3YnkmZr/pJ9bfLSv2bRXQo/nKx6oODXKcoYuFLcLvg2xPxMq5Pg==}
+
+  '@iconify-json/mdi@1.2.3':
+    resolution: {integrity: sha512-O3cLwbDOK7NNDf2ihaQOH5F9JglnulNDFV7WprU2dSoZu3h3cWH//h74uQAB87brHmvFVxIOkuBX2sZSzYhScg==}
 
   '@iconify-json/simple-icons@1.2.54':
     resolution: {integrity: sha512-OQQYl8yC5j3QklZOYnK31QYe5h47IhyCoxSLd53f0e0nA4dgi8VOZS30SgSAbsecQ+S0xlGJMjXIHTIqZ+ML3w==}
@@ -10485,7 +10521,19 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@iconify-json/devicon@1.2.62':
+    dependencies:
+      '@iconify/types': 2.0.0
+
   '@iconify-json/lucide@1.2.69':
+    dependencies:
+      '@iconify/types': 2.0.0
+
+  '@iconify-json/material-symbols@1.2.65':
+    dependencies:
+      '@iconify/types': 2.0.0
+
+  '@iconify-json/mdi@1.2.3':
     dependencies:
       '@iconify/types': 2.0.0
 


### PR DESCRIPTION
## Summary
- Replace `provider: "iconify"` (CDN API) with `serverBundle: "local"` so icons resolve from locally installed `@iconify-json/*` packages instead of network requests during build
- Add missing icon collections: `@iconify-json/devicon`, `@iconify-json/material-symbols`, `@iconify-json/mdi`
- Increase `fetchTimeout` to 10s to handle concurrent prerendering load

## Test plan
- [x] `pnpm build:docs` completes with zero `[Icon] failed to load` or `timed out` warnings