### PR TITLE
feat: Add HamburgerMenu recipe with bars, animations, and docs

### DIFF
--- a/apps/docs/content/docs/06.components/02.composables/14.hamburger-menu.md
+++ b/apps/docs/content/docs/06.components/02.composables/14.hamburger-menu.md
@@ -1,0 +1,367 @@
+---
+title: HamburgerMenu
+description: A toggle button that animates three horizontal bars into various shapes (close, arrows, plus, minus) with configurable colors and sizes using the recipe system.
+---
+
+## Overview
+
+The **HamburgerMenu** is a compact interactive toggle that displays three horizontal bars and animates them into different shapes when activated. The `useHamburgerMenuRecipe()` and `useHamburgerMenuBarsRecipe()` composables create fully configured [recipes](/docs/api/recipes) with color, size, and animation options.
+
+The HamburgerMenu recipe integrates directly with the default [design tokens preset](/docs/design-tokens/presets) and generates type-safe utility classes at build time with zero runtime CSS.
+
+## Why use the HamburgerMenu recipe?
+
+The HamburgerMenu recipe helps you:
+
+- **Ship faster with sensible defaults**: Get 3 adaptive colors, 3 sizes, and 7 animation types out of the box with two composable calls.
+- **Maintain consistency**: All animation transforms and color combinations follow the same design rules across your application.
+- **Customize without forking**: Override base styles, default variants, or filter out options you don't need &mdash; all through the options API.
+- **Stay type-safe**: Full TypeScript support means your editor catches invalid color, size, or animation values at compile time.
+- **Integrate with your tokens**: Every value references the design tokens preset, so theme changes propagate automatically.
+
+## Usage
+
+::steps{level="4"}
+
+#### Register the recipes
+
+Add the HamburgerMenu recipes to a local Styleframe instance. The global `styleframe.config.ts` provides design tokens and utilities, while the component-level file registers the recipes:
+
+:::code-tree{default-value="src/components/hamburger-menu.styleframe.ts"}
+
+```ts [src/components/hamburger-menu.styleframe.ts]
+import { styleframe } from 'virtual:styleframe';
+import { useHamburgerMenuRecipe, useHamburgerMenuBarsRecipe } from '@styleframe/theme';
+
+const s = styleframe();
+
+const hamburgerMenu = useHamburgerMenuRecipe(s);
+const hamburgerMenuBars = useHamburgerMenuBarsRecipe(s);
+
+export default s;
+```
+
+```ts [styleframe.config.ts]
+import { styleframe } from 'styleframe';
+import { useDesignTokensPreset, useUtilitiesPreset } from '@styleframe/theme';
+
+const s = styleframe();
+
+useDesignTokensPreset(s);
+useUtilitiesPreset(s);
+
+export default s;
+```
+
+:::
+
+#### Build the component
+
+Import the `hamburgerMenu` and `hamburgerMenuBars` runtime functions from the virtual module and pass variant props to compute class names:
+
+:::tabs
+::::tabs-item{icon="i-devicon-react" label="React"}
+
+```ts [src/components/HamburgerMenu.tsx]
+import { useState } from "react";
+import { hamburgerMenu, hamburgerMenuBars } from "virtual:styleframe";
+
+interface HamburgerMenuProps {
+    color?: "light" | "dark" | "neutral";
+    size?: "sm" | "md" | "lg";
+    animation?: "close" | "arrow-left" | "arrow-right" | "arrow-up" | "arrow-down" | "plus" | "minus";
+}
+
+export function HamburgerMenu({
+    color = "neutral",
+    size = "md",
+    animation = "close",
+}: HamburgerMenuProps) {
+    const [active, setActive] = useState(false);
+
+    return (
+        <div
+            className={hamburgerMenu({ color, size, animation, active })}
+            role="button"
+            tabIndex={0}
+            aria-expanded={active}
+            aria-label="Toggle menu"
+            onClick={() => setActive(!active)}
+            onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    setActive(!active);
+                }
+            }}
+        >
+            <span className={hamburgerMenuBars({ size, animation, active })} />
+        </div>
+    );
+}
+```
+
+::::
+::::tabs-item{icon="i-devicon-vuejs" label="Vue"}
+
+```vue [src/components/HamburgerMenu.vue]
+<script setup lang="ts">
+import { ref } from "vue";
+import { hamburgerMenu, hamburgerMenuBars } from "virtual:styleframe";
+
+const { color = "neutral", size = "md", animation = "close" } = defineProps<{
+    color?: "light" | "dark" | "neutral";
+    size?: "sm" | "md" | "lg";
+    animation?: "close" | "arrow-left" | "arrow-right" | "arrow-up" | "arrow-down" | "plus" | "minus";
+}>();
+
+const active = ref(false);
+
+function toggle() {
+    active.value = !active.value;
+}
+</script>
+
+<template>
+    <div
+        :class="hamburgerMenu({ color, size, animation, active })"
+        role="button"
+        tabindex="0"
+        :aria-expanded="active"
+        aria-label="Toggle menu"
+        @click="toggle"
+        @keydown.enter="toggle"
+        @keydown.space.prevent="toggle"
+    >
+        <span :class="hamburgerMenuBars({ size, animation, active })" />
+    </div>
+</template>
+```
+
+::::
+:::
+
+#### See it in action
+
+:::story-preview
+---
+story: theme-recipes-hamburger-menu--default
+panel: true
+---
+:::
+
+::
+
+## Colors
+
+The HamburgerMenu uses non-semantic colors that adapt to light and dark modes. The `light` and `dark` colors stay fixed regardless of the color scheme, while `neutral` adapts automatically.
+
+::story-preview
+---
+story: theme-recipes-hamburger-menu--neutral
+panel: true
+---
+::
+
+### Color Reference
+
+::story-preview
+---
+story: theme-recipes-hamburger-menu--all-variants
+height: 240
+---
+::
+
+| Color | Token | Use Case |
+|-------|-------|----------|
+| `light` | `@color.gray-700` | Light surfaces, stays light in dark mode |
+| `dark` | `@color.white` | Dark surfaces, stays dark in light mode |
+| `neutral` | Adaptive (light ↔ dark) | Default color, adapts to the current color scheme |
+
+::tip
+**Pro tip:** Use `neutral` for most cases &mdash; it automatically adapts to light and dark modes.
+::
+
+## Animations
+
+The HamburgerMenu supports 7 animation types that transform the three bars when toggled. Click each hamburger menu below to see the animation in action.
+
+::story-preview
+---
+story: theme-recipes-hamburger-menu--all-animations
+height: 480
+---
+::
+
+| Animation | Description |
+|-----------|-------------|
+| `close` | Bars collapse into an X shape (default) |
+| `arrow-left` | Bars form a left-pointing arrow |
+| `arrow-right` | Bars form a right-pointing arrow |
+| `arrow-up` | Bars form an upward-pointing arrow |
+| `arrow-down` | Bars form a downward-pointing arrow |
+| `plus` | Bars form a plus (+) symbol |
+| `minus` | Bars collapse into a minus (−) symbol |
+
+### Close
+
+The default animation &mdash; the three bars collapse and rotate into an X shape.
+
+::story-preview
+---
+story: theme-recipes-hamburger-menu--close
+panel: true
+---
+::
+
+### Arrow Left
+
+The top and bottom bars shorten and rotate to form a left-pointing chevron.
+
+::story-preview
+---
+story: theme-recipes-hamburger-menu--arrow-left
+panel: true
+---
+::
+
+### Arrow Right
+
+The top and bottom bars shorten and rotate to form a right-pointing chevron.
+
+::story-preview
+---
+story: theme-recipes-hamburger-menu--arrow-right
+panel: true
+---
+::
+
+### Plus
+
+The top and bottom bars collapse to the center, with one rotating 90 degrees to form a plus sign.
+
+::story-preview
+---
+story: theme-recipes-hamburger-menu--plus
+panel: true
+---
+::
+
+## Sizes
+
+The HamburgerMenu comes in three sizes that scale the bar width, height, and spacing proportionally.
+
+::story-preview
+---
+story: theme-recipes-hamburger-menu--all-sizes
+height: 240
+---
+::
+
+| Size | Bar Width | Bar Height |
+|------|-----------|------------|
+| `sm` | 16px | 2px |
+| `md` | 20px | 2px |
+| `lg` | 24px | 2px |
+
+## Accessibility
+
+- **Keyboard support**: The component is focusable and responds to Enter and Space keys for toggling.
+- **ARIA attributes**: Use `role="button"`, `aria-expanded`, and `aria-label="Toggle menu"` for screen reader support.
+- **Focus indicator**: A visible focus ring appears on keyboard navigation via `focus-visible`.
+- **Color contrast**: Ensure sufficient contrast between the bar color and background.
+
+## Customization
+
+### Overriding Defaults
+
+```ts [src/components/hamburger-menu.styleframe.ts]
+const hamburgerMenu = useHamburgerMenuRecipe(s, {
+    defaultVariants: { color: 'dark', size: 'lg', animation: 'arrow-left' },
+});
+```
+
+### Filtering Variants
+
+```ts [src/components/hamburger-menu.styleframe.ts]
+const hamburgerMenuBars = useHamburgerMenuBarsRecipe(s, {
+    filter: {
+        animation: ['close', 'arrow-left'],
+        size: ['md', 'lg'],
+    },
+});
+```
+
+::note
+**Good to know:** Filtering also removes compound variants and adjusts default variants that reference filtered-out values, so your recipe stays consistent.
+::
+
+## API Reference
+
+### `useHamburgerMenuRecipe(s, options?)`
+
+Creates the hamburger menu container recipe with color, size, animation, and active variants.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `s` | `Styleframe` | The Styleframe instance |
+| `options` | `DeepPartial<RecipeConfig>` | Optional overrides for the recipe configuration |
+| `options.base` | `VariantDeclarationsBlock` | Custom base styles |
+| `options.variants` | `Variants` | Custom variant definitions |
+| `options.defaultVariants` | `Record<keyof Variants, string>` | Default variant values |
+| `options.compoundVariants` | `CompoundVariant[]` | Custom compound variant definitions |
+| `options.filter` | `Record<string, string[]>` | Limit which variant values are generated |
+
+**Variants:**
+
+| Variant | Options | Default |
+|---------|---------|---------|
+| `color` | `light`, `dark`, `neutral` | `neutral` |
+| `size` | `sm`, `md`, `lg` | `md` |
+| `animation` | `close`, `arrow-left`, `arrow-right`, `arrow-up`, `arrow-down`, `plus`, `minus` | `close` |
+| `active` | `true`, `false` | `false` |
+
+### `useHamburgerMenuBarsRecipe(s, options?)`
+
+Creates the bars sub-recipe that handles the three horizontal bars and their animation transforms.
+
+**Variants:**
+
+| Variant | Options | Default |
+|---------|---------|---------|
+| `size` | `sm`, `md`, `lg` | `md` |
+| `animation` | `close`, `arrow-left`, `arrow-right`, `arrow-up`, `arrow-down`, `plus`, `minus` | `close` |
+| `active` | `true`, `false` | `false` |
+
+[Learn more about recipes ->](/docs/api/recipes)
+
+## Best Practices
+
+- **Use the `close` animation for navigation menus**: It's the most universally recognized hamburger menu pattern.
+- **Use arrow animations for sidebars**: `arrow-left` and `arrow-right` clearly indicate a panel sliding in or out.
+- **Use `plus`/`minus` for accordion-like toggles**: These animations are familiar for expand/collapse actions.
+- **Filter what you don't need**: Pass a `filter` option to reduce generated CSS if you only use one or two animation types.
+- **Override defaults at the recipe level**: Set your most common combination as `defaultVariants`.
+
+## FAQ
+
+::accordion
+
+:::accordion-item{label="How do the bar animations work?" icon="i-lucide-circle-help"}
+The three bars are created using a single `<span>` element (the middle bar) plus `::before` and `::after` pseudo-elements (the top and bottom bars). When activated, compound variants apply CSS transforms (rotate, translate, scale) and opacity changes to animate the bars into their target shape. All animations use CSS transitions for smooth, performant movement.
+:::
+
+:::accordion-item{label="Can I add custom animation types?" icon="i-lucide-circle-help"}
+Yes! You can extend the bars recipe with additional compound variants for custom animations. Define a new animation value in the `variants.animation` object and add corresponding compound variants with the `active: true` match.
+:::
+
+:::accordion-item{label="How does filtering affect compound variants?" icon="i-lucide-circle-help"}
+When you use the `filter` option, compound variants that reference filtered-out values are automatically removed. Default variants are also adjusted if they reference a removed value. For example, filtering to only `close` and `plus` animations removes all arrow-related compound variants.
+:::
+
+:::accordion-item{label="Why are there two separate recipes?" icon="i-lucide-circle-help"}
+The container recipe (`useHamburgerMenuRecipe`) handles the interactive wrapper (color, focus ring, cursor) while the bars recipe (`useHamburgerMenuBarsRecipe`) handles the visual bars and their animation transforms. This separation follows the same pattern as other multi-part recipes like Spinner, keeping concerns isolated and allowing independent customization.
+:::
+
+::

--- a/apps/storybook/src/components/components/hamburger-menu/HamburgerMenu.vue
+++ b/apps/storybook/src/components/components/hamburger-menu/HamburgerMenu.vue
@@ -1,0 +1,71 @@
+<script setup lang="ts">
+import { computed, ref, watch } from "vue";
+import { hamburgerMenu, hamburgerMenuBars } from "virtual:styleframe";
+
+const props = withDefaults(
+	defineProps<{
+		color?: "light" | "dark" | "neutral";
+		size?: "sm" | "md" | "lg";
+		animation?:
+			| "close"
+			| "arrow-left"
+			| "arrow-right"
+			| "arrow-up"
+			| "arrow-down"
+			| "plus"
+			| "minus";
+		modelValue?: boolean;
+	}>(),
+	{
+		modelValue: false,
+	},
+);
+
+const emit = defineEmits<{ "update:modelValue": [value: boolean] }>();
+
+const isActive = ref(props.modelValue);
+
+watch(
+	() => props.modelValue,
+	(val) => {
+		isActive.value = val;
+	},
+);
+
+function onClick() {
+	isActive.value = !isActive.value;
+	emit("update:modelValue", isActive.value);
+}
+
+const containerClasses = computed(() =>
+	hamburgerMenu({
+		color: props.color,
+		size: props.size,
+		animation: props.animation,
+		active: isActive.value,
+	}),
+);
+
+const barsClasses = computed(() =>
+	hamburgerMenuBars({
+		size: props.size,
+		animation: props.animation,
+		active: isActive.value,
+	}),
+);
+</script>
+
+<template>
+	<div
+		:class="containerClasses"
+		role="button"
+		tabindex="0"
+		:aria-expanded="isActive"
+		aria-label="Toggle menu"
+		@click="onClick"
+		@keydown.enter="onClick"
+		@keydown.space.prevent="onClick"
+	>
+		<span :class="barsClasses" />
+	</div>
+</template>

--- a/apps/storybook/src/components/components/hamburger-menu/preview/HamburgerMenuAnimationGrid.vue
+++ b/apps/storybook/src/components/components/hamburger-menu/preview/HamburgerMenuAnimationGrid.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import HamburgerMenu from "../HamburgerMenu.vue";
+
+const animations = [
+	"close",
+	"arrow-left",
+	"arrow-right",
+	"arrow-up",
+	"arrow-down",
+	"plus",
+	"minus",
+] as const;
+</script>
+
+<template>
+	<div class="hamburger-menu-section">
+		<div v-for="animation in animations" :key="animation">
+			<div class="hamburger-menu-label">{{ animation }}</div>
+			<div class="hamburger-menu-row">
+				<HamburgerMenu :animation="animation" />
+			</div>
+		</div>
+	</div>
+</template>

--- a/apps/storybook/src/components/components/hamburger-menu/preview/HamburgerMenuGrid.vue
+++ b/apps/storybook/src/components/components/hamburger-menu/preview/HamburgerMenuGrid.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import HamburgerMenu from "../HamburgerMenu.vue";
+
+const colors = ["light", "dark", "neutral"] as const;
+</script>
+
+<template>
+	<div class="hamburger-menu-section">
+		<div v-for="color in colors" :key="color">
+			<div class="hamburger-menu-label">{{ color }}</div>
+			<div class="hamburger-menu-row">
+				<HamburgerMenu :color="color" />
+			</div>
+		</div>
+	</div>
+</template>

--- a/apps/storybook/src/components/components/hamburger-menu/preview/HamburgerMenuSizeGrid.vue
+++ b/apps/storybook/src/components/components/hamburger-menu/preview/HamburgerMenuSizeGrid.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import HamburgerMenu from "../HamburgerMenu.vue";
+
+const sizes = ["sm", "md", "lg"] as const;
+</script>
+
+<template>
+	<div class="hamburger-menu-section">
+		<div v-for="size in sizes" :key="size">
+			<div class="hamburger-menu-label">{{ size }}</div>
+			<div class="hamburger-menu-row">
+				<HamburgerMenu :size="size" />
+			</div>
+		</div>
+	</div>
+</template>

--- a/apps/storybook/stories/components/hamburger-menu.stories.ts
+++ b/apps/storybook/stories/components/hamburger-menu.stories.ts
@@ -1,0 +1,138 @@
+import type { Meta, StoryObj } from "@storybook/vue3-vite";
+
+import HamburgerMenu from "../../src/components/components/hamburger-menu/HamburgerMenu.vue";
+import HamburgerMenuGrid from "../../src/components/components/hamburger-menu/preview/HamburgerMenuGrid.vue";
+import HamburgerMenuSizeGrid from "../../src/components/components/hamburger-menu/preview/HamburgerMenuSizeGrid.vue";
+import HamburgerMenuAnimationGrid from "../../src/components/components/hamburger-menu/preview/HamburgerMenuAnimationGrid.vue";
+
+const colors = ["light", "dark", "neutral"] as const;
+const sizes = ["sm", "md", "lg"] as const;
+const animations = [
+	"close",
+	"arrow-left",
+	"arrow-right",
+	"arrow-up",
+	"arrow-down",
+	"plus",
+	"minus",
+] as const;
+
+const meta = {
+	title: "Theme/Recipes/HamburgerMenu",
+	component: HamburgerMenu,
+	tags: ["autodocs"],
+	parameters: {
+		layout: "padded",
+	},
+	argTypes: {
+		color: {
+			control: "select",
+			options: colors,
+			description: "The color variant",
+		},
+		size: {
+			control: "select",
+			options: sizes,
+			description: "The size",
+		},
+		animation: {
+			control: "select",
+			options: animations,
+			description: "The animation type when toggled",
+		},
+		modelValue: {
+			control: "boolean",
+			description: "Whether the menu is active/open",
+		},
+	},
+} satisfies Meta<typeof HamburgerMenu>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {
+		color: "neutral",
+		size: "md",
+		animation: "close",
+	},
+};
+
+export const AllVariants: StoryObj = {
+	render: () => ({
+		components: { HamburgerMenuGrid },
+		template: "<HamburgerMenuGrid />",
+	}),
+};
+
+export const AllAnimations: StoryObj = {
+	render: () => ({
+		components: { HamburgerMenuAnimationGrid },
+		template: "<HamburgerMenuAnimationGrid />",
+	}),
+};
+
+export const AllSizes: StoryObj = {
+	render: () => ({
+		components: { HamburgerMenuSizeGrid },
+		template: "<HamburgerMenuSizeGrid />",
+	}),
+};
+
+// Per-color stories
+export const Light: Story = {
+	args: { color: "light" },
+};
+
+export const Dark: Story = {
+	args: { color: "dark" },
+	parameters: {
+		backgrounds: { default: "dark" },
+	},
+};
+
+export const Neutral: Story = {
+	args: { color: "neutral" },
+};
+
+// Per-animation stories
+export const Close: Story = {
+	args: { animation: "close" },
+};
+
+export const ArrowLeft: Story = {
+	args: { animation: "arrow-left" },
+};
+
+export const ArrowRight: Story = {
+	args: { animation: "arrow-right" },
+};
+
+export const ArrowUp: Story = {
+	args: { animation: "arrow-up" },
+};
+
+export const ArrowDown: Story = {
+	args: { animation: "arrow-down" },
+};
+
+export const Plus: Story = {
+	args: { animation: "plus" },
+};
+
+export const Minus: Story = {
+	args: { animation: "minus" },
+};
+
+// Per-size stories
+export const Small: Story = {
+	args: { size: "sm" },
+};
+
+export const Medium: Story = {
+	args: { size: "md" },
+};
+
+export const Large: Story = {
+	args: { size: "lg" },
+};

--- a/apps/storybook/stories/components/hamburger-menu.styleframe.ts
+++ b/apps/storybook/stories/components/hamburger-menu.styleframe.ts
@@ -1,0 +1,41 @@
+import {
+	useHamburgerMenuRecipe,
+	useHamburgerMenuBarsRecipe,
+} from "@styleframe/theme";
+import { styleframe } from "virtual:styleframe";
+
+const s = styleframe();
+const { selector } = s;
+
+export const hamburgerMenu = useHamburgerMenuRecipe(s);
+export const hamburgerMenuBars = useHamburgerMenuBarsRecipe(s);
+
+selector(".hamburger-menu-grid", {
+	display: "flex",
+	flexWrap: "wrap",
+	gap: "@spacing.md",
+	padding: "@spacing.md",
+	alignItems: "center",
+});
+
+selector(".hamburger-menu-section", {
+	display: "flex",
+	flexDirection: "column",
+	gap: "@spacing.lg",
+	padding: "@spacing.md",
+});
+
+selector(".hamburger-menu-row", {
+	display: "flex",
+	flexWrap: "wrap",
+	gap: "@spacing.sm",
+	alignItems: "center",
+});
+
+selector(".hamburger-menu-label", {
+	fontSize: "@font-size.sm",
+	fontWeight: "@font-weight.semibold",
+	minWidth: "80px",
+});
+
+export default s;

--- a/theme/src/recipes/hamburger-menu/index.ts
+++ b/theme/src/recipes/hamburger-menu/index.ts
@@ -1,0 +1,2 @@
+export * from "./useHamburgerMenuRecipe";
+export * from "./useHamburgerMenuBarsRecipe";

--- a/theme/src/recipes/hamburger-menu/useHamburgerMenuBarsRecipe.test.ts
+++ b/theme/src/recipes/hamburger-menu/useHamburgerMenuBarsRecipe.test.ts
@@ -1,0 +1,299 @@
+import { styleframe } from "@styleframe/core";
+import { useDarkModifier } from "../../modifiers/useMediaPreferenceModifiers";
+import {
+	useBeforeModifier,
+	useAfterModifier,
+} from "../../modifiers/usePseudoElementModifiers";
+import { useHamburgerMenuBarsRecipe } from "./useHamburgerMenuBarsRecipe";
+
+function createInstance() {
+	const s = styleframe();
+	for (const name of [
+		"display",
+		"position",
+		"background",
+		"borderRadius",
+		"transitionProperty",
+		"transitionDuration",
+		"transitionTimingFunction",
+		"width",
+		"height",
+		"opacity",
+		"transform",
+		"transformOrigin",
+		"top",
+		"bottom",
+		"left",
+		"content",
+	]) {
+		s.utility(name, ({ value }) => ({ [name]: value }));
+	}
+	useDarkModifier(s);
+	useBeforeModifier(s);
+	useAfterModifier(s);
+	return s;
+}
+
+describe("useHamburgerMenuBarsRecipe", () => {
+	it("should create a recipe with correct metadata", () => {
+		const s = createInstance();
+		const recipe = useHamburgerMenuBarsRecipe(s);
+
+		expect(recipe.type).toBe("recipe");
+		expect(recipe.name).toBe("hamburger-menu-bars");
+	});
+
+	it("should have correct base styles", () => {
+		const s = createInstance();
+		const recipe = useHamburgerMenuBarsRecipe(s);
+
+		expect(recipe.base).toEqual({
+			display: "block",
+			position: "relative",
+			background: "currentColor",
+			borderRadius: "1px",
+			transitionProperty: "transform, opacity",
+			transitionDuration: "300ms",
+			transitionTimingFunction: "cubic-bezier(0.55, 0.055, 0.675, 0.19)",
+		});
+	});
+
+	describe("variants", () => {
+		it("should have all size variants", () => {
+			const s = createInstance();
+			const recipe = useHamburgerMenuBarsRecipe(s);
+
+			expect(Object.keys(recipe.variants!.size)).toEqual(["sm", "md", "lg"]);
+		});
+
+		it("should have correct size variant styles", () => {
+			const s = createInstance();
+			const recipe = useHamburgerMenuBarsRecipe(s);
+
+			expect(recipe.variants!.size).toEqual({
+				sm: { width: "16px", height: "2px" },
+				md: { width: "20px", height: "2px" },
+				lg: { width: "24px", height: "2px" },
+			});
+		});
+
+		it("should have all animation variants", () => {
+			const s = createInstance();
+			const recipe = useHamburgerMenuBarsRecipe(s);
+
+			expect(Object.keys(recipe.variants!.animation)).toEqual([
+				"close",
+				"arrow-left",
+				"arrow-right",
+				"arrow-up",
+				"arrow-down",
+				"plus",
+				"minus",
+			]);
+		});
+
+		it("should have active variants", () => {
+			const s = createInstance();
+			const recipe = useHamburgerMenuBarsRecipe(s);
+
+			expect(Object.keys(recipe.variants!.active)).toEqual(["true", "false"]);
+		});
+	});
+
+	it("should have correct default variants", () => {
+		const s = createInstance();
+		const recipe = useHamburgerMenuBarsRecipe(s);
+
+		expect(recipe.defaultVariants).toEqual({
+			size: "md",
+			animation: "close",
+			active: "false",
+		});
+	});
+
+	describe("compound variants", () => {
+		it("should have 10 compound variants", () => {
+			const s = createInstance();
+			const recipe = useHamburgerMenuBarsRecipe(s);
+
+			expect(recipe.compoundVariants).toHaveLength(10);
+		});
+
+		it("should have correct sm size spacing compound variant", () => {
+			const s = createInstance();
+			const recipe = useHamburgerMenuBarsRecipe(s);
+
+			const cv = recipe.compoundVariants!.find(
+				(v) => v.match.size === "sm" && !v.match.animation,
+			);
+			expect(cv?.css).toEqual({
+				"&:before": { top: "-5px" },
+				"&:after": { bottom: "-5px" },
+			});
+		});
+
+		it("should have correct md size spacing compound variant", () => {
+			const s = createInstance();
+			const recipe = useHamburgerMenuBarsRecipe(s);
+
+			const cv = recipe.compoundVariants!.find(
+				(v) => v.match.size === "md" && !v.match.animation,
+			);
+			expect(cv?.css).toEqual({
+				"&:before": { top: "-6px" },
+				"&:after": { bottom: "-6px" },
+			});
+		});
+
+		it("should have correct lg size spacing compound variant", () => {
+			const s = createInstance();
+			const recipe = useHamburgerMenuBarsRecipe(s);
+
+			const cv = recipe.compoundVariants!.find(
+				(v) => v.match.size === "lg" && !v.match.animation,
+			);
+			expect(cv?.css).toEqual({
+				"&:before": { top: "-8px" },
+				"&:after": { bottom: "-8px" },
+			});
+		});
+
+		it("should have correct close animation compound variant", () => {
+			const s = createInstance();
+			const recipe = useHamburgerMenuBarsRecipe(s);
+
+			const cv = recipe.compoundVariants!.find(
+				(v) => v.match.animation === "close" && v.match.active === "true",
+			);
+			expect(cv?.css).toEqual({
+				opacity: "0",
+				transform: "rotate(180deg)",
+				"&:before": {
+					top: "0",
+					transform: "rotate(45deg)",
+				},
+				"&:after": {
+					bottom: "0",
+					transform: "rotate(-45deg)",
+				},
+			});
+		});
+
+		it("should have correct arrow-left animation compound variant", () => {
+			const s = createInstance();
+			const recipe = useHamburgerMenuBarsRecipe(s);
+
+			const cv = recipe.compoundVariants!.find(
+				(v) => v.match.animation === "arrow-left" && v.match.active === "true",
+			);
+			expect(cv?.css).toEqual({
+				"&:before": {
+					top: "0",
+					width: "50%",
+					transform: "translateX(-1px) rotate(-45deg)",
+					transformOrigin: "left center",
+				},
+				"&:after": {
+					bottom: "0",
+					width: "50%",
+					transform: "translateX(-1px) rotate(45deg)",
+					transformOrigin: "left center",
+				},
+			});
+		});
+
+		it("should have correct arrow-right animation compound variant", () => {
+			const s = createInstance();
+			const recipe = useHamburgerMenuBarsRecipe(s);
+
+			const cv = recipe.compoundVariants!.find(
+				(v) => v.match.animation === "arrow-right" && v.match.active === "true",
+			);
+			expect(cv?.css).toEqual({
+				"&:before": {
+					top: "0",
+					width: "50%",
+					transform: "translateX(calc(100% + 1px)) rotate(45deg)",
+					transformOrigin: "right center",
+				},
+				"&:after": {
+					bottom: "0",
+					width: "50%",
+					transform: "translateX(calc(100% + 1px)) rotate(-45deg)",
+					transformOrigin: "right center",
+				},
+			});
+		});
+
+		it("should have correct plus animation compound variant", () => {
+			const s = createInstance();
+			const recipe = useHamburgerMenuBarsRecipe(s);
+
+			const cv = recipe.compoundVariants!.find(
+				(v) => v.match.animation === "plus" && v.match.active === "true",
+			);
+			expect(cv?.css).toEqual({
+				"&:before": {
+					top: "0",
+					transform: "rotate(90deg)",
+				},
+				"&:after": {
+					bottom: "0",
+					transform: "rotate(0deg)",
+				},
+			});
+		});
+	});
+
+	describe("config overrides", () => {
+		it("should allow overriding base styles", () => {
+			const s = createInstance();
+			const recipe = useHamburgerMenuBarsRecipe(s, {
+				base: { display: "inline-block" },
+			});
+
+			expect(recipe.base?.display).toBe("inline-block");
+		});
+	});
+
+	describe("filter", () => {
+		it("should filter size variants", () => {
+			const s = createInstance();
+			const recipe = useHamburgerMenuBarsRecipe(s, {
+				filter: { size: ["md"] },
+			});
+
+			expect(Object.keys(recipe.variants!.size)).toEqual(["md"]);
+		});
+
+		it("should filter animation variants", () => {
+			const s = createInstance();
+			const recipe = useHamburgerMenuBarsRecipe(s, {
+				filter: { animation: ["close", "plus"] },
+			});
+
+			expect(Object.keys(recipe.variants!.animation)).toEqual([
+				"close",
+				"plus",
+			]);
+		});
+
+		it("should prune compound variants when filtering", () => {
+			const s = createInstance();
+			const recipe = useHamburgerMenuBarsRecipe(s, {
+				filter: { size: ["md"], animation: ["close"] },
+			});
+
+			expect(recipe.compoundVariants!.length).toBeLessThan(10);
+		});
+
+		it("should adjust default variants when filtered out", () => {
+			const s = createInstance();
+			const recipe = useHamburgerMenuBarsRecipe(s, {
+				filter: { size: ["lg"] },
+			});
+
+			expect(recipe.defaultVariants?.size).toBeUndefined();
+		});
+	});
+});

--- a/theme/src/recipes/hamburger-menu/useHamburgerMenuBarsRecipe.ts
+++ b/theme/src/recipes/hamburger-menu/useHamburgerMenuBarsRecipe.ts
@@ -1,0 +1,233 @@
+import { createUseRecipe } from "../../utils/createUseRecipe";
+
+/**
+ * Hamburger menu bars recipe.
+ * Styles the three horizontal bars (middle bar + ::before/::after pseudo-elements)
+ * with animation transforms for close, arrow, plus, and minus states.
+ */
+export const useHamburgerMenuBarsRecipe = createUseRecipe(
+	"hamburger-menu-bars",
+	{
+		base: {
+			display: "block",
+			position: "relative",
+			background: "currentColor",
+			borderRadius: "1px",
+			transitionProperty: "transform, opacity",
+			transitionDuration: "300ms",
+			transitionTimingFunction: "cubic-bezier(0.55, 0.055, 0.675, 0.19)",
+		},
+		variants: {
+			size: {
+				sm: {
+					width: "16px",
+					height: "2px",
+				},
+				md: {
+					width: "20px",
+					height: "2px",
+				},
+				lg: {
+					width: "24px",
+					height: "2px",
+				},
+			},
+			animation: {
+				close: {},
+				"arrow-left": {},
+				"arrow-right": {},
+				"arrow-up": {},
+				"arrow-down": {},
+				plus: {},
+				minus: {},
+			},
+			active: {
+				true: {},
+				false: {},
+			},
+		},
+		compoundVariants: [
+			{
+				match: { size: "sm" as const },
+				css: {
+					"&:before": { top: "-5px" },
+					"&:after": { bottom: "-5px" },
+				},
+			},
+			{
+				match: { size: "md" as const },
+				css: {
+					"&:before": { top: "-6px" },
+					"&:after": { bottom: "-6px" },
+				},
+			},
+			{
+				match: { size: "lg" as const },
+				css: {
+					"&:before": { top: "-8px" },
+					"&:after": { bottom: "-8px" },
+				},
+			},
+			{
+				match: {
+					animation: "close" as const,
+					active: "true" as const,
+				},
+				css: {
+					opacity: "0",
+					transform: "rotate(180deg)",
+					"&:before": {
+						top: "0",
+						transform: "rotate(45deg)",
+					},
+					"&:after": {
+						bottom: "0",
+						transform: "rotate(-45deg)",
+					},
+				},
+			},
+			{
+				match: {
+					animation: "arrow-left" as const,
+					active: "true" as const,
+				},
+				css: {
+					"&:before": {
+						top: "0",
+						width: "50%",
+						transform: "translateX(-1px) rotate(-45deg)",
+						transformOrigin: "left center",
+					},
+					"&:after": {
+						bottom: "0",
+						width: "50%",
+						transform: "translateX(-1px) rotate(45deg)",
+						transformOrigin: "left center",
+					},
+				},
+			},
+			{
+				match: {
+					animation: "arrow-right" as const,
+					active: "true" as const,
+				},
+				css: {
+					"&:before": {
+						top: "0",
+						width: "50%",
+						transform: "translateX(calc(100% + 1px)) rotate(45deg)",
+						transformOrigin: "right center",
+					},
+					"&:after": {
+						bottom: "0",
+						width: "50%",
+						transform: "translateX(calc(100% + 1px)) rotate(-45deg)",
+						transformOrigin: "right center",
+					},
+				},
+			},
+			{
+				match: {
+					animation: "arrow-up" as const,
+					active: "true" as const,
+				},
+				css: {
+					transform: "rotate(90deg)",
+					"&:before": {
+						top: "0",
+						width: "50%",
+						transform: "translateX(-1px) rotate(-45deg)",
+						transformOrigin: "left center",
+					},
+					"&:after": {
+						bottom: "0",
+						width: "50%",
+						transform: "translateX(-1px) rotate(45deg)",
+						transformOrigin: "left center",
+					},
+				},
+			},
+			{
+				match: {
+					animation: "arrow-down" as const,
+					active: "true" as const,
+				},
+				css: {
+					transform: "rotate(-90deg)",
+					"&:before": {
+						top: "0",
+						width: "50%",
+						transform: "translateX(-1px) rotate(-45deg)",
+						transformOrigin: "left center",
+					},
+					"&:after": {
+						bottom: "0",
+						width: "50%",
+						transform: "translateX(-1px) rotate(45deg)",
+						transformOrigin: "left center",
+					},
+				},
+			},
+			{
+				match: {
+					animation: "plus" as const,
+					active: "true" as const,
+				},
+				css: {
+					"&:before": {
+						top: "0",
+						transform: "rotate(90deg)",
+					},
+					"&:after": {
+						bottom: "0",
+						transform: "rotate(0deg)",
+					},
+				},
+			},
+			{
+				match: {
+					animation: "minus" as const,
+					active: "true" as const,
+				},
+				css: {
+					"&:before": {
+						top: "0",
+						transform: "rotate(0deg)",
+					},
+					"&:after": {
+						bottom: "0",
+						transform: "rotate(0deg)",
+					},
+				},
+			},
+		],
+		defaultVariants: {
+			size: "md",
+			animation: "close",
+			active: "false",
+		},
+	},
+	(s) => {
+		s.selector(".hamburger-menu-bars::before, .hamburger-menu-bars::after", {
+			content: "''",
+			display: "block",
+			position: "absolute",
+			left: "0",
+			width: "100%",
+			height: "100%",
+			background: "currentColor",
+			borderRadius: "inherit",
+			transitionProperty: "transform, opacity, width, top, bottom",
+			transitionDuration: "300ms",
+			transitionTimingFunction: "cubic-bezier(0.55, 0.055, 0.675, 0.19)",
+		});
+
+		s.selector(".hamburger-menu-bars::before", {
+			top: "-6px",
+		});
+
+		s.selector(".hamburger-menu-bars::after", {
+			bottom: "-6px",
+		});
+	},
+);

--- a/theme/src/recipes/hamburger-menu/useHamburgerMenuRecipe.test.ts
+++ b/theme/src/recipes/hamburger-menu/useHamburgerMenuRecipe.test.ts
@@ -1,0 +1,240 @@
+import { styleframe } from "@styleframe/core";
+import { useDarkModifier } from "../../modifiers/useMediaPreferenceModifiers";
+import {
+	useHoverModifier,
+	useFocusModifier,
+	useFocusVisibleModifier,
+} from "../../modifiers/usePseudoStateModifiers";
+import { useHamburgerMenuRecipe } from "./useHamburgerMenuRecipe";
+
+function createInstance() {
+	const s = styleframe();
+	for (const name of [
+		"display",
+		"alignItems",
+		"justifyContent",
+		"cursor",
+		"userSelect",
+		"background",
+		"borderWidth",
+		"padding",
+		"outline",
+		"outlineWidth",
+		"outlineStyle",
+		"outlineColor",
+		"outlineOffset",
+		"transitionProperty",
+		"transitionTimingFunction",
+		"transitionDuration",
+		"opacity",
+		"width",
+		"height",
+		"color",
+	]) {
+		s.utility(name, ({ value }) => ({ [name]: value }));
+	}
+	useDarkModifier(s);
+	useHoverModifier(s);
+	useFocusModifier(s);
+	useFocusVisibleModifier(s);
+	return s;
+}
+
+describe("useHamburgerMenuRecipe", () => {
+	it("should create a recipe with correct metadata", () => {
+		const s = createInstance();
+		const recipe = useHamburgerMenuRecipe(s);
+
+		expect(recipe.type).toBe("recipe");
+		expect(recipe.name).toBe("hamburger-menu");
+	});
+
+	it("should have correct base styles", () => {
+		const s = createInstance();
+		const recipe = useHamburgerMenuRecipe(s);
+
+		expect(recipe.base).toEqual({
+			display: "inline-flex",
+			alignItems: "center",
+			justifyContent: "center",
+			cursor: "pointer",
+			userSelect: "none",
+			background: "transparent",
+			borderWidth: "0",
+			padding: "@0.25",
+			outline: "none",
+			transitionProperty: "opacity",
+			transitionTimingFunction: "@easing.ease-in-out",
+			transitionDuration: "150ms",
+			"&:hover": {
+				opacity: "0.8",
+			},
+			"&:focus": {
+				opacity: "0.8",
+			},
+			"&:focus-visible": {
+				outlineWidth: "2px",
+				outlineStyle: "solid",
+				outlineColor: "@color.primary",
+				outlineOffset: "2px",
+			},
+		});
+	});
+
+	describe("variants", () => {
+		it("should have all color variants", () => {
+			const s = createInstance();
+			const recipe = useHamburgerMenuRecipe(s);
+
+			expect(Object.keys(recipe.variants!.color)).toEqual([
+				"light",
+				"dark",
+				"neutral",
+			]);
+		});
+
+		it("should have all size variants", () => {
+			const s = createInstance();
+			const recipe = useHamburgerMenuRecipe(s);
+
+			expect(Object.keys(recipe.variants!.size)).toEqual(["sm", "md", "lg"]);
+		});
+
+		it("should have all animation variants", () => {
+			const s = createInstance();
+			const recipe = useHamburgerMenuRecipe(s);
+
+			expect(Object.keys(recipe.variants!.animation)).toEqual([
+				"close",
+				"arrow-left",
+				"arrow-right",
+				"arrow-up",
+				"arrow-down",
+				"plus",
+				"minus",
+			]);
+		});
+
+		it("should have active variants", () => {
+			const s = createInstance();
+			const recipe = useHamburgerMenuRecipe(s);
+
+			expect(Object.keys(recipe.variants!.active)).toEqual(["true", "false"]);
+		});
+
+		it("should have correct size variant styles", () => {
+			const s = createInstance();
+			const recipe = useHamburgerMenuRecipe(s);
+
+			expect(recipe.variants!.size).toEqual({
+				sm: { width: "@2", height: "@2" },
+				md: { width: "@2.5", height: "@2.5" },
+				lg: { width: "@3", height: "@3" },
+			});
+		});
+	});
+
+	it("should have correct default variants", () => {
+		const s = createInstance();
+		const recipe = useHamburgerMenuRecipe(s);
+
+		expect(recipe.defaultVariants).toEqual({
+			color: "neutral",
+			size: "md",
+			animation: "close",
+			active: "false",
+		});
+	});
+
+	describe("compound variants", () => {
+		it("should have 3 compound variants", () => {
+			const s = createInstance();
+			const recipe = useHamburgerMenuRecipe(s);
+
+			expect(recipe.compoundVariants).toHaveLength(3);
+		});
+
+		it("should have correct light compound variant", () => {
+			const s = createInstance();
+			const recipe = useHamburgerMenuRecipe(s);
+
+			const cv = recipe.compoundVariants!.find(
+				(v) => v.match.color === "light",
+			);
+			expect(cv?.css).toEqual({
+				color: "@color.gray-700",
+				"&:dark": {
+					color: "@color.gray-700",
+				},
+			});
+		});
+
+		it("should have correct dark compound variant", () => {
+			const s = createInstance();
+			const recipe = useHamburgerMenuRecipe(s);
+
+			const cv = recipe.compoundVariants!.find((v) => v.match.color === "dark");
+			expect(cv?.css).toEqual({
+				color: "@color.white",
+				"&:dark": {
+					color: "@color.white",
+				},
+			});
+		});
+
+		it("should have correct neutral compound variant", () => {
+			const s = createInstance();
+			const recipe = useHamburgerMenuRecipe(s);
+
+			const cv = recipe.compoundVariants!.find(
+				(v) => v.match.color === "neutral",
+			);
+			expect(cv?.css).toEqual({
+				color: "@color.gray-700",
+				"&:dark": {
+					color: "@color.white",
+				},
+			});
+		});
+	});
+
+	describe("config overrides", () => {
+		it("should allow overriding base styles", () => {
+			const s = createInstance();
+			const recipe = useHamburgerMenuRecipe(s, {
+				base: { display: "flex" },
+			});
+
+			expect(recipe.base?.display).toBe("flex");
+		});
+	});
+
+	describe("filter", () => {
+		it("should filter color variants", () => {
+			const s = createInstance();
+			const recipe = useHamburgerMenuRecipe(s, {
+				filter: { color: ["light"] },
+			});
+
+			expect(Object.keys(recipe.variants!.color)).toEqual(["light"]);
+		});
+
+		it("should prune compound variants when filtering", () => {
+			const s = createInstance();
+			const recipe = useHamburgerMenuRecipe(s, {
+				filter: { color: ["light", "dark"] },
+			});
+
+			expect(recipe.compoundVariants!.length).toBe(2);
+		});
+
+		it("should adjust default variants when filtered out", () => {
+			const s = createInstance();
+			const recipe = useHamburgerMenuRecipe(s, {
+				filter: { color: ["light"] },
+			});
+
+			expect(recipe.defaultVariants?.color).toBeUndefined();
+		});
+	});
+});

--- a/theme/src/recipes/hamburger-menu/useHamburgerMenuRecipe.ts
+++ b/theme/src/recipes/hamburger-menu/useHamburgerMenuRecipe.ts
@@ -1,0 +1,104 @@
+import { createUseRecipe } from "../../utils/createUseRecipe";
+
+/**
+ * Hamburger menu container recipe.
+ * Provides the interactive wrapper with color, size, and focus styles.
+ * Color is applied via CSS `color` property and inherited by the bars via `currentColor`.
+ */
+export const useHamburgerMenuRecipe = createUseRecipe("hamburger-menu", {
+	base: {
+		display: "inline-flex",
+		alignItems: "center",
+		justifyContent: "center",
+		cursor: "pointer",
+		userSelect: "none",
+		background: "transparent",
+		borderWidth: "0",
+		padding: "@0.25",
+		outline: "none",
+		transitionProperty: "opacity",
+		transitionTimingFunction: "@easing.ease-in-out",
+		transitionDuration: "150ms",
+		"&:hover": {
+			opacity: "0.8",
+		},
+		"&:focus": {
+			opacity: "0.8",
+		},
+		"&:focus-visible": {
+			outlineWidth: "2px",
+			outlineStyle: "solid",
+			outlineColor: "@color.primary",
+			outlineOffset: "2px",
+		},
+	},
+	variants: {
+		color: {
+			light: {},
+			dark: {},
+			neutral: {},
+		},
+		size: {
+			sm: {
+				width: "@2",
+				height: "@2",
+			},
+			md: {
+				width: "@2.5",
+				height: "@2.5",
+			},
+			lg: {
+				width: "@3",
+				height: "@3",
+			},
+		},
+		animation: {
+			close: {},
+			"arrow-left": {},
+			"arrow-right": {},
+			"arrow-up": {},
+			"arrow-down": {},
+			plus: {},
+			minus: {},
+		},
+		active: {
+			true: {},
+			false: {},
+		},
+	},
+	compoundVariants: [
+		{
+			match: { color: "light" as const },
+			css: {
+				color: "@color.gray-700",
+				"&:dark": {
+					color: "@color.gray-700",
+				},
+			},
+		},
+		{
+			match: { color: "dark" as const },
+			css: {
+				color: "@color.white",
+				"&:dark": {
+					color: "@color.white",
+				},
+			},
+		},
+		{
+			match: { color: "neutral" as const },
+			css: {
+				color: "@color.gray-700",
+				"&:dark": {
+					color: "@color.white",
+				},
+			},
+		},
+	],
+	defaultVariants: {
+		color: "neutral",
+		size: "md",
+		animation: "close",
+		active: "false",
+	},
+});

--- a/theme/src/recipes/index.ts
+++ b/theme/src/recipes/index.ts
@@ -4,6 +4,7 @@ export * from "./button-group";
 export * from "./callout";
 export * from "./card";
 export * from "./chip";
+export * from "./hamburger-menu";
 export * from "./spinner";
 export * from "./modal";
 export * from "./nav";


### PR DESCRIPTION
## Summary
- Adds a new HamburgerMenu recipe with a composable `bars` sub-recipe, including size/animation variants and defaults.
- Exposes the recipe via `theme/src/recipes/index.ts` with unit tests covering both `useHamburgerMenuRecipe` and `useHamburgerMenuBarsRecipe`.
- Ships Storybook stories with animation/size preview grids and a full documentation page under `apps/docs/content/docs/06.components/02.composables/14.hamburger-menu.md`.

## Test plan
- [ ] `pnpm test` (theme recipes)
- [ ] Verify stories render in Storybook across size and animation variants
- [ ] Verify docs page renders correctly