### PR TITLE
fix(docs): flatten grouped navigation in mobile hamburger menu

### DIFF
--- a/apps/docs/app/components/app/AppHeaderBody.vue
+++ b/apps/docs/app/components/app/AppHeaderBody.vue
@@ -1,7 +1,12 @@
 <script setup lang="ts">
 import type { ContentNavigationItem } from "@nuxt/content";
 
-const navigation = inject<Ref<ContentNavigationItem[]>>("navigation");
+const navigationMap =
+	inject<Ref<Record<string, ContentNavigationItem[]> | null>>("navigation");
+
+const navigation = computed<ContentNavigationItem[]>(() =>
+	navigationMap?.value ? Object.values(navigationMap.value).flat() : [],
+);
 </script>
 
 <template>


### PR DESCRIPTION
## Summary

- The mobile hamburger menu in `apps/docs` crashed on click with `props.navigation?.map is not a function`.
- `app.vue` provides `navigation` as `Record<section, ContentNavigationItem[]>`, but `AppHeaderBody.vue` passed it straight to `<UContentNavigation>`, which requires an Array.
- Flatten the grouped record locally (same `Object.values(...).flat()` pattern already used by `flatNavigation` for `<UContentSearch>`) and correct the inject type annotation.

## Test plan

- [x] Open `/docs/getting-started/introduction` at mobile viewport (390x844)
- [x] Click hamburger — slide-over opens, full nav renders across all sections (Getting Started, API Reference, Design Tokens, Components, Utilities, Modifiers), zero console errors
- [x] `pnpm typecheck` passes