### PR TITLE
feat: Add Spinner recipe with circle, text, overlay, and docs

### DIFF
--- a/.changeset/add-spinner-recipe.md
+++ b/.changeset/add-spinner-recipe.md
@@ -1,0 +1,12 @@
+---
+"@styleframe/theme": minor
+"styleframe": minor
+---
+
+Add Spinner recipe with circle, text, overlay, tests, and documentation
+
+- Add `useSpinnerRecipe` container recipe with 4 colors (primary, light, dark, neutral) and 4 sizes (auto, sm, md, lg)
+- Add `useSpinnerCircleRecipe` with SVG stroke-dasharray animation and keyframes
+- Add `useSpinnerTextRecipe` for centered label overlay on the spinner
+- Add `useSpinnerOverlayRecipe` for fixed/absolute backdrop
+- Add Spinner documentation page with usage examples, API reference, and FAQ

--- a/apps/docs/content/docs/06.components/02.composables/13.spinner.md
+++ b/apps/docs/content/docs/06.components/02.composables/13.spinner.md
@@ -1,0 +1,316 @@
+---
+title: Spinner
+description: A loading spinner component with color, size, and optional overlay — built as a multi-part recipe system with SVG-based animation.
+---
+
+## Overview
+
+The **Spinner** is a visual indicator used to communicate that an action is in progress. The `useSpinnerRecipe()` composable creates a fully configured [recipe](/docs/api/recipes) with color and size options, while `useSpinnerCircleRecipe()` handles the SVG spinner animation and `useSpinnerOverlayRecipe()` provides an optional backdrop overlay.
+
+The Spinner recipe integrates directly with the default [design tokens preset](/docs/design-tokens/presets) and generates type-safe utility classes at build time with zero runtime CSS.
+
+## Why use the Spinner recipe?
+
+The Spinner recipe helps you:
+
+- **Ship faster with sensible defaults**: Get 4 colors and 3 sizes out of the box with a single composable call.
+- **Maintain consistency**: The SVG-based spinner animation is consistent across all color and size combinations.
+- **Customize without forking**: Override base styles, default variants, or filter out options you don't need &mdash; all through the options API.
+- **Stay type-safe**: Full TypeScript support means your editor catches invalid color or size values at compile time.
+- **Integrate with your tokens**: Every value references the design tokens preset, so theme changes propagate automatically.
+
+## Usage
+
+::steps{level="4"}
+
+#### Register the recipes
+
+Add the Spinner recipes to a local Styleframe instance. The global `styleframe.config.ts` provides design tokens and utilities, while the component-level file registers the recipes themselves:
+
+:::code-tree{default-value="src/components/spinner.styleframe.ts"}
+
+```ts [src/components/spinner.styleframe.ts]
+import { styleframe } from 'virtual:styleframe';
+import { useSpinnerRecipe, useSpinnerCircleRecipe, useSpinnerOverlayRecipe } from '@styleframe/theme';
+
+const s = styleframe();
+
+const spinner = useSpinnerRecipe(s);
+const spinnerCircle = useSpinnerCircleRecipe(s);
+const spinnerOverlay = useSpinnerOverlayRecipe(s);
+
+export default s;
+```
+
+```ts [styleframe.config.ts]
+import { styleframe } from 'styleframe';
+import { useDesignTokensPreset, useUtilitiesPreset } from '@styleframe/theme';
+
+const s = styleframe();
+
+useDesignTokensPreset(s);
+useUtilitiesPreset(s);
+
+export default s;
+```
+
+:::
+
+#### Build the component
+
+Import the `spinner` and `spinnerCircle` runtime functions from the virtual module and pass variant props to compute class names:
+
+:::tabs
+::::tabs-item{icon="i-devicon-react" label="React"}
+
+```ts [src/components/Spinner.tsx]
+import { spinner, spinnerCircle } from "virtual:styleframe";
+
+interface SpinnerProps {
+	color?: "primary" | "light" | "dark" | "neutral";
+	size?: "auto" | "sm" | "md" | "lg";
+	label?: string;
+	children?: React.ReactNode;
+}
+
+export function Spinner({
+	color = "primary",
+	size = "md",
+	label,
+	children,
+}: SpinnerProps) {
+	const containerClasses = spinner({ color, size });
+	const circleClasses = spinnerCircle({ size });
+
+	return (
+		<div className={containerClasses} role="status">
+			<svg className={circleClasses} viewBox="0 0 50 50">
+				<circle cx="25" cy="25" r="20" />
+			</svg>
+			{label && <span>{label}</span>}
+			{children}
+		</div>
+	);
+}
+```
+
+::::
+::::tabs-item{icon="i-devicon-vuejs" label="Vue"}
+
+```vue [src/components/Spinner.vue]
+<script setup lang="ts">
+import { spinner, spinnerCircle } from "virtual:styleframe";
+
+const { color = "primary", size = "md", label } = defineProps<{
+	color?: "primary" | "light" | "dark" | "neutral";
+	size?: "auto" | "sm" | "md" | "lg";
+	label?: string;
+}>();
+</script>
+
+<template>
+	<div :class="spinner({ color, size })" role="status">
+		<svg :class="spinnerCircle({ size })" viewBox="0 0 50 50">
+			<circle cx="25" cy="25" r="20" />
+		</svg>
+		<span v-if="label">{{ label }}</span>
+		<slot />
+	</div>
+</template>
+```
+
+::::
+:::
+
+#### See it in action
+
+:::story-preview
+---
+story: theme-recipes-spinner--default
+panel: true
+---
+:::
+
+::
+
+## Colors
+
+The Spinner supports 4 color options. The `color` variant sets the CSS `color` property on the container, which cascades to the SVG spinner via `currentColor`.
+
+::story-preview
+---
+story: theme-recipes-spinner--primary
+panel: true
+---
+::
+
+### Color Reference
+
+::story-preview
+---
+story: theme-recipes-spinner--all-variants
+height: 320
+---
+::
+
+| Color | Token | Use Case |
+|-------|-------|----------|
+| `primary` | `@color.primary` | Default loading state, primary actions |
+| `light` | `@color.gray-700` | Loading on dark backgrounds, stays fixed in dark mode |
+| `dark` | `@color.white` | Loading on light backgrounds, stays fixed in dark mode |
+| `neutral` | Adaptive (light ↔ dark) | Default adaptive color, adjusts to the current color scheme |
+
+::tip
+**Pro tip:** Use `neutral` for general-purpose loading states that need to adapt to both light and dark mode automatically.
+::
+
+## Sizes
+
+The Spinner comes in 3 sizes that control both the spinner dimensions and the label text size.
+
+::story-preview
+---
+story: theme-recipes-spinner--all-sizes
+height: 320
+---
+::
+
+| Size | Spinner Dimensions | Font Size |
+|------|-------------------|-----------|
+| `auto` | `100%` × `100%` | Inherits base |
+| `sm` | `@2` × `@2` | `@font-size.xs` |
+| `md` | `@3` × `@3` | `@font-size.sm` |
+| `lg` | `@4` × `@4` | `@font-size.md` |
+
+## Label
+
+You can display optional text below the spinner using the `label` prop.
+
+::story-preview
+---
+story: theme-recipes-spinner--with-label
+panel: true
+---
+::
+
+## Overlay
+
+Use `useSpinnerOverlayRecipe()` to create a fixed overlay backdrop for full-page or container-level loading states.
+
+```vue [src/components/SpinnerOverlay.vue]
+<script setup lang="ts">
+import { spinnerOverlay } from "virtual:styleframe";
+</script>
+
+<template>
+	<div :class="spinnerOverlay({})">
+		<Spinner color="dark" size="lg" label="Loading..." />
+	</div>
+</template>
+```
+
+## Accessibility
+
+- **Always include `role="status"`** on the spinner container to announce loading state to screen readers.
+- **Provide descriptive text** via the `label` prop or a visually hidden `<span>` for screen readers when no visible label is shown.
+- **Animation respects `prefers-reduced-motion`**: The design tokens preset automatically disables animations when the user has reduced motion enabled.
+
+## Customization
+
+### Overriding Defaults
+
+```ts [src/components/spinner.styleframe.ts]
+const spinner = useSpinnerRecipe(s, {
+    defaultVariants: { color: 'neutral', size: 'lg' },
+});
+```
+
+### Filtering Variants
+
+```ts [src/components/spinner.styleframe.ts]
+const spinner = useSpinnerRecipe(s, {
+    filter: {
+        color: ['primary', 'neutral'],
+    },
+});
+```
+
+::note
+**Good to know:** Filtering also removes compound variants and adjusts default variants that reference filtered-out values, so your recipe stays consistent.
+::
+
+## API Reference
+
+### `useSpinnerRecipe(s, options?)`
+
+Creates the spinner container recipe with color and size variants.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `s` | `Styleframe` | The Styleframe instance |
+| `options` | `DeepPartial<RecipeConfig>` | Optional overrides for the recipe configuration |
+| `options.base` | `VariantDeclarationsBlock` | Custom base styles |
+| `options.variants` | `Variants` | Custom variant definitions |
+| `options.defaultVariants` | `Record<keyof Variants, string>` | Default variant values |
+| `options.compoundVariants` | `CompoundVariant[]` | Custom compound variant definitions |
+| `options.filter` | `Record<string, string[]>` | Limit which variant values are generated |
+
+**Variants:**
+
+| Variant | Options | Default |
+|---------|---------|---------|
+| `color` | `primary`, `light`, `dark`, `neutral` | `primary` |
+| `size` | `auto`, `sm`, `md`, `lg` | `md` |
+
+### `useSpinnerCircleRecipe(s, options?)`
+
+Creates the SVG spinner recipe with size variants and animation keyframes.
+
+**Variants:**
+
+| Variant | Options | Default |
+|---------|---------|---------|
+| `size` | `auto`, `sm`, `md`, `lg` | `md` |
+
+### `useSpinnerOverlayRecipe(s, options?)`
+
+Creates the overlay backdrop recipe. No variants &mdash; provides a fixed full-screen backdrop.
+
+[Learn more about recipes ->](/docs/api/recipes)
+
+## Best Practices
+
+- **Use `role="status"`** on the spinner element for accessibility.
+- **Provide a label** for longer loading operations so users know what's happening.
+- **Choose the right color**: Use `primary` for brand-colored spinners, `neutral` for general use, and `light`/`dark` for specific background contexts.
+- **Filter what you don't need**: Pass a `filter` option to reduce generated CSS.
+- **Use the overlay sparingly**: Full-page overlays block interaction &mdash; prefer inline spinners when possible.
+
+## FAQ
+
+::accordion
+
+:::accordion-item{label="How does the SVG spinner animation work?" icon="i-lucide-circle-help"}
+The spinner uses two CSS keyframe animations: `spinner-rotate` for continuous rotation and `spinner-dash` for the stroke dash effect that creates the "chasing" appearance. These are registered automatically when you call `useSpinnerCircleRecipe()`.
+:::
+
+:::accordion-item{label="How does color inheritance work?" icon="i-lucide-circle-help"}
+The `useSpinnerRecipe` sets the CSS `color` property via compound variants. The SVG circle's `stroke` is set to `currentColor` via a selector in the spinner circle recipe's setup function. This means the spinner color automatically inherits from the container &mdash; no extra wiring needed.
+:::
+
+:::accordion-item{label="How does filtering affect compound variants?" icon="i-lucide-circle-help"}
+When you use the `filter` option, compound variants that reference filtered-out values are automatically removed. Default variants are also adjusted if they reference a removed value.
+:::
+
+:::accordion-item{label="Can I use the overlay with a container instead of full-page?" icon="i-lucide-circle-help"}
+Yes! Override the overlay's `position` to `absolute` and ensure the parent container has `position: relative`:
+```ts
+const spinnerOverlay = useSpinnerOverlayRecipe(s, {
+    base: { position: 'absolute' },
+});
+```
+:::
+
+::

--- a/apps/storybook/src/components/components/spinner/Spinner.vue
+++ b/apps/storybook/src/components/components/spinner/Spinner.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { spinner, spinnerCircle, spinnerText } from "virtual:styleframe";
+
+const props = withDefaults(
+	defineProps<{
+		color?: "primary" | "light" | "dark" | "neutral";
+		size?: "auto" | "sm" | "md" | "lg";
+		label?: string;
+	}>(),
+	{},
+);
+
+const spinnerClasses = computed(() =>
+	spinner({
+		color: props.color,
+		size: props.size,
+	}),
+);
+
+const circleClasses = computed(() =>
+	spinnerCircle({
+		size: props.size,
+	}),
+);
+
+const textClasses = computed(() =>
+	spinnerText({
+		size: props.size,
+	}),
+);
+</script>
+
+<template>
+	<div :class="spinnerClasses" role="status">
+		<svg :class="circleClasses" viewBox="0 0 50 50">
+			<circle cx="25" cy="25" r="20" />
+		</svg>
+		<span v-if="props.label" :class="textClasses">{{ props.label }}</span>
+		<slot />
+	</div>
+</template>

--- a/apps/storybook/src/components/components/spinner/SpinnerOverlay.vue
+++ b/apps/storybook/src/components/components/spinner/SpinnerOverlay.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { spinnerOverlay } from "virtual:styleframe";
+
+const classes = computed(() => spinnerOverlay({}));
+</script>
+
+<template>
+	<div :class="classes">
+		<slot />
+	</div>
+</template>

--- a/apps/storybook/src/components/components/spinner/preview/SpinnerGrid.vue
+++ b/apps/storybook/src/components/components/spinner/preview/SpinnerGrid.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import Spinner from "../Spinner.vue";
+
+const colors = ["primary", "light", "dark", "neutral"] as const;
+</script>
+
+<template>
+	<div class="spinner-section">
+		<div v-for="color in colors" :key="color">
+			<div class="spinner-label">{{ color }}</div>
+			<div class="spinner-row">
+				<Spinner :color="color" />
+			</div>
+		</div>
+	</div>
+</template>

--- a/apps/storybook/src/components/components/spinner/preview/SpinnerSizeGrid.vue
+++ b/apps/storybook/src/components/components/spinner/preview/SpinnerSizeGrid.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import Spinner from "../Spinner.vue";
+
+const sizes = ["auto", "sm", "md", "lg"] as const;
+</script>
+
+<template>
+	<div class="spinner-section">
+		<div v-for="size in sizes" :key="size">
+			<div class="spinner-label">{{ size }}</div>
+			<div class="spinner-row">
+				<div
+					v-if="size === 'auto'"
+					class="_width:[100px] _height:[100px]"
+				>
+					<Spinner :size="size" />
+				</div>
+				<Spinner v-else :size="size" />
+			</div>
+		</div>
+	</div>
+</template>

--- a/apps/storybook/stories/components/spinner.stories.ts
+++ b/apps/storybook/stories/components/spinner.stories.ts
@@ -1,0 +1,107 @@
+import type { Meta, StoryObj } from "@storybook/vue3-vite";
+
+import Spinner from "../../src/components/components/spinner/Spinner.vue";
+import SpinnerGrid from "../../src/components/components/spinner/preview/SpinnerGrid.vue";
+import SpinnerSizeGrid from "../../src/components/components/spinner/preview/SpinnerSizeGrid.vue";
+
+const colors = ["primary", "light", "dark", "neutral"] as const;
+const sizes = ["auto", "sm", "md", "lg"] as const;
+
+const meta = {
+	title: "Theme/Recipes/Spinner",
+	component: Spinner,
+	tags: ["autodocs"],
+	parameters: {
+		layout: "padded",
+	},
+	argTypes: {
+		color: {
+			control: "select",
+			options: colors,
+			description: "The color variant",
+		},
+		size: {
+			control: "select",
+			options: sizes,
+			description: "The size",
+		},
+		label: {
+			control: "text",
+			description: "Optional label text displayed below the spinner",
+		},
+	},
+} satisfies Meta<typeof Spinner>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {
+		color: "primary",
+		size: "md",
+	},
+};
+
+export const AllVariants: StoryObj = {
+	render: () => ({
+		components: { SpinnerGrid },
+		template: "<SpinnerGrid />",
+	}),
+};
+
+export const AllSizes: StoryObj = {
+	render: () => ({
+		components: { SpinnerSizeGrid },
+		template: "<SpinnerSizeGrid />",
+	}),
+};
+
+// Per-color stories
+export const Primary: Story = {
+	args: { color: "primary" },
+};
+
+export const Light: Story = {
+	args: { color: "light" },
+};
+
+export const Dark: Story = {
+	args: { color: "dark" },
+	parameters: {
+		backgrounds: { default: "dark" },
+	},
+};
+
+export const Neutral: Story = {
+	args: { color: "neutral" },
+};
+
+// Per-size stories
+export const Auto: StoryObj = {
+	render: () => ({
+		components: { Spinner },
+		template:
+			'<div class="_width:[100px] _height:[100px]"><Spinner size="auto" /></div>',
+	}),
+};
+
+export const Small: Story = {
+	args: { size: "sm" },
+};
+
+export const Medium: Story = {
+	args: { size: "md" },
+};
+
+export const Large: Story = {
+	args: { size: "lg" },
+};
+
+// Feature stories
+export const WithLabel: Story = {
+	args: {
+		color: "primary",
+		size: "md",
+		label: "65%",
+	},
+};

--- a/apps/storybook/stories/components/spinner.styleframe.ts
+++ b/apps/storybook/stories/components/spinner.styleframe.ts
@@ -1,0 +1,45 @@
+import {
+	useSpinnerRecipe,
+	useSpinnerCircleRecipe,
+	useSpinnerTextRecipe,
+	useSpinnerOverlayRecipe,
+} from "@styleframe/theme";
+import { styleframe } from "virtual:styleframe";
+
+const s = styleframe();
+const { selector } = s;
+
+export const spinner = useSpinnerRecipe(s);
+export const spinnerCircle = useSpinnerCircleRecipe(s);
+export const spinnerText = useSpinnerTextRecipe(s);
+export const spinnerOverlay = useSpinnerOverlayRecipe(s);
+
+selector(".spinner-grid", {
+	display: "flex",
+	flexWrap: "wrap",
+	gap: "@spacing.md",
+	padding: "@spacing.md",
+	alignItems: "center",
+});
+
+selector(".spinner-section", {
+	display: "flex",
+	flexDirection: "column",
+	gap: "@spacing.lg",
+	padding: "@spacing.md",
+});
+
+selector(".spinner-row", {
+	display: "flex",
+	flexWrap: "wrap",
+	gap: "@spacing.sm",
+	alignItems: "center",
+});
+
+selector(".spinner-label", {
+	fontSize: "@font-size.sm",
+	fontWeight: "@font-weight.semibold",
+	minWidth: "80px",
+});
+
+export default s;

--- a/theme/src/recipes/index.ts
+++ b/theme/src/recipes/index.ts
@@ -4,6 +4,7 @@ export * from "./button-group";
 export * from "./callout";
 export * from "./card";
 export * from "./chip";
+export * from "./spinner";
 export * from "./modal";
 export * from "./nav";
 export * from "./placeholder";

--- a/theme/src/recipes/spinner/index.ts
+++ b/theme/src/recipes/spinner/index.ts
@@ -1,0 +1,4 @@
+export * from "./useSpinnerRecipe";
+export * from "./useSpinnerCircleRecipe";
+export * from "./useSpinnerTextRecipe";
+export * from "./useSpinnerOverlayRecipe";

--- a/theme/src/recipes/spinner/useSpinnerCircleRecipe.test.ts
+++ b/theme/src/recipes/spinner/useSpinnerCircleRecipe.test.ts
@@ -1,0 +1,115 @@
+import { styleframe } from "@styleframe/core";
+import { useSpinnerCircleRecipe } from "./useSpinnerCircleRecipe";
+
+function createInstance() {
+	const s = styleframe();
+	for (const name of [
+		"animationName",
+		"animationDuration",
+		"animationTimingFunction",
+		"animationIterationCount",
+		"transformOrigin",
+		"width",
+		"height",
+	]) {
+		s.utility(name, ({ value }) => ({ [name]: value }));
+	}
+	return s;
+}
+
+describe("useSpinnerCircleRecipe", () => {
+	it("should create a recipe with correct metadata", () => {
+		const s = createInstance();
+		const recipe = useSpinnerCircleRecipe(s);
+
+		expect(recipe.type).toBe("recipe");
+		expect(recipe.name).toBe("spinner-circle");
+	});
+
+	it("should have correct base styles", () => {
+		const s = createInstance();
+		const recipe = useSpinnerCircleRecipe(s);
+
+		expect(recipe.base).toEqual({
+			animationName: "spinner-rotate",
+			animationDuration: "1.2s",
+			animationTimingFunction: "linear",
+			animationIterationCount: "infinite",
+			transformOrigin: "center center",
+		});
+	});
+
+	describe("variants", () => {
+		it("should have all size variants", () => {
+			const s = createInstance();
+			const recipe = useSpinnerCircleRecipe(s);
+
+			expect(Object.keys(recipe.variants!.size)).toEqual([
+				"auto",
+				"sm",
+				"md",
+				"lg",
+			]);
+		});
+
+		it("should have correct size variant styles", () => {
+			const s = createInstance();
+			const recipe = useSpinnerCircleRecipe(s);
+
+			expect(recipe.variants!.size).toEqual({
+				auto: { width: "100%", height: "100%" },
+				sm: { width: "@2", height: "@2" },
+				md: { width: "@3", height: "@3" },
+				lg: { width: "@4", height: "@4" },
+			});
+		});
+	});
+
+	it("should have correct default variants", () => {
+		const s = createInstance();
+		const recipe = useSpinnerCircleRecipe(s);
+
+		expect(recipe.defaultVariants).toEqual({
+			size: "md",
+		});
+	});
+
+	it("should have no compound variants", () => {
+		const s = createInstance();
+		const recipe = useSpinnerCircleRecipe(s);
+
+		expect(recipe.compoundVariants).toEqual(undefined);
+	});
+
+	describe("config overrides", () => {
+		it("should allow overriding base styles", () => {
+			const s = createInstance();
+			const recipe = useSpinnerCircleRecipe(s, {
+				base: { animationDuration: "2s" },
+			});
+
+			expect(recipe.base?.animationDuration).toBe("2s");
+			expect(recipe.base?.animationName).toBe("spinner-rotate");
+		});
+	});
+
+	describe("filter", () => {
+		it("should filter size variants", () => {
+			const s = createInstance();
+			const recipe = useSpinnerCircleRecipe(s, {
+				filter: { size: ["sm", "md"] },
+			});
+
+			expect(Object.keys(recipe.variants!.size)).toEqual(["sm", "md"]);
+		});
+
+		it("should adjust default variants when filtered out", () => {
+			const s = createInstance();
+			const recipe = useSpinnerCircleRecipe(s, {
+				filter: { size: ["sm", "lg"] },
+			});
+
+			expect(recipe.defaultVariants?.size).toBeUndefined();
+		});
+	});
+});

--- a/theme/src/recipes/spinner/useSpinnerCircleRecipe.ts
+++ b/theme/src/recipes/spinner/useSpinnerCircleRecipe.ts
@@ -1,0 +1,76 @@
+import { createUseRecipe } from "../../utils/createUseRecipe";
+
+/**
+ * Spinner circle recipe.
+ * Styles the SVG spinner element with rotation animation and size variants.
+ */
+export const useSpinnerCircleRecipe = createUseRecipe(
+	"spinner-circle",
+	{
+		base: {
+			animationName: "spinner-rotate",
+			animationDuration: "1.2s",
+			animationTimingFunction: "linear",
+			animationIterationCount: "infinite",
+			transformOrigin: "center center",
+		},
+		variants: {
+			size: {
+				auto: {
+					width: "100%",
+					height: "100%",
+				},
+				sm: {
+					width: "@2",
+					height: "@2",
+				},
+				md: {
+					width: "@3",
+					height: "@3",
+				},
+				lg: {
+					width: "@4",
+					height: "@4",
+				},
+			},
+		},
+		defaultVariants: {
+			size: "md",
+		},
+	},
+	(s) => {
+		s.keyframes("spinner-rotate", {
+			"100%": {
+				transform: "rotate(360deg)",
+			},
+		});
+
+		s.keyframes("spinner-dash", {
+			"0%": {
+				strokeDasharray: "1, 200",
+				strokeDashoffset: "0",
+			},
+			"50%": {
+				strokeDasharray: "89, 200",
+				strokeDashoffset: "-35px",
+			},
+			"100%": {
+				strokeDasharray: "89, 200",
+				strokeDashoffset: "-124px",
+			},
+		});
+
+		s.selector(".spinner-circle circle", {
+			stroke: "currentColor",
+			fill: "none",
+			strokeWidth: "4",
+			strokeDasharray: "89, 200",
+			strokeDashoffset: "-35px",
+			animationName: "spinner-dash",
+			animationDuration: "1.2s",
+			animationTimingFunction: "linear",
+			animationIterationCount: "infinite",
+			strokeLinecap: "round",
+		});
+	},
+);

--- a/theme/src/recipes/spinner/useSpinnerOverlayRecipe.test.ts
+++ b/theme/src/recipes/spinner/useSpinnerOverlayRecipe.test.ts
@@ -1,0 +1,82 @@
+import { styleframe } from "@styleframe/core";
+import { useSpinnerOverlayRecipe } from "./useSpinnerOverlayRecipe";
+
+function createInstance() {
+	const s = styleframe();
+	for (const name of [
+		"position",
+		"top",
+		"right",
+		"bottom",
+		"left",
+		"display",
+		"alignItems",
+		"justifyContent",
+		"background",
+		"zIndex",
+	]) {
+		s.utility(name, ({ value }) => ({ [name]: value }));
+	}
+	return s;
+}
+
+describe("useSpinnerOverlayRecipe", () => {
+	it("should create a recipe with correct metadata", () => {
+		const s = createInstance();
+		const recipe = useSpinnerOverlayRecipe(s);
+
+		expect(recipe.type).toBe("recipe");
+		expect(recipe.name).toBe("spinner-overlay");
+	});
+
+	it("should have correct base styles", () => {
+		const s = createInstance();
+		const recipe = useSpinnerOverlayRecipe(s);
+
+		expect(recipe.base).toEqual({
+			position: "fixed",
+			top: "0",
+			right: "0",
+			bottom: "0",
+			left: "0",
+			display: "flex",
+			alignItems: "center",
+			justifyContent: "center",
+			background: "rgba(0, 0, 0, 0.5)",
+			zIndex: "@z-index.overlay",
+		});
+	});
+
+	it("should have no variants", () => {
+		const s = createInstance();
+		const recipe = useSpinnerOverlayRecipe(s);
+
+		expect(recipe.variants).toEqual({});
+	});
+
+	it("should have no compound variants", () => {
+		const s = createInstance();
+		const recipe = useSpinnerOverlayRecipe(s);
+
+		expect(recipe.compoundVariants).toEqual([]);
+	});
+
+	it("should have no default variants", () => {
+		const s = createInstance();
+		const recipe = useSpinnerOverlayRecipe(s);
+
+		expect(recipe.defaultVariants).toEqual({});
+	});
+
+	describe("config overrides", () => {
+		it("should allow overriding base styles", () => {
+			const s = createInstance();
+			const recipe = useSpinnerOverlayRecipe(s, {
+				base: { position: "absolute" },
+			});
+
+			expect(recipe.base?.position).toBe("absolute");
+			expect(recipe.base?.background).toBe("rgba(0, 0, 0, 0.5)");
+		});
+	});
+});

--- a/theme/src/recipes/spinner/useSpinnerOverlayRecipe.ts
+++ b/theme/src/recipes/spinner/useSpinnerOverlayRecipe.ts
@@ -1,0 +1,22 @@
+import { createUseRecipe } from "../../utils/createUseRecipe";
+
+/**
+ * Spinner overlay recipe for the backdrop behind the spinner.
+ */
+export const useSpinnerOverlayRecipe = createUseRecipe("spinner-overlay", {
+	base: {
+		position: "fixed",
+		top: "0",
+		right: "0",
+		bottom: "0",
+		left: "0",
+		display: "flex",
+		alignItems: "center",
+		justifyContent: "center",
+		background: "rgba(0, 0, 0, 0.5)",
+		zIndex: "@z-index.overlay",
+	},
+	variants: {},
+	compoundVariants: [],
+	defaultVariants: {},
+});

--- a/theme/src/recipes/spinner/useSpinnerRecipe.test.ts
+++ b/theme/src/recipes/spinner/useSpinnerRecipe.test.ts
@@ -1,0 +1,196 @@
+import { styleframe } from "@styleframe/core";
+import { useDarkModifier } from "../../modifiers/useMediaPreferenceModifiers";
+import { useSpinnerRecipe } from "./useSpinnerRecipe";
+
+function createInstance() {
+	const s = styleframe();
+	for (const name of [
+		"display",
+		"position",
+		"alignItems",
+		"justifyContent",
+		"fontSize",
+		"lineHeight",
+		"color",
+	]) {
+		s.utility(name, ({ value }) => ({ [name]: value }));
+	}
+	useDarkModifier(s);
+	return s;
+}
+
+describe("useSpinnerRecipe", () => {
+	it("should create a recipe with correct metadata", () => {
+		const s = createInstance();
+		const recipe = useSpinnerRecipe(s);
+
+		expect(recipe.type).toBe("recipe");
+		expect(recipe.name).toBe("spinner");
+	});
+
+	it("should have correct base styles", () => {
+		const s = createInstance();
+		const recipe = useSpinnerRecipe(s);
+
+		expect(recipe.base).toEqual({
+			display: "inline-flex",
+			position: "relative",
+			alignItems: "center",
+			justifyContent: "center",
+			fontSize: "@font-size.sm",
+			lineHeight: "@line-height.normal",
+		});
+	});
+
+	describe("variants", () => {
+		it("should have all color variants", () => {
+			const s = createInstance();
+			const recipe = useSpinnerRecipe(s);
+
+			expect(Object.keys(recipe.variants!.color)).toEqual([
+				"primary",
+				"light",
+				"dark",
+				"neutral",
+			]);
+		});
+
+		it("should have all size variants", () => {
+			const s = createInstance();
+			const recipe = useSpinnerRecipe(s);
+
+			expect(Object.keys(recipe.variants!.size)).toEqual([
+				"auto",
+				"sm",
+				"md",
+				"lg",
+			]);
+		});
+
+		it("should have correct size variant styles", () => {
+			const s = createInstance();
+			const recipe = useSpinnerRecipe(s);
+
+			expect(recipe.variants!.size).toEqual({
+				auto: {},
+				sm: {},
+				md: {},
+				lg: {},
+			});
+		});
+	});
+
+	it("should have correct default variants", () => {
+		const s = createInstance();
+		const recipe = useSpinnerRecipe(s);
+
+		expect(recipe.defaultVariants).toEqual({
+			color: "primary",
+			size: "md",
+		});
+	});
+
+	describe("compound variants", () => {
+		it("should have 4 compound variants", () => {
+			const s = createInstance();
+			const recipe = useSpinnerRecipe(s);
+
+			expect(recipe.compoundVariants).toHaveLength(4);
+		});
+
+		it("should have correct primary compound variant", () => {
+			const s = createInstance();
+			const recipe = useSpinnerRecipe(s);
+
+			const cv = recipe.compoundVariants!.find(
+				(v) => v.match.color === "primary",
+			);
+			expect(cv?.css).toEqual({
+				color: "@color.primary",
+			});
+		});
+
+		it("should have correct light compound variant", () => {
+			const s = createInstance();
+			const recipe = useSpinnerRecipe(s);
+
+			const cv = recipe.compoundVariants!.find(
+				(v) => v.match.color === "light",
+			);
+			expect(cv?.css).toEqual({
+				color: "@color.gray-700",
+				"&:dark": {
+					color: "@color.gray-700",
+				},
+			});
+		});
+
+		it("should have correct dark compound variant", () => {
+			const s = createInstance();
+			const recipe = useSpinnerRecipe(s);
+
+			const cv = recipe.compoundVariants!.find((v) => v.match.color === "dark");
+			expect(cv?.css).toEqual({
+				color: "@color.white",
+				"&:dark": {
+					color: "@color.white",
+				},
+			});
+		});
+
+		it("should have correct neutral compound variant", () => {
+			const s = createInstance();
+			const recipe = useSpinnerRecipe(s);
+
+			const cv = recipe.compoundVariants!.find(
+				(v) => v.match.color === "neutral",
+			);
+			expect(cv?.css).toEqual({
+				color: "@color.gray-700",
+				"&:dark": {
+					color: "@color.white",
+				},
+			});
+		});
+	});
+
+	describe("config overrides", () => {
+		it("should allow overriding base styles", () => {
+			const s = createInstance();
+			const recipe = useSpinnerRecipe(s, {
+				base: { display: "flex" },
+			});
+
+			expect(recipe.base?.display).toBe("flex");
+		});
+	});
+
+	describe("filter", () => {
+		it("should filter color variants", () => {
+			const s = createInstance();
+			const recipe = useSpinnerRecipe(s, {
+				filter: { color: ["primary"] },
+			});
+
+			expect(Object.keys(recipe.variants!.color)).toEqual(["primary"]);
+		});
+
+		it("should prune compound variants when filtering", () => {
+			const s = createInstance();
+			const recipe = useSpinnerRecipe(s, {
+				filter: { color: ["primary", "neutral"] },
+			});
+
+			expect(recipe.compoundVariants!.length).toBe(2);
+		});
+
+		it("should adjust default variants when filtered out", () => {
+			const s = createInstance();
+			const recipe = useSpinnerRecipe(s, {
+				filter: { color: ["neutral"] },
+			});
+
+			expect(recipe.defaultVariants?.color).toBeUndefined();
+		});
+	});
+});

--- a/theme/src/recipes/spinner/useSpinnerRecipe.ts
+++ b/theme/src/recipes/spinner/useSpinnerRecipe.ts
@@ -1,0 +1,69 @@
+import { createUseRecipe } from "../../utils/createUseRecipe";
+
+/**
+ * Spinner container recipe.
+ * Provides color and layout for the loading spinner with optional label text.
+ */
+export const useSpinnerRecipe = createUseRecipe("spinner", {
+	base: {
+		display: "inline-flex",
+		position: "relative",
+		alignItems: "center",
+		justifyContent: "center",
+		fontSize: "@font-size.sm",
+		lineHeight: "@line-height.normal",
+	},
+	variants: {
+		color: {
+			primary: {},
+			light: {},
+			dark: {},
+			neutral: {},
+		},
+		size: {
+			auto: {},
+			sm: {},
+			md: {},
+			lg: {},
+		},
+	},
+	compoundVariants: [
+		{
+			match: { color: "primary" as const },
+			css: {
+				color: "@color.primary",
+			},
+		},
+		{
+			match: { color: "light" as const },
+			css: {
+				color: "@color.gray-700",
+				"&:dark": {
+					color: "@color.gray-700",
+				},
+			},
+		},
+		{
+			match: { color: "dark" as const },
+			css: {
+				color: "@color.white",
+				"&:dark": {
+					color: "@color.white",
+				},
+			},
+		},
+		{
+			match: { color: "neutral" as const },
+			css: {
+				color: "@color.gray-700",
+				"&:dark": {
+					color: "@color.white",
+				},
+			},
+		},
+	],
+	defaultVariants: {
+		color: "primary",
+		size: "md",
+	},
+});

--- a/theme/src/recipes/spinner/useSpinnerTextRecipe.test.ts
+++ b/theme/src/recipes/spinner/useSpinnerTextRecipe.test.ts
@@ -1,0 +1,113 @@
+import { styleframe } from "@styleframe/core";
+import { useSpinnerTextRecipe } from "./useSpinnerTextRecipe";
+
+function createInstance() {
+	const s = styleframe();
+	for (const name of [
+		"position",
+		"top",
+		"right",
+		"bottom",
+		"left",
+		"display",
+		"alignItems",
+		"justifyContent",
+		"lineHeight",
+		"fontSize",
+	]) {
+		s.utility(name, ({ value }) => ({ [name]: value }));
+	}
+	return s;
+}
+
+describe("useSpinnerTextRecipe", () => {
+	it("should create a recipe with correct metadata", () => {
+		const s = createInstance();
+		const recipe = useSpinnerTextRecipe(s);
+
+		expect(recipe.type).toBe("recipe");
+		expect(recipe.name).toBe("spinner-text");
+	});
+
+	it("should have correct base styles", () => {
+		const s = createInstance();
+		const recipe = useSpinnerTextRecipe(s);
+
+		expect(recipe.base).toEqual({
+			position: "absolute",
+			top: "0",
+			right: "0",
+			bottom: "0",
+			left: "0",
+			display: "flex",
+			alignItems: "center",
+			justifyContent: "center",
+			lineHeight: "@line-height.normal",
+		});
+	});
+
+	describe("variants", () => {
+		it("should have all size variants", () => {
+			const s = createInstance();
+			const recipe = useSpinnerTextRecipe(s);
+
+			expect(Object.keys(recipe.variants!.size)).toEqual([
+				"auto",
+				"sm",
+				"md",
+				"lg",
+			]);
+		});
+
+		it("should have correct size variant styles", () => {
+			const s = createInstance();
+			const recipe = useSpinnerTextRecipe(s);
+
+			expect(recipe.variants!.size).toEqual({
+				auto: {},
+				sm: { fontSize: "@font-size.2xs" },
+				md: { fontSize: "@font-size.xs" },
+				lg: { fontSize: "@font-size.sm" },
+			});
+		});
+	});
+
+	it("should have correct default variants", () => {
+		const s = createInstance();
+		const recipe = useSpinnerTextRecipe(s);
+
+		expect(recipe.defaultVariants).toEqual({
+			size: "md",
+		});
+	});
+
+	it("should have no compound variants", () => {
+		const s = createInstance();
+		const recipe = useSpinnerTextRecipe(s);
+
+		expect(recipe.compoundVariants).toEqual(undefined);
+	});
+
+	describe("config overrides", () => {
+		it("should allow overriding base styles", () => {
+			const s = createInstance();
+			const recipe = useSpinnerTextRecipe(s, {
+				base: { position: "relative" },
+			});
+
+			expect(recipe.base?.position).toBe("relative");
+			expect(recipe.base?.display).toBe("flex");
+		});
+	});
+
+	describe("filter", () => {
+		it("should filter size variants", () => {
+			const s = createInstance();
+			const recipe = useSpinnerTextRecipe(s, {
+				filter: { size: ["sm", "md"] },
+			});
+
+			expect(Object.keys(recipe.variants!.size)).toEqual(["sm", "md"]);
+		});
+	});
+});

--- a/theme/src/recipes/spinner/useSpinnerTextRecipe.ts
+++ b/theme/src/recipes/spinner/useSpinnerTextRecipe.ts
@@ -1,0 +1,36 @@
+import { createUseRecipe } from "../../utils/createUseRecipe";
+
+/**
+ * Spinner text recipe.
+ * Positions the label text centered over the spinner circle.
+ */
+export const useSpinnerTextRecipe = createUseRecipe("spinner-text", {
+	base: {
+		position: "absolute",
+		top: "0",
+		right: "0",
+		bottom: "0",
+		left: "0",
+		display: "flex",
+		alignItems: "center",
+		justifyContent: "center",
+		lineHeight: "@line-height.normal",
+	},
+	variants: {
+		size: {
+			auto: {},
+			sm: {
+				fontSize: "@font-size.2xs",
+			},
+			md: {
+				fontSize: "@font-size.xs",
+			},
+			lg: {
+				fontSize: "@font-size.sm",
+			},
+		},
+	},
+	defaultVariants: {
+		size: "md",
+	},
+});


### PR DESCRIPTION
## Summary

- Adds a multi-part Spinner recipe with 4 sub-recipes: `useSpinnerRecipe` (container with color/size), `useSpinnerCircleRecipe` (SVG animation with keyframes), `useSpinnerTextRecipe` (centered label overlay), and `useSpinnerOverlayRecipe` (fixed backdrop).
- Supports 4 colors (primary, light, dark, neutral) and 4 sizes (auto, sm, md, lg). SVG-based stroke-dasharray animation inspired by the old Inkline loader.
- Includes full test coverage, Storybook stories with preview grids, Vue components, and documentation page.

## Test plan
- [x] `pnpm test` — 2145 tests pass (182 files)
- [x] `pnpm typecheck` — clean (12/12)
- [x] `pnpm lint` — 0 errors
- [ ] Visual verification via `pnpm storybook`