### PR TITLE
feat(core): Track variable references in `root._usage.variables`

### DIFF
--- a/.changeset/track-variable-refs-usage.md
+++ b/.changeset/track-variable-refs-usage.md
@@ -1,0 +1,9 @@
+---
+"@styleframe/core": minor
+"styleframe": minor
+---
+
+Track variable references in `root._usage.variables` for future transpiler optimizations
+
+- Add `_usage: { variables: Set<string> }` to `Root` type and initialize in `createRoot()`
+- Record variable names whenever `ref()` is called or `@`-prefixed syntax is resolved

--- a/engine/core/src/tokens/ref.ts
+++ b/engine/core/src/tokens/ref.ts
@@ -19,6 +19,7 @@ export function createRefFunction(parent: Container, root: Root) {
 			fallback != null ? resolvePropertyValue(fallback) : fallback;
 
 		if (isVariable(variable)) {
+			root._usage.variables.add(variable.name);
 			return {
 				type: "reference",
 				name: variable.name,
@@ -33,6 +34,7 @@ export function createRefFunction(parent: Container, root: Root) {
 		}
 
 		// If a string name is passed, use it directly
+		root._usage.variables.add(variable);
 		return {
 			type: "reference",
 			name: variable,

--- a/engine/core/src/tokens/resolve.ts
+++ b/engine/core/src/tokens/resolve.ts
@@ -81,6 +81,7 @@ export function createPropertyValueResolver(parent: Container, root: Root) {
 		if (isKeyReferenceValue(value) && /^@[\w.-]+$/.test(value)) {
 			const name = value.slice(1);
 			validateReference(name, parent, root);
+			root._usage.variables.add(name);
 			return { type: "reference", name: name } as Reference;
 		}
 
@@ -88,6 +89,11 @@ export function createPropertyValueResolver(parent: Container, root: Root) {
 		const parts = parseAtReferences(value);
 		const hasReferences = parts.some((p) => isRef(p));
 		if (hasReferences) {
+			for (const part of parts) {
+				if (isRef(part)) {
+					root._usage.variables.add(part.name);
+				}
+			}
 			return { type: "css", value: parts } as CSS;
 		}
 

--- a/engine/core/src/tokens/root.test.ts
+++ b/engine/core/src/tokens/root.test.ts
@@ -25,6 +25,9 @@ describe("createRoot", () => {
 				type: "root",
 				id: expect.any(String),
 				_registry: expect.any(Map),
+				_usage: {
+					variables: expect.any(Set),
+				},
 				declarations: {},
 				utilities: [],
 				modifiers: [],

--- a/engine/core/src/tokens/root.ts
+++ b/engine/core/src/tokens/root.ts
@@ -13,6 +13,9 @@ export function createRoot(): Root {
 		children: [],
 		themes: [],
 		_registry: new Map(),
+		_usage: {
+			variables: new Set(),
+		},
 	};
 
 	root._registry.set(root.id, root);

--- a/engine/core/src/types/tokens.ts
+++ b/engine/core/src/types/tokens.ts
@@ -216,4 +216,7 @@ export type Root = {
 	children: ContainerChild[];
 	themes: Theme[];
 	_registry: Map<string, Container | Root | Theme>;
+	_usage: {
+		variables: Set<string>;
+	};
 };

--- a/engine/core/src/utils/merge.test.ts
+++ b/engine/core/src/utils/merge.test.ts
@@ -384,6 +384,7 @@ describe("mergeContainers", () => {
 					},
 				],
 				_registry: new Map(),
+				_usage: { variables: new Set() },
 			};
 			const b: Root = {
 				type: "root",
@@ -405,6 +406,7 @@ describe("mergeContainers", () => {
 					},
 				],
 				_registry: new Map(),
+				_usage: { variables: new Set() },
 			};
 
 			const result = mergeContainers(a, b);
@@ -437,6 +439,7 @@ describe("mergeContainers", () => {
 				children: [],
 				themes: [],
 				_registry: new Map(),
+				_usage: { variables: new Set() },
 			};
 			const b: Root = {
 				type: "root",
@@ -458,6 +461,7 @@ describe("mergeContainers", () => {
 				children: [],
 				themes: [],
 				_registry: new Map(),
+				_usage: { variables: new Set() },
 			};
 
 			const result = mergeContainers(a, b);
@@ -485,6 +489,7 @@ describe("mergeContainers", () => {
 				children: [],
 				themes: [],
 				_registry: new Map(),
+				_usage: { variables: new Set() },
 			};
 			const b: Root = {
 				type: "root",
@@ -503,6 +508,7 @@ describe("mergeContainers", () => {
 				children: [],
 				themes: [],
 				_registry: new Map(),
+				_usage: { variables: new Set() },
 			};
 
 			const result = mergeContainers(a, b);
@@ -530,6 +536,7 @@ describe("mergeContainers", () => {
 				children: [],
 				themes: [],
 				_registry: new Map(),
+				_usage: { variables: new Set() },
 			};
 			const b: Root = {
 				type: "root",
@@ -548,6 +555,7 @@ describe("mergeContainers", () => {
 				children: [],
 				themes: [],
 				_registry: new Map(),
+				_usage: { variables: new Set() },
 			};
 
 			const result = mergeContainers(a, b);
@@ -592,6 +600,7 @@ describe("mergeContainers", () => {
 				children: [],
 				themes: [],
 				_registry: new Map(),
+				_usage: { variables: new Set() },
 			};
 			const b: Root = {
 				type: "root",
@@ -604,6 +613,7 @@ describe("mergeContainers", () => {
 				children: [],
 				themes: [],
 				_registry: new Map(),
+				_usage: { variables: new Set() },
 			};
 
 			const result = mergeContainers(a, b);

--- a/engine/scanner/src/matcher.test.ts
+++ b/engine/scanner/src/matcher.test.ts
@@ -18,6 +18,7 @@ function createMockRoot(
 		type: "root",
 		id: "test-id",
 		_registry: new Map(),
+		_usage: { variables: new Set() },
 		declarations: {},
 		utilities,
 		modifiers,


### PR DESCRIPTION
Add a _usage.variables Set<string> to Root that records every variable name referenced via ref() or @-prefixed syntax, enabling future transpiler optimizations like tree-shaking unused variables.