### PR TITLE
feat: Add Dropdown Menu recipe with menu, item, and divider

### DIFF
--- a/apps/docs/content/docs/06.components/02.composables/14.dropdown-menu.md
+++ b/apps/docs/content/docs/06.components/02.composables/14.dropdown-menu.md
@@ -1,0 +1,424 @@
+---
+title: Dropdown Menu
+description: A dropdown menu component with interactive items and visual dividers for contextual action lists. Supports multiple colors, visual styles, and sizes through the recipe system.
+---
+
+## Overview
+
+The **Dropdown Menu** is a floating action list used for contextual menus triggered by user interaction. It is composed of three recipe parts: `useDropdownMenuRecipe()` for the container, `useDropdownItemRecipe()` for interactive menu items, and `useDropdownDividerRecipe()` for visual separators. Each composable creates a fully configured [recipe](/docs/api/recipes) with color, variant, and size options &mdash; plus compound variants that handle the color-variant combinations automatically.
+
+The Dropdown Menu combines the floating container of a [Popover](/docs/components/composables/popover) with the interactive item pattern of a [Nav](/docs/components/composables/nav). The recipes integrate directly with the default [design tokens preset](/docs/design-tokens/presets) and generate type-safe utility classes at build time with zero runtime CSS.
+
+## Why use the Dropdown Menu recipe?
+
+The Dropdown Menu recipe helps you:
+
+- **Ship faster with sensible defaults**: Get 3 colors, 3 visual styles, and 3 sizes out of the box with three composable calls.
+- **Compose structured action menus**: Three coordinated recipes (container, item, divider) share the same variant axes, so your menus stay internally consistent.
+- **Maintain consistency**: Compound variants ensure every color-variant combination follows the same design rules, including hover states, divider colors, and dark mode overrides.
+- **Customize without forking**: Override base styles, default variants, or filter out options you don't need &mdash; all through the options API.
+- **Stay type-safe**: Full TypeScript support means your editor catches invalid color, variant, or size values at compile time.
+- **Integrate with your tokens**: Every value references the design tokens preset, so theme changes propagate automatically.
+
+## Usage
+
+::steps{level="4"}
+
+#### Register the recipes
+
+Add the Dropdown Menu recipes to a local Styleframe instance. The global `styleframe.config.ts` provides design tokens and utilities, while the component-level file registers the recipes themselves:
+
+:::code-tree{default-value="src/components/dropdown-menu.styleframe.ts"}
+
+```ts [src/components/dropdown-menu.styleframe.ts]
+import { styleframe } from 'virtual:styleframe';
+import {
+    useDropdownMenuRecipe,
+    useDropdownItemRecipe,
+    useDropdownDividerRecipe,
+} from '@styleframe/theme';
+
+const s = styleframe();
+
+const dropdownMenu = useDropdownMenuRecipe(s);
+const dropdownItem = useDropdownItemRecipe(s);
+const dropdownDivider = useDropdownDividerRecipe(s);
+
+export default s;
+```
+
+```ts [styleframe.config.ts]
+import { styleframe } from 'styleframe';
+import { useDesignTokensPreset, useUtilitiesPreset } from '@styleframe/theme';
+
+const s = styleframe();
+
+useDesignTokensPreset(s);
+useUtilitiesPreset(s);
+
+export default s;
+```
+
+:::
+
+#### Build the component
+
+Import the `dropdownMenu`, `dropdownItem`, and `dropdownDivider` runtime functions from the virtual module and pass variant props to compute class names:
+
+:::tabs
+::::tabs-item{icon="i-devicon-react" label="React"}
+
+```ts [src/components/DropdownMenu.tsx]
+import { dropdownMenu, dropdownItem, dropdownDivider } from "virtual:styleframe";
+
+interface DropdownMenuProps {
+    color?: "light" | "dark" | "neutral";
+    variant?: "solid" | "soft" | "subtle";
+    size?: "sm" | "md" | "lg";
+    items: Array<{ label: string; active?: boolean; disabled?: boolean } | "divider">;
+}
+
+export function DropdownMenu({
+    color = "neutral",
+    variant = "solid",
+    size = "md",
+    items,
+}: DropdownMenuProps) {
+    return (
+        <div className={dropdownMenu({ color, variant, size })} role="menu">
+            {items.map((item, i) =>
+                item === "divider" ? (
+                    <hr key={i} className={dropdownDivider({ color, variant })} role="separator" />
+                ) : (
+                    <div
+                        key={i}
+                        className={dropdownItem({
+                            color, variant, size,
+                            active: item.active ? "true" : "false",
+                            disabled: item.disabled ? "true" : "false",
+                        })}
+                        role="menuitem"
+                    >
+                        {item.label}
+                    </div>
+                )
+            )}
+        </div>
+    );
+}
+```
+
+::::
+::::tabs-item{icon="i-devicon-vuejs" label="Vue"}
+
+```vue [src/components/DropdownMenu.vue]
+<script setup lang="ts">
+import { dropdownMenu, dropdownItem, dropdownDivider } from "virtual:styleframe";
+
+const { color = "neutral", variant = "solid", size = "md" } = defineProps<{
+    color?: "light" | "dark" | "neutral";
+    variant?: "solid" | "soft" | "subtle";
+    size?: "sm" | "md" | "lg";
+}>();
+</script>
+
+<template>
+    <div :class="dropdownMenu({ color, variant, size })" role="menu">
+        <slot />
+    </div>
+</template>
+```
+
+::::
+:::
+
+#### See it in action
+
+:::story-preview
+---
+story: theme-recipes-dropdownmenu--default
+panel: true
+---
+:::
+
+::
+
+## Colors
+
+The Dropdown Menu recipe includes 3 color variants: `light`, `dark`, and `neutral`. Like the Popover recipe, the Dropdown Menu uses neutral-spectrum colors designed for content surfaces rather than status communication. Each color is combined with every visual style variant through compound variants, so you get consistent, predictable styling across all combinations &mdash; including dark mode overrides.
+
+The `neutral` color adapts automatically: it uses a light appearance in light mode and a dark appearance in dark mode, making it the safest default for general-purpose menus.
+
+::story-preview
+---
+story: theme-recipes-dropdownmenu--neutral
+panel: true
+---
+::
+
+### Color Reference
+
+::story-preview
+---
+story: theme-recipes-dropdownmenu--all-variants
+height: 500
+---
+::
+
+| Color | Token | Use Case |
+|-------|-------|----------|
+| `light` | `@color.white` / `@color.gray-*` | Light surfaces, stays light in dark mode |
+| `dark` | `@color.gray-900` | Dark surfaces, stays dark in light mode |
+| `neutral` | Adaptive (light ↔ dark) | Default color, adapts to the current color scheme |
+
+::tip
+**Pro tip:** Use `neutral` as your default dropdown menu color. It adapts automatically to the user's color scheme, so you don't need to manage light and dark variants separately.
+::
+
+## Variants
+
+Three visual style variants control how the dropdown menu is rendered. Each variant is combined with the selected color through [compound variants](/docs/api/recipes#compound-variants), so you always get the correct background, text, border, and divider colors for your chosen color.
+
+### Solid
+
+Filled background with a subtle border. The most prominent style, ideal for primary action menus.
+
+::story-preview
+---
+story: theme-recipes-dropdownmenu--solid
+panel: true
+---
+::
+
+### Soft
+
+Light tinted background with no visible border. A gentle, borderless style that works well for menus in dense layouts.
+
+::story-preview
+---
+story: theme-recipes-dropdownmenu--soft
+panel: true
+---
+::
+
+### Subtle
+
+Light tinted background with a matching border. Combines the softness of the `soft` variant with added visual definition from a border.
+
+::story-preview
+---
+story: theme-recipes-dropdownmenu--subtle
+panel: true
+---
+::
+
+## Sizes
+
+Three size variants from `sm` to `lg` control the border radius of the menu container and the padding, font size, and gap of each item.
+
+::story-preview
+---
+story: theme-recipes-dropdownmenu--all-sizes
+height: 500
+---
+::
+
+| Size | Font Size | Border Radius | Item Padding (V / H) |
+|------|-----------|---------------|----------------------|
+| `sm` | `@font-size.xs` | `@border-radius.sm` | `@0.25` / `@0.5` |
+| `md` | `@font-size.sm` | `@border-radius.md` | `@0.375` / `@0.75` |
+| `lg` | `@font-size.md` | `@border-radius.lg` | `@0.5` / `@1` |
+
+::note
+**Good to know:** The `size` prop must be passed to both the container and items individually. The divider recipe does not have a size variant &mdash; it is always a thin line with consistent spacing.
+::
+
+## Anatomy
+
+The Dropdown Menu recipe is composed of three independent recipes that work together to form an action menu:
+
+| Part | Recipe | Role |
+|------|--------|------|
+| **Container** | `useDropdownMenuRecipe()` | Outer wrapper with background, border, border radius, shadow, and `overflow: hidden` |
+| **Item** | `useDropdownItemRecipe()` | Interactive menu item with hover, focus, active, and disabled states |
+| **Divider** | `useDropdownDividerRecipe()` | Horizontal separator between menu sections |
+
+The `color` and `variant` props should be passed consistently to the container, items, and dividers so that hover backgrounds and divider colors match the menu's visual style. The item recipe also accepts `active` and `disabled` boolean props for state management.
+
+```html
+<!-- All three parts working together -->
+<div class="dropdownMenu(...)" role="menu">
+    <div class="dropdownItem(...)" role="menuitem">Action</div>
+    <div class="dropdownItem(...)" role="menuitem">Another action</div>
+    <hr class="dropdownDivider(...)" role="separator" />
+    <div class="dropdownItem(...)" role="menuitem">Separated action</div>
+</div>
+```
+
+::tip
+**Pro tip:** The divider is optional. Use it only when you need to visually separate groups of related actions within the menu.
+::
+
+## Accessibility
+
+- **Use `role="menu"` on the container.** The dropdown menu container should have `role="menu"` and `aria-labelledby` pointing to the trigger element.
+
+```html
+<!-- Correct: dropdown menu with menu role -->
+<div role="menu" aria-labelledby="dropdown-trigger" class="...">
+    <div role="menuitem" class="...">Action</div>
+    <hr role="separator" class="..." />
+    <div role="menuitem" class="...">Another action</div>
+</div>
+```
+
+- **Use `role="menuitem"` on items.** Each interactive item should have `role="menuitem"`. Disabled items should include `aria-disabled="true"`.
+- **Use `role="separator"` on dividers.** The divider element should have `role="separator"` to communicate its purpose to assistive technology.
+- **Support keyboard navigation.** Arrow keys should move focus between items, Enter/Space should activate the focused item, and Escape should close the menu.
+- **Manage focus.** When the menu opens, move focus to the first item. When it closes, return focus to the trigger.
+- **Verify contrast ratios.** The `solid` variant with `dark` color places light text on a dark background. Default tokens meet WCAG AA 4.5:1 contrast. If you override colors, verify with the [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/).
+
+## Customization
+
+### Overriding Defaults
+
+Each dropdown menu composable accepts an optional second argument to override any part of the recipe configuration. Overrides are deep-merged with the defaults, so you only need to specify the properties you want to change:
+
+```ts [src/components/dropdown-menu.styleframe.ts]
+const dropdownMenu = useDropdownMenuRecipe(s, {
+    base: { boxShadow: '@box-shadow.lg' },
+    defaultVariants: { color: 'neutral', variant: 'subtle', size: 'md' },
+});
+
+const dropdownItem = useDropdownItemRecipe(s, {
+    defaultVariants: { color: 'neutral', variant: 'subtle', size: 'md' },
+});
+
+const dropdownDivider = useDropdownDividerRecipe(s, {
+    defaultVariants: { color: 'neutral', variant: 'subtle' },
+});
+```
+
+### Filtering Variants
+
+```ts [src/components/dropdown-menu.styleframe.ts]
+const dropdownMenu = useDropdownMenuRecipe(s, {
+    filter: {
+        color: ['neutral'],
+        variant: ['solid', 'subtle'],
+    },
+});
+```
+
+::note
+**Good to know:** Filtering also removes compound variants and adjusts default variants that reference filtered-out values, so your recipe stays consistent.
+::
+
+## API Reference
+
+### `useDropdownMenuRecipe(s, options?)`
+
+Creates the dropdown menu container recipe with background, border, border radius, shadow, and flex column layout.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `s` | `Styleframe` | The Styleframe instance |
+| `options` | `DeepPartial<RecipeConfig>` | Optional overrides for the recipe configuration |
+| `options.base` | `VariantDeclarationsBlock` | Custom base styles |
+| `options.variants` | `Variants` | Custom variant definitions |
+| `options.defaultVariants` | `Record<keyof Variants, string>` | Default variant values |
+| `options.compoundVariants` | `CompoundVariant[]` | Custom compound variant definitions |
+| `options.filter` | `Record<string, string[]>` | Limit which variant values are generated |
+
+**Variants:**
+
+| Variant | Options | Default |
+|---------|---------|---------|
+| `color` | `light`, `dark`, `neutral` | `neutral` |
+| `variant` | `solid`, `soft`, `subtle` | `solid` |
+| `size` | `sm`, `md`, `lg` | `md` |
+
+### `useDropdownItemRecipe(s, options?)`
+
+Creates the dropdown item recipe for interactive menu items with hover, focus, active, and disabled states. Accepts the same parameters as `useDropdownMenuRecipe`.
+
+**Variants:**
+
+| Variant | Options | Default |
+|---------|---------|---------|
+| `color` | `light`, `dark`, `neutral` | `neutral` |
+| `variant` | `solid`, `soft`, `subtle` | `solid` |
+| `size` | `sm`, `md`, `lg` | `md` |
+| `active` | `true`, `false` | `false` |
+| `disabled` | `true`, `false` | `false` |
+
+### `useDropdownDividerRecipe(s, options?)`
+
+Creates the dropdown divider recipe for horizontal separators between menu sections. Accepts the same parameters as `useDropdownMenuRecipe`.
+
+**Variants:**
+
+| Variant | Options | Default |
+|---------|---------|---------|
+| `color` | `light`, `dark`, `neutral` | `neutral` |
+| `variant` | `solid`, `soft`, `subtle` | `solid` |
+
+[Learn more about recipes &rarr;](/docs/api/recipes)
+
+## Best Practices
+
+- **Pass `color` and `variant` consistently**: The container, items, and dividers all need the same `color` and `variant` values so that hover backgrounds and divider colors match the menu's visual style.
+- **Pass `size` to the container and each item**: The container controls the border radius and vertical padding, while items manage their own padding and font size based on the `size` prop.
+- **The divider only needs `color` and `variant`**: Do not pass `size` to the divider. It is always a thin line with consistent spacing.
+- **Use `neutral` for general-purpose menus**: The neutral color adapts to light and dark mode automatically, making it the safest default.
+- **Prefer `solid` for primary menus**: Reserve `soft` and `subtle` for secondary or nested menus to create visual hierarchy.
+- **Use a positioning library for placement**: The recipe handles visual styling only. Use Floating UI or a similar library for dynamic positioning and collision detection.
+- **Use `active` for the current selection**: Mark the currently selected or active item with the `active` prop to give it a semibold font weight.
+- **Filter what you don't need**: If your component only uses one color, pass a `filter` option to reduce generated CSS.
+- **Override defaults at the recipe level**: Set your most common variant combination as `defaultVariants` so component consumers write less code.
+
+## FAQ
+
+::accordion
+
+:::accordion-item{label="Why are there three separate recipes instead of one?" icon="i-lucide-circle-help"}
+Dropdown menus have distinct structural parts (container, items, dividers) that need independent styling &mdash; different interactive states, padding approaches, and rendering techniques. Three separate recipes keep each part focused and let you compose only the parts you need.
+:::
+
+:::accordion-item{label="Do I have to use the divider recipe?" icon="i-lucide-circle-help"}
+No. The divider is optional. A dropdown menu with only items is perfectly valid. Use dividers only when you need to visually separate groups of related actions.
+:::
+
+:::accordion-item{label="What's the difference between Dropdown Menu and Popover?" icon="i-lucide-circle-help"}
+Dropdown Menus are action lists with interactive items, typically triggered by a button click, using `role="menu"`. Popovers are richer floating containers with header, body, and footer sections, using `role="dialog"`. Dropdown menus have interactive items with hover/focus states; popovers have static content sections with separator borders.
+:::
+
+:::accordion-item{label="What's the difference between light, dark, and neutral colors?" icon="i-lucide-circle-help"}
+`light` always uses white and gray-100 backgrounds regardless of the color scheme. `dark` always uses gray-800 and gray-900 backgrounds. `neutral` adapts to the current color scheme: it appears light in light mode and dark in dark mode. Use `neutral` when you want the menu to blend naturally with the surrounding interface.
+:::
+
+:::accordion-item{label="What's the difference between the soft and subtle variants?" icon="i-lucide-circle-help"}
+Both use a light tinted background. The difference is that `subtle` also adds a matching border, giving the menu more visual definition. Use `soft` when you want a borderless, gentler appearance, and `subtle` when the menu needs slightly more structure.
+:::
+
+:::accordion-item{label="Why doesn't the Dropdown Menu recipe include semantic colors like primary or success?" icon="i-lucide-circle-help"}
+Dropdown menus are action containers, not status indicators. Semantic colors (primary, success, error) communicate meaning through color, which is better suited to smaller, focused elements like badges, buttons, and callouts. Dropdown menus use `light`, `dark`, and `neutral` to provide surface variations that work across all content types without implying a specific status.
+:::
+
+:::accordion-item{label="How do compound variants work in the Dropdown Menu recipe?" icon="i-lucide-circle-help"}
+The Dropdown Menu recipe uses compound variants to map each color-variant combination to specific styles. For the 3 colors and 3 variants, 9 compound variant entries define the background, text color, and border color &mdash; each with dark mode overrides via the `&:dark` selector. The item recipe uses compound variants for hover, focus, and active pseudo-state colors. The divider recipe uses compound variants to set the separator color that matches the menu's visual style.
+
+[Learn more about compound variants &rarr;](/docs/api/recipes#compound-variants)
+:::
+
+:::accordion-item{label="How does the active state work for items?" icon="i-lucide-circle-help"}
+The `active` variant is a boolean axis on the dropdown item recipe. Setting `active: "true"` applies `fontWeight: semibold` to visually highlight the currently selected item. This follows the same pattern as the [Nav](/docs/components/composables/nav) recipe's active state.
+:::
+
+:::accordion-item{label="Can I use the Dropdown Menu recipe without the design tokens preset?" icon="i-lucide-circle-help"}
+The Dropdown Menu recipe references design tokens like `@color.white`, `@border-radius.md`, and `@box-shadow.md` through string refs. These tokens need to be defined in your Styleframe instance for the recipe to generate valid CSS. The easiest way is to use `useDesignTokensPreset(s)`, but you can also define the required tokens manually.
+:::
+
+::

--- a/apps/storybook/src/components/components/dropdown-menu/DropdownDivider.vue
+++ b/apps/storybook/src/components/components/dropdown-menu/DropdownDivider.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { dropdownDivider } from "virtual:styleframe";
+
+const props = withDefaults(
+	defineProps<{
+		color?: "light" | "dark" | "neutral";
+		variant?: "solid" | "soft" | "subtle";
+	}>(),
+	{},
+);
+
+const classes = computed(() =>
+	dropdownDivider({
+		color: props.color,
+		variant: props.variant,
+	}),
+);
+</script>
+
+<template>
+	<hr :class="classes" role="separator" />
+</template>

--- a/apps/storybook/src/components/components/dropdown-menu/DropdownItem.vue
+++ b/apps/storybook/src/components/components/dropdown-menu/DropdownItem.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { dropdownItem } from "virtual:styleframe";
+
+const props = withDefaults(
+	defineProps<{
+		color?: "light" | "dark" | "neutral";
+		variant?: "solid" | "soft" | "subtle";
+		size?: "sm" | "md" | "lg";
+		active?: boolean;
+		disabled?: boolean;
+		label?: string;
+	}>(),
+	{},
+);
+
+const classes = computed(() =>
+	dropdownItem({
+		color: props.color,
+		variant: props.variant,
+		size: props.size,
+		active: props.active ? "true" : "false",
+		disabled: props.disabled ? "true" : "false",
+	}),
+);
+</script>
+
+<template>
+	<div :class="classes" role="menuitem" :aria-disabled="disabled || undefined">
+		{{ props.label }}
+		<slot />
+	</div>
+</template>

--- a/apps/storybook/src/components/components/dropdown-menu/DropdownMenu.vue
+++ b/apps/storybook/src/components/components/dropdown-menu/DropdownMenu.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { dropdownMenu } from "virtual:styleframe";
+
+const props = withDefaults(
+	defineProps<{
+		color?: "light" | "dark" | "neutral";
+		variant?: "solid" | "soft" | "subtle";
+		size?: "sm" | "md" | "lg";
+	}>(),
+	{},
+);
+
+const classes = computed(() =>
+	dropdownMenu({
+		color: props.color,
+		variant: props.variant,
+		size: props.size,
+	}),
+);
+</script>
+
+<template>
+	<div :class="classes">
+		<slot />
+	</div>
+</template>

--- a/apps/storybook/src/components/components/dropdown-menu/preview/DropdownMenuGrid.vue
+++ b/apps/storybook/src/components/components/dropdown-menu/preview/DropdownMenuGrid.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import DropdownMenu from "../DropdownMenu.vue";
+import DropdownItem from "../DropdownItem.vue";
+import DropdownDivider from "../DropdownDivider.vue";
+
+const colors = ["neutral", "light", "dark"] as const;
+const variants = ["solid", "soft", "subtle"] as const;
+</script>
+
+<template>
+	<div class="dropdown-menu-section">
+		<div v-for="variant in variants" :key="variant">
+			<div class="dropdown-menu-label">{{ variant }}</div>
+			<div class="dropdown-menu-row">
+				<DropdownMenu
+					v-for="color in colors"
+					:key="`${variant}-${color}`"
+					:color="color"
+					:variant="variant"
+					style="min-width: 180px"
+				>
+					<DropdownItem :color="color" :variant="variant" label="Action" />
+					<DropdownItem :color="color" :variant="variant" label="Another action" />
+					<DropdownDivider :color="color" :variant="variant" />
+					<DropdownItem :color="color" :variant="variant" label="Something else" />
+				</DropdownMenu>
+			</div>
+		</div>
+	</div>
+</template>

--- a/apps/storybook/src/components/components/dropdown-menu/preview/DropdownMenuSizeGrid.vue
+++ b/apps/storybook/src/components/components/dropdown-menu/preview/DropdownMenuSizeGrid.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import DropdownMenu from "../DropdownMenu.vue";
+import DropdownItem from "../DropdownItem.vue";
+import DropdownDivider from "../DropdownDivider.vue";
+
+const colors = ["neutral", "light", "dark"] as const;
+const sizes = ["sm", "md", "lg"] as const;
+const sizeTitles: Record<string, string> = {
+	sm: "Small",
+	md: "Medium",
+	lg: "Large",
+};
+</script>
+
+<template>
+	<div class="dropdown-menu-section">
+		<div v-for="size in sizes" :key="size">
+			<div class="dropdown-menu-label">{{ size }}</div>
+			<div class="dropdown-menu-row">
+				<DropdownMenu
+					v-for="color in colors"
+					:key="`${size}-${color}`"
+					:color="color"
+					:size="size"
+					style="min-width: 180px"
+				>
+					<DropdownItem :color="color" :size="size" :label="`${sizeTitles[size]} action`" />
+					<DropdownItem :color="color" :size="size" label="Another action" />
+					<DropdownDivider :color="color" />
+					<DropdownItem :color="color" :size="size" label="Something else" />
+				</DropdownMenu>
+			</div>
+		</div>
+	</div>
+</template>

--- a/apps/storybook/stories/components/dropdown-menu.stories.ts
+++ b/apps/storybook/stories/components/dropdown-menu.stories.ts
@@ -1,0 +1,171 @@
+import type { Meta, StoryObj } from "@storybook/vue3-vite";
+
+import DropdownMenu from "@/components/components/dropdown-menu/DropdownMenu.vue";
+import DropdownItem from "@/components/components/dropdown-menu/DropdownItem.vue";
+import DropdownDivider from "@/components/components/dropdown-menu/DropdownDivider.vue";
+import DropdownMenuGrid from "@/components/components/dropdown-menu/preview/DropdownMenuGrid.vue";
+import DropdownMenuSizeGrid from "@/components/components/dropdown-menu/preview/DropdownMenuSizeGrid.vue";
+
+const colors = ["neutral", "light", "dark"] as const;
+const variants = ["solid", "soft", "subtle"] as const;
+const sizes = ["sm", "md", "lg"] as const;
+
+const meta = {
+	title: "Theme/Recipes/DropdownMenu",
+	component: DropdownMenu,
+	tags: ["autodocs"],
+	parameters: {
+		layout: "padded",
+	},
+	argTypes: {
+		color: {
+			control: "select",
+			options: colors,
+			description: "The color variant of the dropdown menu",
+		},
+		variant: {
+			control: "select",
+			options: variants,
+			description: "The visual style variant",
+		},
+		size: {
+			control: "select",
+			options: sizes,
+			description: "The size of the dropdown menu",
+		},
+	},
+	render: (args) => ({
+		components: {
+			DropdownMenu,
+			DropdownItem,
+			DropdownDivider,
+		},
+		setup() {
+			return { args };
+		},
+		template: `
+			<DropdownMenu v-bind="args" style="min-width: 200px">
+				<DropdownItem v-bind="args" label="Action" />
+				<DropdownItem v-bind="args" label="Another action" />
+				<DropdownItem v-bind="args" label="Something else" />
+				<DropdownDivider v-bind="args" />
+				<DropdownItem v-bind="args" label="Separated action" />
+			</DropdownMenu>
+		`,
+	}),
+} satisfies Meta<typeof DropdownMenu>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {
+		color: "neutral",
+		variant: "solid",
+		size: "md",
+	},
+};
+
+export const AllVariants: StoryObj = {
+	render: () => ({
+		components: { DropdownMenuGrid },
+		template: "<DropdownMenuGrid />",
+	}),
+};
+
+export const AllSizes: StoryObj = {
+	render: () => ({
+		components: { DropdownMenuSizeGrid },
+		template: "<DropdownMenuSizeGrid />",
+	}),
+};
+
+// Individual color stories
+export const Neutral: Story = {
+	args: {
+		color: "neutral",
+	},
+};
+
+export const Light: Story = {
+	args: {
+		color: "light",
+	},
+};
+
+export const Dark: Story = {
+	args: {
+		color: "dark",
+	},
+};
+
+// Variant stories
+export const Solid: Story = {
+	args: {
+		variant: "solid",
+	},
+};
+
+export const Soft: Story = {
+	args: {
+		variant: "soft",
+	},
+};
+
+export const Subtle: Story = {
+	args: {
+		variant: "subtle",
+	},
+};
+
+// Size stories
+export const Small: Story = {
+	args: {
+		size: "sm",
+	},
+};
+
+export const Medium: Story = {
+	args: {
+		size: "md",
+	},
+};
+
+export const Large: Story = {
+	args: {
+		size: "lg",
+	},
+};
+
+// Feature stories
+export const ActiveItem: StoryObj = {
+	render: (args) => ({
+		components: { DropdownMenu, DropdownItem, DropdownDivider },
+		setup() {
+			return { args };
+		},
+		template: `
+			<DropdownMenu v-bind="args" style="min-width: 200px">
+				<DropdownItem v-bind="args" label="Action" />
+				<DropdownItem v-bind="args" label="Active action" :active="true" />
+				<DropdownItem v-bind="args" label="Another action" />
+			</DropdownMenu>
+		`,
+	}),
+};
+
+export const DisabledItem: StoryObj = {
+	render: (args) => ({
+		components: { DropdownMenu, DropdownItem, DropdownDivider },
+		setup() {
+			return { args };
+		},
+		template: `
+			<DropdownMenu v-bind="args" style="min-width: 200px">
+				<DropdownItem v-bind="args" label="Action" />
+				<DropdownItem v-bind="args" label="Disabled action" :disabled="true" />
+				<DropdownItem v-bind="args" label="Another action" />
+			</DropdownMenu>
+		`,
+	}),
+};

--- a/apps/storybook/stories/components/dropdown-menu.styleframe.ts
+++ b/apps/storybook/stories/components/dropdown-menu.styleframe.ts
@@ -1,0 +1,45 @@
+import {
+	useDropdownMenuRecipe,
+	useDropdownItemRecipe,
+	useDropdownDividerRecipe,
+} from "@styleframe/theme";
+import { styleframe } from "virtual:styleframe";
+
+const s = styleframe();
+const { selector } = s;
+
+// Initialize dropdown menu recipes
+export const dropdownMenu = useDropdownMenuRecipe(s);
+export const dropdownItem = useDropdownItemRecipe(s);
+export const dropdownDivider = useDropdownDividerRecipe(s);
+
+// Container styles for story layout
+selector(".dropdown-menu-grid", {
+	display: "flex",
+	flexWrap: "wrap",
+	gap: "@spacing.md",
+	padding: "@spacing.md",
+	alignItems: "flex-start",
+});
+
+selector(".dropdown-menu-section", {
+	display: "flex",
+	flexDirection: "column",
+	gap: "@spacing.lg",
+	padding: "@spacing.md",
+});
+
+selector(".dropdown-menu-row", {
+	display: "flex",
+	flexWrap: "wrap",
+	gap: "@spacing.sm",
+	alignItems: "flex-start",
+});
+
+selector(".dropdown-menu-label", {
+	fontSize: "@font-size.sm",
+	fontWeight: "@font-weight.semibold",
+	minWidth: "80px",
+});
+
+export default s;

--- a/theme/src/recipes/dropdown-menu/index.ts
+++ b/theme/src/recipes/dropdown-menu/index.ts
@@ -1,0 +1,3 @@
+export * from "./useDropdownMenuRecipe";
+export * from "./useDropdownItemRecipe";
+export * from "./useDropdownDividerRecipe";

--- a/theme/src/recipes/dropdown-menu/useDropdownDividerRecipe.test.ts
+++ b/theme/src/recipes/dropdown-menu/useDropdownDividerRecipe.test.ts
@@ -1,0 +1,205 @@
+import { styleframe } from "@styleframe/core";
+import { useDarkModifier } from "../../modifiers/useMediaPreferenceModifiers";
+import { useDropdownDividerRecipe } from "./index";
+
+function createInstance() {
+	const s = styleframe();
+	for (const name of [
+		"borderTopWidth",
+		"borderTopStyle",
+		"borderTopColor",
+		"marginTop",
+		"marginBottom",
+	]) {
+		s.utility(name, ({ value }) => ({ [name]: value }));
+	}
+	useDarkModifier(s);
+	return s;
+}
+
+describe("useDropdownDividerRecipe", () => {
+	it("should create a recipe with correct metadata", () => {
+		const s = createInstance();
+		const recipe = useDropdownDividerRecipe(s);
+
+		expect(recipe.type).toBe("recipe");
+		expect(recipe.name).toBe("dropdown-divider");
+	});
+
+	it("should have correct base styles", () => {
+		const s = createInstance();
+		const recipe = useDropdownDividerRecipe(s);
+
+		expect(recipe.base).toEqual({
+			borderTopWidth: "@border-width.thin",
+			borderTopStyle: "@border-style.solid",
+			borderTopColor: "transparent",
+			marginTop: "@0.25",
+			marginBottom: "@0.25",
+		});
+	});
+
+	describe("variants", () => {
+		it("should have all color variants", () => {
+			const s = createInstance();
+			const recipe = useDropdownDividerRecipe(s);
+
+			expect(Object.keys(recipe.variants!.color)).toEqual([
+				"light",
+				"dark",
+				"neutral",
+			]);
+		});
+
+		it("should have all style variants", () => {
+			const s = createInstance();
+			const recipe = useDropdownDividerRecipe(s);
+
+			expect(Object.keys(recipe.variants!.variant)).toEqual([
+				"solid",
+				"soft",
+				"subtle",
+			]);
+		});
+
+		it("should not have size variants", () => {
+			const s = createInstance();
+			const recipe = useDropdownDividerRecipe(s);
+
+			expect((recipe.variants as Record<string, unknown>).size).toBeUndefined();
+		});
+	});
+
+	it("should have correct default variants", () => {
+		const s = createInstance();
+		const recipe = useDropdownDividerRecipe(s);
+
+		expect(recipe.defaultVariants).toEqual({
+			color: "neutral",
+			variant: "solid",
+		});
+	});
+
+	describe("compound variants", () => {
+		it("should have 9 compound variants total", () => {
+			const s = createInstance();
+			const recipe = useDropdownDividerRecipe(s);
+
+			// 3 colors × 3 variants = 9
+			expect(recipe.compoundVariants).toHaveLength(9);
+		});
+
+		it("should have correct light solid compound variant", () => {
+			const s = createInstance();
+			const recipe = useDropdownDividerRecipe(s);
+
+			const lightSolid = recipe.compoundVariants!.find(
+				(cv) => cv.match.color === "light" && cv.match.variant === "solid",
+			);
+
+			expect(lightSolid).toEqual({
+				match: { color: "light", variant: "solid" },
+				css: {
+					borderTopColor: "@color.gray-200",
+					"&:dark": {
+						borderTopColor: "@color.gray-200",
+					},
+				},
+			});
+		});
+
+		it("should have correct dark solid compound variant", () => {
+			const s = createInstance();
+			const recipe = useDropdownDividerRecipe(s);
+
+			const darkSolid = recipe.compoundVariants!.find(
+				(cv) => cv.match.color === "dark" && cv.match.variant === "solid",
+			);
+
+			expect(darkSolid).toEqual({
+				match: { color: "dark", variant: "solid" },
+				css: {
+					borderTopColor: "@color.gray-700",
+					"&:dark": {
+						borderTopColor: "@color.gray-700",
+					},
+				},
+			});
+		});
+
+		it("should have correct neutral solid compound variant with adaptive dark mode", () => {
+			const s = createInstance();
+			const recipe = useDropdownDividerRecipe(s);
+
+			const neutralSolid = recipe.compoundVariants!.find(
+				(cv) => cv.match.color === "neutral" && cv.match.variant === "solid",
+			);
+
+			expect(neutralSolid).toEqual({
+				match: { color: "neutral", variant: "solid" },
+				css: {
+					borderTopColor: "@color.gray-200",
+					"&:dark": {
+						borderTopColor: "@color.gray-700",
+					},
+				},
+			});
+		});
+
+		it("should always show visible divider lines even for soft variant", () => {
+			const s = createInstance();
+			const recipe = useDropdownDividerRecipe(s);
+
+			const neutralSoft = recipe.compoundVariants!.find(
+				(cv) => cv.match.color === "neutral" && cv.match.variant === "soft",
+			);
+
+			expect(neutralSoft?.css?.borderTopColor).toBe("@color.gray-200");
+		});
+	});
+
+	describe("config overrides", () => {
+		it("should allow overriding base styles", () => {
+			const s = createInstance();
+			const recipe = useDropdownDividerRecipe(s, {
+				base: { marginTop: "@0.5" },
+			});
+
+			expect(recipe.base!.marginTop).toBe("@0.5");
+			expect(recipe.base!.marginBottom).toBe("@0.25");
+		});
+	});
+
+	describe("filter", () => {
+		it("should filter color variants", () => {
+			const s = createInstance();
+			const recipe = useDropdownDividerRecipe(s, {
+				filter: { color: ["neutral"] },
+			});
+
+			expect(Object.keys(recipe.variants!.color)).toEqual(["neutral"]);
+		});
+
+		it("should prune compound variants when filtering colors", () => {
+			const s = createInstance();
+			const recipe = useDropdownDividerRecipe(s, {
+				filter: { color: ["neutral"] },
+			});
+
+			expect(
+				recipe.compoundVariants!.every((cv) => cv.match.color === "neutral"),
+			).toBe(true);
+			expect(recipe.compoundVariants).toHaveLength(3);
+		});
+
+		it("should adjust default variants when filtered out", () => {
+			const s = createInstance();
+			const recipe = useDropdownDividerRecipe(s, {
+				filter: { color: ["light"] },
+			});
+
+			expect(recipe.defaultVariants?.color).toBeUndefined();
+			expect(recipe.defaultVariants?.variant).toBe("solid");
+		});
+	});
+});

--- a/theme/src/recipes/dropdown-menu/useDropdownDividerRecipe.ts
+++ b/theme/src/recipes/dropdown-menu/useDropdownDividerRecipe.ts
@@ -1,0 +1,119 @@
+import { createUseRecipe } from "../../utils/createUseRecipe";
+
+/**
+ * Dropdown divider recipe for visual separation between menu items.
+ * Supports color (light, dark, neutral) and variant axes.
+ */
+export const useDropdownDividerRecipe = createUseRecipe("dropdown-divider", {
+	base: {
+		borderTopWidth: "@border-width.thin",
+		borderTopStyle: "@border-style.solid",
+		borderTopColor: "transparent",
+		marginTop: "@0.25",
+		marginBottom: "@0.25",
+	},
+	variants: {
+		color: {
+			light: {},
+			dark: {},
+			neutral: {},
+		},
+		variant: {
+			solid: {},
+			soft: {},
+			subtle: {},
+		},
+	},
+	compoundVariants: [
+		// Light color (fixed across themes)
+		{
+			match: { color: "light" as const, variant: "solid" as const },
+			css: {
+				borderTopColor: "@color.gray-200",
+				"&:dark": {
+					borderTopColor: "@color.gray-200",
+				},
+			},
+		},
+		{
+			match: { color: "light" as const, variant: "soft" as const },
+			css: {
+				borderTopColor: "@color.gray-200",
+				"&:dark": {
+					borderTopColor: "@color.gray-200",
+				},
+			},
+		},
+		{
+			match: { color: "light" as const, variant: "subtle" as const },
+			css: {
+				borderTopColor: "@color.gray-200",
+				"&:dark": {
+					borderTopColor: "@color.gray-200",
+				},
+			},
+		},
+
+		// Dark color (fixed across themes)
+		{
+			match: { color: "dark" as const, variant: "solid" as const },
+			css: {
+				borderTopColor: "@color.gray-700",
+				"&:dark": {
+					borderTopColor: "@color.gray-700",
+				},
+			},
+		},
+		{
+			match: { color: "dark" as const, variant: "soft" as const },
+			css: {
+				borderTopColor: "@color.gray-700",
+				"&:dark": {
+					borderTopColor: "@color.gray-700",
+				},
+			},
+		},
+		{
+			match: { color: "dark" as const, variant: "subtle" as const },
+			css: {
+				borderTopColor: "@color.gray-700",
+				"&:dark": {
+					borderTopColor: "@color.gray-700",
+				},
+			},
+		},
+
+		// Neutral color (adaptive: light in light mode, dark in dark mode)
+		{
+			match: { color: "neutral" as const, variant: "solid" as const },
+			css: {
+				borderTopColor: "@color.gray-200",
+				"&:dark": {
+					borderTopColor: "@color.gray-700",
+				},
+			},
+		},
+		{
+			match: { color: "neutral" as const, variant: "soft" as const },
+			css: {
+				borderTopColor: "@color.gray-200",
+				"&:dark": {
+					borderTopColor: "@color.gray-700",
+				},
+			},
+		},
+		{
+			match: { color: "neutral" as const, variant: "subtle" as const },
+			css: {
+				borderTopColor: "@color.gray-200",
+				"&:dark": {
+					borderTopColor: "@color.gray-700",
+				},
+			},
+		},
+	],
+	defaultVariants: {
+		color: "neutral",
+		variant: "solid",
+	},
+});

--- a/theme/src/recipes/dropdown-menu/useDropdownItemRecipe.test.ts
+++ b/theme/src/recipes/dropdown-menu/useDropdownItemRecipe.test.ts
@@ -1,0 +1,383 @@
+import { styleframe } from "@styleframe/core";
+import { useDarkModifier } from "../../modifiers/useMediaPreferenceModifiers";
+import {
+	useHoverModifier,
+	useFocusModifier,
+	useFocusVisibleModifier,
+	useActiveModifier,
+} from "../../modifiers/usePseudoStateModifiers";
+import { useDisabledModifier } from "../../modifiers/useFormStateModifiers";
+import { useDropdownItemRecipe } from "./index";
+
+function createInstance() {
+	const s = styleframe();
+	for (const name of [
+		"display",
+		"alignItems",
+		"gap",
+		"cursor",
+		"background",
+		"color",
+		"fontWeight",
+		"fontSize",
+		"lineHeight",
+		"textDecoration",
+		"transitionProperty",
+		"transitionTimingFunction",
+		"transitionDuration",
+		"outline",
+		"outlineWidth",
+		"outlineStyle",
+		"outlineColor",
+		"outlineOffset",
+		"opacity",
+		"pointerEvents",
+		"paddingTop",
+		"paddingBottom",
+		"paddingLeft",
+		"paddingRight",
+		"textUnderlineOffset",
+	]) {
+		s.utility(name, ({ value }) => ({ [name]: value }));
+	}
+	useDarkModifier(s);
+	useHoverModifier(s);
+	useFocusModifier(s);
+	useFocusVisibleModifier(s);
+	useActiveModifier(s);
+	useDisabledModifier(s);
+	return s;
+}
+
+describe("useDropdownItemRecipe", () => {
+	it("should create a recipe with correct metadata", () => {
+		const s = createInstance();
+		const recipe = useDropdownItemRecipe(s);
+
+		expect(recipe.type).toBe("recipe");
+		expect(recipe.name).toBe("dropdown-item");
+	});
+
+	it("should have correct base styles", () => {
+		const s = createInstance();
+		const recipe = useDropdownItemRecipe(s);
+
+		expect(recipe.base).toEqual({
+			display: "flex",
+			alignItems: "center",
+			gap: "@0.5",
+			cursor: "pointer",
+			background: "transparent",
+			fontWeight: "@font-weight.normal",
+			lineHeight: "@line-height.normal",
+			textDecoration: "none",
+			transitionProperty: "color, background-color",
+			transitionTimingFunction: "@easing.ease-in-out",
+			transitionDuration: "150ms",
+			outline: "none",
+			"&:hover": {
+				textDecoration: "none",
+			},
+			"&:focus": {
+				textDecoration: "none",
+			},
+			"&:focus-visible": {
+				outlineWidth: "2px",
+				outlineStyle: "solid",
+				outlineColor: "@color.primary",
+				outlineOffset: "-2px",
+			},
+			"&:disabled": {
+				cursor: "not-allowed",
+				opacity: "0.5",
+				pointerEvents: "none",
+			},
+		});
+	});
+
+	describe("variants", () => {
+		it("should have all color variants", () => {
+			const s = createInstance();
+			const recipe = useDropdownItemRecipe(s);
+
+			expect(Object.keys(recipe.variants!.color)).toEqual([
+				"light",
+				"dark",
+				"neutral",
+			]);
+		});
+
+		it("should have all style variants", () => {
+			const s = createInstance();
+			const recipe = useDropdownItemRecipe(s);
+
+			expect(Object.keys(recipe.variants!.variant)).toEqual([
+				"solid",
+				"soft",
+				"subtle",
+			]);
+		});
+
+		it("should have size variants with correct styles", () => {
+			const s = createInstance();
+			const recipe = useDropdownItemRecipe(s);
+
+			expect(recipe.variants!.size).toEqual({
+				sm: {
+					fontSize: "@font-size.xs",
+					paddingTop: "@0.25",
+					paddingBottom: "@0.25",
+					paddingLeft: "@0.5",
+					paddingRight: "@0.5",
+					gap: "@0.375",
+				},
+				md: {
+					fontSize: "@font-size.sm",
+					paddingTop: "@0.375",
+					paddingBottom: "@0.375",
+					paddingLeft: "@0.75",
+					paddingRight: "@0.75",
+					gap: "@0.5",
+				},
+				lg: {
+					fontSize: "@font-size.md",
+					paddingTop: "@0.5",
+					paddingBottom: "@0.5",
+					paddingLeft: "@1",
+					paddingRight: "@1",
+					gap: "@0.75",
+				},
+			});
+		});
+
+		it("should have active variant axis", () => {
+			const s = createInstance();
+			const recipe = useDropdownItemRecipe(s);
+
+			expect(recipe.variants!.active).toEqual({
+				true: { fontWeight: "@font-weight.semibold" },
+				false: {},
+			});
+		});
+
+		it("should have disabled variant axis", () => {
+			const s = createInstance();
+			const recipe = useDropdownItemRecipe(s);
+
+			expect(recipe.variants!.disabled).toEqual({
+				true: {
+					cursor: "not-allowed",
+					opacity: "0.5",
+					pointerEvents: "none",
+				},
+				false: {},
+			});
+		});
+	});
+
+	it("should have correct default variants", () => {
+		const s = createInstance();
+		const recipe = useDropdownItemRecipe(s);
+
+		expect(recipe.defaultVariants).toEqual({
+			color: "neutral",
+			variant: "solid",
+			size: "md",
+			active: "false",
+			disabled: "false",
+		});
+	});
+
+	describe("compound variants", () => {
+		it("should have 9 compound variants total", () => {
+			const s = createInstance();
+			const recipe = useDropdownItemRecipe(s);
+
+			// 3 colors × 3 variants = 9
+			expect(recipe.compoundVariants).toHaveLength(9);
+		});
+
+		it("should have correct neutral solid compound variant", () => {
+			const s = createInstance();
+			const recipe = useDropdownItemRecipe(s);
+
+			const neutralSolid = recipe.compoundVariants!.find(
+				(cv) => cv.match.color === "neutral" && cv.match.variant === "solid",
+			);
+
+			expect(neutralSolid).toEqual({
+				match: { color: "neutral", variant: "solid" },
+				css: {
+					color: "@color.text",
+					"&:hover": {
+						color: "@color.text",
+						background: "@color.gray-100",
+					},
+					"&:focus": {
+						color: "@color.text",
+						background: "@color.gray-100",
+					},
+					"&:active": {
+						background: "@color.gray-200",
+					},
+					"&:dark": {
+						color: "@color.gray-200",
+					},
+					"&:dark:hover": {
+						color: "@color.gray-200",
+						background: "@color.gray-800",
+					},
+					"&:dark:focus": {
+						color: "@color.gray-200",
+						background: "@color.gray-800",
+					},
+					"&:dark:active": {
+						background: "@color.gray-750",
+					},
+				},
+			});
+		});
+
+		it("should have correct light solid compound variant", () => {
+			const s = createInstance();
+			const recipe = useDropdownItemRecipe(s);
+
+			const lightSolid = recipe.compoundVariants!.find(
+				(cv) => cv.match.color === "light" && cv.match.variant === "solid",
+			);
+
+			expect(lightSolid).toEqual({
+				match: { color: "light", variant: "solid" },
+				css: {
+					color: "@color.text",
+					"&:hover": {
+						color: "@color.text",
+						background: "@color.gray-100",
+					},
+					"&:focus": {
+						color: "@color.text",
+						background: "@color.gray-100",
+					},
+					"&:active": {
+						background: "@color.gray-200",
+					},
+					"&:dark": {
+						color: "@color.text-inverted",
+					},
+					"&:dark:hover": {
+						color: "@color.text-inverted",
+						background: "@color.gray-100",
+					},
+					"&:dark:focus": {
+						color: "@color.text-inverted",
+						background: "@color.gray-100",
+					},
+					"&:dark:active": {
+						background: "@color.gray-200",
+					},
+				},
+			});
+		});
+
+		it("should have correct dark solid compound variant", () => {
+			const s = createInstance();
+			const recipe = useDropdownItemRecipe(s);
+
+			const darkSolid = recipe.compoundVariants!.find(
+				(cv) => cv.match.color === "dark" && cv.match.variant === "solid",
+			);
+
+			expect(darkSolid).toEqual({
+				match: { color: "dark", variant: "solid" },
+				css: {
+					color: "@color.gray-200",
+					"&:hover": {
+						color: "@color.gray-200",
+						background: "@color.gray-800",
+					},
+					"&:focus": {
+						color: "@color.gray-200",
+						background: "@color.gray-800",
+					},
+					"&:active": {
+						background: "@color.gray-750",
+					},
+					"&:dark": {
+						color: "@color.gray-200",
+					},
+					"&:dark:hover": {
+						color: "@color.gray-200",
+						background: "@color.gray-800",
+					},
+					"&:dark:focus": {
+						color: "@color.gray-200",
+						background: "@color.gray-800",
+					},
+					"&:dark:active": {
+						background: "@color.gray-750",
+					},
+				},
+			});
+		});
+	});
+
+	describe("config overrides", () => {
+		it("should allow overriding base styles", () => {
+			const s = createInstance();
+			const recipe = useDropdownItemRecipe(s, {
+				base: { display: "inline-flex" },
+			});
+
+			expect(recipe.base!.display).toBe("inline-flex");
+			expect(recipe.base!.alignItems).toBe("center");
+		});
+	});
+
+	describe("filter", () => {
+		it("should filter color variants", () => {
+			const s = createInstance();
+			const recipe = useDropdownItemRecipe(s, {
+				filter: { color: ["neutral"] },
+			});
+
+			expect(Object.keys(recipe.variants!.color)).toEqual(["neutral"]);
+		});
+
+		it("should prune compound variants when filtering colors", () => {
+			const s = createInstance();
+			const recipe = useDropdownItemRecipe(s, {
+				filter: { color: ["neutral"] },
+			});
+
+			expect(
+				recipe.compoundVariants!.every((cv) => cv.match.color === "neutral"),
+			).toBe(true);
+			expect(recipe.compoundVariants).toHaveLength(3);
+		});
+
+		it("should filter variant axis", () => {
+			const s = createInstance();
+			const recipe = useDropdownItemRecipe(s, {
+				filter: { variant: ["solid", "soft"] },
+			});
+
+			expect(Object.keys(recipe.variants!.variant)).toEqual(["solid", "soft"]);
+			expect(
+				recipe.compoundVariants!.every(
+					(cv) => cv.match.variant === "solid" || cv.match.variant === "soft",
+				),
+			).toBe(true);
+		});
+
+		it("should adjust default variants when filtered out", () => {
+			const s = createInstance();
+			const recipe = useDropdownItemRecipe(s, {
+				filter: { color: ["light"] },
+			});
+
+			expect(recipe.defaultVariants?.color).toBeUndefined();
+			expect(recipe.defaultVariants?.variant).toBe("solid");
+			expect(recipe.defaultVariants?.size).toBe("md");
+		});
+	});
+});

--- a/theme/src/recipes/dropdown-menu/useDropdownItemRecipe.ts
+++ b/theme/src/recipes/dropdown-menu/useDropdownItemRecipe.ts
@@ -1,0 +1,360 @@
+import { createUseRecipe } from "../../utils/createUseRecipe";
+
+/**
+ * Dropdown item recipe for interactive menu items.
+ * Supports color (light, dark, neutral), variant, size, active, and disabled axes.
+ */
+export const useDropdownItemRecipe = createUseRecipe("dropdown-item", {
+	base: {
+		display: "flex",
+		alignItems: "center",
+		gap: "@0.5",
+		cursor: "pointer",
+		background: "transparent",
+		fontWeight: "@font-weight.normal",
+		lineHeight: "@line-height.normal",
+		textDecoration: "none",
+		transitionProperty: "color, background-color",
+		transitionTimingFunction: "@easing.ease-in-out",
+		transitionDuration: "150ms",
+		outline: "none",
+		"&:hover": {
+			textDecoration: "none",
+		},
+		"&:focus": {
+			textDecoration: "none",
+		},
+		"&:focus-visible": {
+			outlineWidth: "2px",
+			outlineStyle: "solid",
+			outlineColor: "@color.primary",
+			outlineOffset: "-2px",
+		},
+		"&:disabled": {
+			cursor: "not-allowed",
+			opacity: "0.5",
+			pointerEvents: "none",
+		},
+	},
+	variants: {
+		color: {
+			light: {},
+			dark: {},
+			neutral: {},
+		},
+		variant: {
+			solid: {},
+			soft: {},
+			subtle: {},
+		},
+		size: {
+			sm: {
+				fontSize: "@font-size.xs",
+				paddingTop: "@0.25",
+				paddingBottom: "@0.25",
+				paddingLeft: "@0.5",
+				paddingRight: "@0.5",
+				gap: "@0.375",
+			},
+			md: {
+				fontSize: "@font-size.sm",
+				paddingTop: "@0.375",
+				paddingBottom: "@0.375",
+				paddingLeft: "@0.75",
+				paddingRight: "@0.75",
+				gap: "@0.5",
+			},
+			lg: {
+				fontSize: "@font-size.md",
+				paddingTop: "@0.5",
+				paddingBottom: "@0.5",
+				paddingLeft: "@1",
+				paddingRight: "@1",
+				gap: "@0.75",
+			},
+		},
+		active: {
+			true: {
+				fontWeight: "@font-weight.semibold",
+			},
+			false: {},
+		},
+		disabled: {
+			true: {
+				cursor: "not-allowed",
+				opacity: "0.5",
+				pointerEvents: "none",
+			},
+			false: {},
+		},
+	},
+	compoundVariants: [
+		// Light color (fixed across themes)
+		{
+			match: { color: "light" as const, variant: "solid" as const },
+			css: {
+				color: "@color.text",
+				"&:hover": {
+					color: "@color.text",
+					background: "@color.gray-100",
+				},
+				"&:focus": {
+					color: "@color.text",
+					background: "@color.gray-100",
+				},
+				"&:active": {
+					background: "@color.gray-200",
+				},
+				"&:dark": {
+					color: "@color.text-inverted",
+				},
+				"&:dark:hover": {
+					color: "@color.text-inverted",
+					background: "@color.gray-100",
+				},
+				"&:dark:focus": {
+					color: "@color.text-inverted",
+					background: "@color.gray-100",
+				},
+				"&:dark:active": {
+					background: "@color.gray-200",
+				},
+			},
+		},
+		{
+			match: { color: "light" as const, variant: "soft" as const },
+			css: {
+				color: "@color.gray-700",
+				"&:hover": {
+					background: "@color.gray-200",
+				},
+				"&:focus": {
+					background: "@color.gray-200",
+				},
+				"&:active": {
+					background: "@color.gray-300",
+				},
+				"&:dark": {
+					color: "@color.gray-700",
+				},
+				"&:dark:hover": {
+					background: "@color.gray-200",
+				},
+				"&:dark:focus": {
+					background: "@color.gray-200",
+				},
+				"&:dark:active": {
+					background: "@color.gray-300",
+				},
+			},
+		},
+		{
+			match: { color: "light" as const, variant: "subtle" as const },
+			css: {
+				color: "@color.gray-700",
+				"&:hover": {
+					background: "@color.gray-200",
+				},
+				"&:focus": {
+					background: "@color.gray-200",
+				},
+				"&:active": {
+					background: "@color.gray-300",
+				},
+				"&:dark": {
+					color: "@color.gray-700",
+				},
+				"&:dark:hover": {
+					background: "@color.gray-200",
+				},
+				"&:dark:focus": {
+					background: "@color.gray-200",
+				},
+				"&:dark:active": {
+					background: "@color.gray-300",
+				},
+			},
+		},
+
+		// Dark color (fixed across themes)
+		{
+			match: { color: "dark" as const, variant: "solid" as const },
+			css: {
+				color: "@color.gray-200",
+				"&:hover": {
+					color: "@color.gray-200",
+					background: "@color.gray-800",
+				},
+				"&:focus": {
+					color: "@color.gray-200",
+					background: "@color.gray-800",
+				},
+				"&:active": {
+					background: "@color.gray-750",
+				},
+				"&:dark": {
+					color: "@color.gray-200",
+				},
+				"&:dark:hover": {
+					color: "@color.gray-200",
+					background: "@color.gray-800",
+				},
+				"&:dark:focus": {
+					color: "@color.gray-200",
+					background: "@color.gray-800",
+				},
+				"&:dark:active": {
+					background: "@color.gray-750",
+				},
+			},
+		},
+		{
+			match: { color: "dark" as const, variant: "soft" as const },
+			css: {
+				color: "@color.gray-300",
+				"&:hover": {
+					background: "@color.gray-700",
+				},
+				"&:focus": {
+					background: "@color.gray-700",
+				},
+				"&:active": {
+					background: "@color.gray-650",
+				},
+				"&:dark": {
+					color: "@color.gray-300",
+				},
+				"&:dark:hover": {
+					background: "@color.gray-700",
+				},
+				"&:dark:focus": {
+					background: "@color.gray-700",
+				},
+				"&:dark:active": {
+					background: "@color.gray-650",
+				},
+			},
+		},
+		{
+			match: { color: "dark" as const, variant: "subtle" as const },
+			css: {
+				color: "@color.gray-300",
+				"&:hover": {
+					background: "@color.gray-700",
+				},
+				"&:focus": {
+					background: "@color.gray-700",
+				},
+				"&:active": {
+					background: "@color.gray-650",
+				},
+				"&:dark": {
+					color: "@color.gray-300",
+				},
+				"&:dark:hover": {
+					background: "@color.gray-700",
+				},
+				"&:dark:focus": {
+					background: "@color.gray-700",
+				},
+				"&:dark:active": {
+					background: "@color.gray-650",
+				},
+			},
+		},
+
+		// Neutral color (adaptive: light in light mode, dark in dark mode)
+		{
+			match: { color: "neutral" as const, variant: "solid" as const },
+			css: {
+				color: "@color.text",
+				"&:hover": {
+					color: "@color.text",
+					background: "@color.gray-100",
+				},
+				"&:focus": {
+					color: "@color.text",
+					background: "@color.gray-100",
+				},
+				"&:active": {
+					background: "@color.gray-200",
+				},
+				"&:dark": {
+					color: "@color.gray-200",
+				},
+				"&:dark:hover": {
+					color: "@color.gray-200",
+					background: "@color.gray-800",
+				},
+				"&:dark:focus": {
+					color: "@color.gray-200",
+					background: "@color.gray-800",
+				},
+				"&:dark:active": {
+					background: "@color.gray-750",
+				},
+			},
+		},
+		{
+			match: { color: "neutral" as const, variant: "soft" as const },
+			css: {
+				color: "@color.gray-700",
+				"&:hover": {
+					background: "@color.gray-200",
+				},
+				"&:focus": {
+					background: "@color.gray-200",
+				},
+				"&:active": {
+					background: "@color.gray-300",
+				},
+				"&:dark": {
+					color: "@color.gray-300",
+				},
+				"&:dark:hover": {
+					background: "@color.gray-700",
+				},
+				"&:dark:focus": {
+					background: "@color.gray-700",
+				},
+				"&:dark:active": {
+					background: "@color.gray-650",
+				},
+			},
+		},
+		{
+			match: { color: "neutral" as const, variant: "subtle" as const },
+			css: {
+				color: "@color.gray-700",
+				"&:hover": {
+					background: "@color.gray-200",
+				},
+				"&:focus": {
+					background: "@color.gray-200",
+				},
+				"&:active": {
+					background: "@color.gray-300",
+				},
+				"&:dark": {
+					color: "@color.gray-300",
+				},
+				"&:dark:hover": {
+					background: "@color.gray-700",
+				},
+				"&:dark:focus": {
+					background: "@color.gray-700",
+				},
+				"&:dark:active": {
+					background: "@color.gray-650",
+				},
+			},
+		},
+	],
+	defaultVariants: {
+		color: "neutral",
+		variant: "solid",
+		size: "md",
+		active: "false",
+		disabled: "false",
+	},
+});

--- a/theme/src/recipes/dropdown-menu/useDropdownMenuRecipe.test.ts
+++ b/theme/src/recipes/dropdown-menu/useDropdownMenuRecipe.test.ts
@@ -1,0 +1,277 @@
+import { styleframe } from "@styleframe/core";
+import { useDarkModifier } from "../../modifiers/useMediaPreferenceModifiers";
+import { useDropdownMenuRecipe } from "./index";
+
+function createInstance() {
+	const s = styleframe();
+	for (const name of [
+		"display",
+		"flexDirection",
+		"position",
+		"borderWidth",
+		"borderStyle",
+		"borderColor",
+		"borderRadius",
+		"overflow",
+		"lineHeight",
+		"boxShadow",
+		"paddingTop",
+		"paddingBottom",
+		"background",
+		"color",
+	]) {
+		s.utility(name, ({ value }) => ({ [name]: value }));
+	}
+	useDarkModifier(s);
+	return s;
+}
+
+describe("useDropdownMenuRecipe", () => {
+	it("should create a recipe with correct metadata", () => {
+		const s = createInstance();
+		const recipe = useDropdownMenuRecipe(s);
+
+		expect(recipe.type).toBe("recipe");
+		expect(recipe.name).toBe("dropdown-menu");
+	});
+
+	it("should have correct base styles", () => {
+		const s = createInstance();
+		const recipe = useDropdownMenuRecipe(s);
+
+		expect(recipe.base).toEqual({
+			display: "flex",
+			flexDirection: "column",
+			position: "relative",
+			borderWidth: "@border-width.thin",
+			borderStyle: "@border-style.solid",
+			borderColor: "transparent",
+			borderRadius: "@border-radius.md",
+			overflow: "hidden",
+			lineHeight: "@line-height.normal",
+			boxShadow: "@box-shadow.md",
+			paddingTop: "@0.25",
+			paddingBottom: "@0.25",
+		});
+	});
+
+	describe("variants", () => {
+		it("should have all color variants", () => {
+			const s = createInstance();
+			const recipe = useDropdownMenuRecipe(s);
+
+			expect(Object.keys(recipe.variants!.color)).toEqual([
+				"light",
+				"dark",
+				"neutral",
+			]);
+		});
+
+		it("should have all style variants", () => {
+			const s = createInstance();
+			const recipe = useDropdownMenuRecipe(s);
+
+			expect(Object.keys(recipe.variants!.variant)).toEqual([
+				"solid",
+				"soft",
+				"subtle",
+			]);
+		});
+
+		it("should have size variants with correct styles", () => {
+			const s = createInstance();
+			const recipe = useDropdownMenuRecipe(s);
+
+			expect(recipe.variants!.size).toEqual({
+				sm: {
+					borderRadius: "@border-radius.sm",
+					paddingTop: "@0.125",
+					paddingBottom: "@0.125",
+				},
+				md: {
+					borderRadius: "@border-radius.md",
+					paddingTop: "@0.25",
+					paddingBottom: "@0.25",
+				},
+				lg: {
+					borderRadius: "@border-radius.lg",
+					paddingTop: "@0.375",
+					paddingBottom: "@0.375",
+				},
+			});
+		});
+	});
+
+	it("should have correct default variants", () => {
+		const s = createInstance();
+		const recipe = useDropdownMenuRecipe(s);
+
+		expect(recipe.defaultVariants).toEqual({
+			color: "neutral",
+			variant: "solid",
+			size: "md",
+		});
+	});
+
+	describe("compound variants", () => {
+		it("should have 9 compound variants total", () => {
+			const s = createInstance();
+			const recipe = useDropdownMenuRecipe(s);
+
+			// 3 colors × 3 variants = 9
+			expect(recipe.compoundVariants).toHaveLength(9);
+		});
+
+		it("should have correct light solid compound variant", () => {
+			const s = createInstance();
+			const recipe = useDropdownMenuRecipe(s);
+
+			const lightSolid = recipe.compoundVariants!.find(
+				(cv) => cv.match.color === "light" && cv.match.variant === "solid",
+			);
+
+			expect(lightSolid).toEqual({
+				match: { color: "light", variant: "solid" },
+				css: {
+					background: "@color.white",
+					color: "@color.text",
+					borderColor: "@color.gray-200",
+					"&:dark": {
+						background: "@color.white",
+						color: "@color.text-inverted",
+						borderColor: "@color.gray-200",
+					},
+				},
+			});
+		});
+
+		it("should have correct dark solid compound variant", () => {
+			const s = createInstance();
+			const recipe = useDropdownMenuRecipe(s);
+
+			const darkSolid = recipe.compoundVariants!.find(
+				(cv) => cv.match.color === "dark" && cv.match.variant === "solid",
+			);
+
+			expect(darkSolid).toEqual({
+				match: { color: "dark", variant: "solid" },
+				css: {
+					background: "@color.gray-900",
+					color: "@color.text-inverted",
+					borderColor: "@color.gray-700",
+					"&:dark": {
+						background: "@color.gray-900",
+						color: "@color.text",
+						borderColor: "@color.gray-700",
+					},
+				},
+			});
+		});
+
+		it("should have correct neutral solid compound variant with adaptive dark mode", () => {
+			const s = createInstance();
+			const recipe = useDropdownMenuRecipe(s);
+
+			const neutralSolid = recipe.compoundVariants!.find(
+				(cv) => cv.match.color === "neutral" && cv.match.variant === "solid",
+			);
+
+			expect(neutralSolid).toEqual({
+				match: { color: "neutral", variant: "solid" },
+				css: {
+					background: "@color.white",
+					color: "@color.text",
+					borderColor: "@color.gray-200",
+					"&:dark": {
+						background: "@color.gray-900",
+						color: "@color.white",
+						borderColor: "@color.gray-700",
+					},
+				},
+			});
+		});
+
+		it("should have correct neutral subtle compound variant", () => {
+			const s = createInstance();
+			const recipe = useDropdownMenuRecipe(s);
+
+			const neutralSubtle = recipe.compoundVariants!.find(
+				(cv) => cv.match.color === "neutral" && cv.match.variant === "subtle",
+			);
+
+			expect(neutralSubtle).toEqual({
+				match: { color: "neutral", variant: "subtle" },
+				css: {
+					background: "@color.gray-100",
+					color: "@color.gray-700",
+					borderColor: "@color.gray-200",
+					"&:dark": {
+						background: "@color.gray-800",
+						color: "@color.gray-300",
+						borderColor: "@color.gray-700",
+					},
+				},
+			});
+		});
+	});
+
+	describe("config overrides", () => {
+		it("should allow overriding base styles", () => {
+			const s = createInstance();
+			const recipe = useDropdownMenuRecipe(s, {
+				base: { display: "inline-flex" },
+			});
+
+			expect(recipe.base!.display).toBe("inline-flex");
+			expect(recipe.base!.flexDirection).toBe("column");
+		});
+	});
+
+	describe("filter", () => {
+		it("should filter color variants", () => {
+			const s = createInstance();
+			const recipe = useDropdownMenuRecipe(s, {
+				filter: { color: ["neutral"] },
+			});
+
+			expect(Object.keys(recipe.variants!.color)).toEqual(["neutral"]);
+		});
+
+		it("should prune compound variants when filtering colors", () => {
+			const s = createInstance();
+			const recipe = useDropdownMenuRecipe(s, {
+				filter: { color: ["neutral"] },
+			});
+
+			expect(
+				recipe.compoundVariants!.every((cv) => cv.match.color === "neutral"),
+			).toBe(true);
+			expect(recipe.compoundVariants).toHaveLength(3);
+		});
+
+		it("should filter variant axis", () => {
+			const s = createInstance();
+			const recipe = useDropdownMenuRecipe(s, {
+				filter: { variant: ["solid", "soft"] },
+			});
+
+			expect(Object.keys(recipe.variants!.variant)).toEqual(["solid", "soft"]);
+			expect(
+				recipe.compoundVariants!.every(
+					(cv) => cv.match.variant === "solid" || cv.match.variant === "soft",
+				),
+			).toBe(true);
+		});
+
+		it("should adjust default variants when filtered out", () => {
+			const s = createInstance();
+			const recipe = useDropdownMenuRecipe(s, {
+				filter: { color: ["light"] },
+			});
+
+			expect(recipe.defaultVariants?.color).toBeUndefined();
+			expect(recipe.defaultVariants?.variant).toBe("solid");
+			expect(recipe.defaultVariants?.size).toBe("md");
+		});
+	});
+});

--- a/theme/src/recipes/dropdown-menu/useDropdownMenuRecipe.ts
+++ b/theme/src/recipes/dropdown-menu/useDropdownMenuRecipe.ts
@@ -1,0 +1,174 @@
+import { createUseRecipe } from "../../utils/createUseRecipe";
+
+/**
+ * Dropdown menu container recipe.
+ * Supports color (light, dark, neutral), variant, and size axes.
+ */
+export const useDropdownMenuRecipe = createUseRecipe("dropdown-menu", {
+	base: {
+		display: "flex",
+		flexDirection: "column",
+		position: "relative",
+		borderWidth: "@border-width.thin",
+		borderStyle: "@border-style.solid",
+		borderColor: "transparent",
+		borderRadius: "@border-radius.md",
+		overflow: "hidden",
+		lineHeight: "@line-height.normal",
+		boxShadow: "@box-shadow.md",
+		paddingTop: "@0.25",
+		paddingBottom: "@0.25",
+	},
+	variants: {
+		color: {
+			light: {},
+			dark: {},
+			neutral: {},
+		},
+		variant: {
+			solid: {},
+			soft: {},
+			subtle: {},
+		},
+		size: {
+			sm: {
+				borderRadius: "@border-radius.sm",
+				paddingTop: "@0.125",
+				paddingBottom: "@0.125",
+			},
+			md: {
+				borderRadius: "@border-radius.md",
+				paddingTop: "@0.25",
+				paddingBottom: "@0.25",
+			},
+			lg: {
+				borderRadius: "@border-radius.lg",
+				paddingTop: "@0.375",
+				paddingBottom: "@0.375",
+			},
+		},
+	},
+	compoundVariants: [
+		// Light color (fixed across themes)
+		{
+			match: { color: "light" as const, variant: "solid" as const },
+			css: {
+				background: "@color.white",
+				color: "@color.text",
+				borderColor: "@color.gray-200",
+				"&:dark": {
+					background: "@color.white",
+					color: "@color.text-inverted",
+					borderColor: "@color.gray-200",
+				},
+			},
+		},
+		{
+			match: { color: "light" as const, variant: "soft" as const },
+			css: {
+				background: "@color.gray-100",
+				color: "@color.gray-700",
+				"&:dark": {
+					background: "@color.gray-100",
+					color: "@color.gray-700",
+				},
+			},
+		},
+		{
+			match: { color: "light" as const, variant: "subtle" as const },
+			css: {
+				background: "@color.gray-100",
+				color: "@color.gray-700",
+				borderColor: "@color.gray-200",
+				"&:dark": {
+					background: "@color.gray-100",
+					color: "@color.gray-700",
+					borderColor: "@color.gray-200",
+				},
+			},
+		},
+
+		// Dark color (fixed across themes)
+		{
+			match: { color: "dark" as const, variant: "solid" as const },
+			css: {
+				background: "@color.gray-900",
+				color: "@color.text-inverted",
+				borderColor: "@color.gray-700",
+				"&:dark": {
+					background: "@color.gray-900",
+					color: "@color.text",
+					borderColor: "@color.gray-700",
+				},
+			},
+		},
+		{
+			match: { color: "dark" as const, variant: "soft" as const },
+			css: {
+				background: "@color.gray-800",
+				color: "@color.gray-300",
+				"&:dark": {
+					background: "@color.gray-800",
+					color: "@color.gray-300",
+				},
+			},
+		},
+		{
+			match: { color: "dark" as const, variant: "subtle" as const },
+			css: {
+				background: "@color.gray-800",
+				color: "@color.gray-300",
+				borderColor: "@color.gray-700",
+				"&:dark": {
+					background: "@color.gray-800",
+					color: "@color.gray-300",
+					borderColor: "@color.gray-700",
+				},
+			},
+		},
+
+		// Neutral color (adaptive: light in light mode, dark in dark mode)
+		{
+			match: { color: "neutral" as const, variant: "solid" as const },
+			css: {
+				background: "@color.white",
+				color: "@color.text",
+				borderColor: "@color.gray-200",
+				"&:dark": {
+					background: "@color.gray-900",
+					color: "@color.white",
+					borderColor: "@color.gray-700",
+				},
+			},
+		},
+		{
+			match: { color: "neutral" as const, variant: "soft" as const },
+			css: {
+				background: "@color.gray-100",
+				color: "@color.gray-700",
+				"&:dark": {
+					background: "@color.gray-800",
+					color: "@color.gray-300",
+				},
+			},
+		},
+		{
+			match: { color: "neutral" as const, variant: "subtle" as const },
+			css: {
+				background: "@color.gray-100",
+				color: "@color.gray-700",
+				borderColor: "@color.gray-200",
+				"&:dark": {
+					background: "@color.gray-800",
+					color: "@color.gray-300",
+					borderColor: "@color.gray-700",
+				},
+			},
+		},
+	],
+	defaultVariants: {
+		color: "neutral",
+		variant: "solid",
+		size: "md",
+	},
+});

--- a/theme/src/recipes/index.ts
+++ b/theme/src/recipes/index.ts
@@ -4,6 +4,7 @@ export * from "./button-group";
 export * from "./callout";
 export * from "./card";
 export * from "./chip";
+export * from "./dropdown-menu";
 export * from "./spinner";
 export * from "./modal";
 export * from "./nav";


### PR DESCRIPTION
## Summary

- Adds `useDropdownMenuRecipe`, `useDropdownItemRecipe`, and `useDropdownDividerRecipe` — a multi-part recipe for dropdown action menus, modeled after the Popover recipe and inspired by Inkline's dropdown.
- Supports 3 colors (light/dark/neutral), 3 variants (solid/soft/subtle), 3 sizes (sm/md/lg), plus `active`/`disabled` boolean axes on items.
- Includes full test coverage, Storybook stories + preview grids, Vue components, and documentation at `/docs/components/composables/dropdown-menu`.

## Test plan

- [x] `pnpm typecheck` passes
- [x] Theme test suite passes (2193 tests)
- [ ] Verify stories render correctly in Storybook
- [ ] Verify docs page renders correctly