### PR TITLE
feat(theme): add media recipe with figure, body, title parts

### DIFF
--- a/.changeset/add-media-recipe.md
+++ b/.changeset/add-media-recipe.md
@@ -1,0 +1,11 @@
+---
+"@styleframe/theme": minor
+"styleframe": minor
+---
+
+Add `Media` recipe — a layout-only multi-part recipe modeled on the Bootstrap/Inkline media object pattern for image-plus-content layouts (comments, posts, list items)
+
+- New recipes: `useMediaRecipe`, `useMediaFigureRecipe`, `useMediaBodyRecipe`, `useMediaTitleRecipe`
+- Root recipe exposes `orientation` (`horizontal`/`vertical`), `align` (`start`/`center`/`end`), and `size` (`sm`/`md`/`lg`) axes — no color or surface styling, so it composes inside Card, Callout, etc.
+- `useMediaBodyRecipe` sets `min-width: 0` to safely wrap long titles inside flex containers
+- Designed for nesting (parent Media → child Media inside `MediaBody`) for comment threads and reply chains

--- a/apps/docs/content/docs/04.components/02.composables/15.media.md
+++ b/apps/docs/content/docs/04.components/02.composables/15.media.md
@@ -1,0 +1,480 @@
+---
+title: Media
+description: A flexible layout primitive that places visual content alongside text content. Built for comments, social posts, list items, and any UI where a fixed-size visual sits next to flowing text.
+---
+
+## Overview
+
+The **Media** is a layout primitive used to align visual content (image, avatar, icon) with adjacent text content &mdash; the canonical "media object" pattern popularized by Bootstrap. It is composed of four recipe parts: `useMediaRecipe()` for the flex container, `useMediaFigureRecipe()` for the visual holder, `useMediaBodyRecipe()` for the text container, and `useMediaTitleRecipe()` for the heading. Each composable creates a fully configured [recipe](/docs/api/recipes) with its own variant axes &mdash; no color or surface styling, so the Media composes cleanly inside other containers like Card or Callout.
+
+The Media recipes integrate directly with the default [design tokens preset](/docs/theme/design-tokens/presets) and generate type-safe utility classes at build time with zero runtime CSS.
+
+## Why use the Media recipe?
+
+The Media recipe helps you:
+
+- **Ship the canonical media object pattern**: Get the image-plus-text layout that powers comments, posts, notifications, and list items out of the box.
+- **Control orientation and alignment declaratively**: Switch between horizontal and vertical layouts, and align the figure to the start, center, or end of the body, all through props.
+- **Scale typography and spacing together**: Pass a single `size` prop to each part to keep figure radius, body gap, and title font-size in lockstep.
+- **Compose inside other recipes**: Layout-only with no color or background means the Media slots into Cards, Callouts, or any container without conflicting styles.
+- **Stay type-safe**: Full TypeScript support means your editor catches invalid orientation, align, or size values at compile time.
+- **Customize without forking**: Override base styles, default variants, or filter out options you don't need &mdash; all through the options API.
+
+## Usage
+
+::steps{level="4"}
+
+#### Register the recipes
+
+Add the Media recipes to a local Styleframe instance. The global `styleframe.config.ts` provides design tokens and utilities, while the component-level file registers the recipes themselves:
+
+:::code-tree{default-value="src/components/media.styleframe.ts"}
+
+```ts [src/components/media.styleframe.ts]
+import { styleframe } from 'virtual:styleframe';
+import {
+    useMediaRecipe,
+    useMediaFigureRecipe,
+    useMediaBodyRecipe,
+    useMediaTitleRecipe,
+} from '@styleframe/theme';
+
+const s = styleframe();
+
+const media = useMediaRecipe(s);
+const mediaFigure = useMediaFigureRecipe(s);
+const mediaBody = useMediaBodyRecipe(s);
+const mediaTitle = useMediaTitleRecipe(s);
+
+export default s;
+```
+
+```ts [styleframe.config.ts]
+import { styleframe } from 'styleframe';
+import { useDesignTokensPreset, useUtilitiesPreset } from '@styleframe/theme';
+
+const s = styleframe();
+
+useDesignTokensPreset(s);
+useUtilitiesPreset(s);
+
+export default s;
+```
+
+:::
+
+#### Build the component
+
+Import the `media`, `mediaFigure`, `mediaBody`, and `mediaTitle` runtime functions from the virtual module and pass variant props to compute class names:
+
+:::tabs
+::::tabs-item{icon="i-devicon-react" label="React"}
+
+```ts [src/components/Media.tsx]
+import { media, mediaFigure, mediaBody, mediaTitle } from "virtual:styleframe";
+
+interface MediaProps {
+	orientation?: "horizontal" | "vertical";
+	align?: "start" | "center" | "end";
+	size?: "sm" | "md" | "lg";
+	figure?: React.ReactNode;
+	title?: string;
+	children?: React.ReactNode;
+}
+
+export function Media({
+	orientation = "horizontal",
+	align = "start",
+	size = "md",
+	figure,
+	title,
+	children,
+}: MediaProps) {
+	return (
+		<div className={media({ orientation, align, size })}>
+			{figure && (
+				<div className={mediaFigure({ size })}>{figure}</div>
+			)}
+			<div className={mediaBody({ size })}>
+				{title && <h3 className={mediaTitle({ size })}>{title}</h3>}
+				{children}
+			</div>
+		</div>
+	);
+}
+```
+
+::::
+::::tabs-item{icon="i-devicon-vuejs" label="Vue"}
+
+```vue [src/components/Media.vue]
+<script setup lang="ts">
+import { media, mediaFigure, mediaBody, mediaTitle } from "virtual:styleframe";
+
+const {
+	orientation = "horizontal",
+	align = "start",
+	size = "md",
+} = defineProps<{
+	orientation?: "horizontal" | "vertical";
+	align?: "start" | "center" | "end";
+	size?: "sm" | "md" | "lg";
+}>();
+</script>
+
+<template>
+	<div :class="media({ orientation, align, size })">
+		<div :class="mediaFigure({ size })">
+			<slot name="figure" />
+		</div>
+		<div :class="mediaBody({ size })">
+			<h3 :class="mediaTitle({ size })">
+				<slot name="title" />
+			</h3>
+			<slot />
+		</div>
+	</div>
+</template>
+```
+
+::::
+:::
+
+#### See it in action
+
+:::story-preview
+---
+story: theme-recipes-media--default
+panel: true
+---
+:::
+
+::
+
+## Variants
+
+Two layout axes shape the media object: `orientation` and `align`. Together they cover the full set of media-object arrangements without forcing a color or surface choice.
+
+### Orientation
+
+Two orientations control how the figure and body are arranged. `horizontal` places the figure to the left (the default media-object layout); `vertical` stacks the figure on top of the body, useful for media cards or compact list items where vertical space is plentiful.
+
+::story-preview
+---
+story: theme-recipes-media--horizontal
+panel: true
+---
+::
+
+::story-preview
+---
+story: theme-recipes-media--vertical
+panel: true
+---
+::
+
+### Align
+
+Three alignment options control how the figure aligns with the body on the cross-axis. `start` (the default) aligns the top of the figure with the top of the body, ideal for comments and posts where the avatar should sit next to the title. `center` vertically centers the figure for compact list items. `end` aligns the figure to the bottom of the body, useful when the visual is decorative.
+
+::story-preview
+---
+story: theme-recipes-media--all-variants
+---
+::
+
+| Align | CSS Value | Use Case |
+|-------|-----------|----------|
+| `start` | `align-items: flex-start` | Default. Comments, posts, list rows where avatar aligns with title |
+| `center` | `align-items: center` | Compact list items, single-line content |
+| `end` | `align-items: flex-end` | Decorative figures, icon-as-suffix layouts |
+
+## Sizes
+
+Three size variants from `sm` to `lg` scale the gap between figure and body, the figure's border radius, the body's internal gap, and the title's font size in lockstep.
+
+::story-preview
+---
+story: theme-recipes-media--large
+panel: true
+---
+::
+
+### Size Reference
+
+::story-preview
+---
+story: theme-recipes-media--all-sizes
+---
+::
+
+| Size | Container Gap | Figure Radius | Body Gap | Title Font Size |
+|------|---------------|---------------|----------|-----------------|
+| `sm` | `@0.5` | `@border-radius.sm` | `@0.25` | `@font-size.sm` |
+| `md` | `@0.75` | `@border-radius.md` | `@0.375` | `@font-size.md` |
+| `lg` | `@1` | `@border-radius.lg` | `@0.5` | `@font-size.lg` |
+
+::note
+**Good to know:** The `size` prop must be passed to each sub-recipe individually. The container controls the figure-to-body gap, the figure controls its own border radius, the body controls the title-to-content gap, and the title controls its font size.
+::
+
+## Anatomy
+
+The Media recipe is composed of four independent recipes that work together to form the layout:
+
+| Part | Recipe | Role |
+|------|--------|------|
+| **Container** | `useMediaRecipe()` | Outer flex wrapper with orientation, align, and gap |
+| **Figure** | `useMediaFigureRecipe()` | Visual holder with `flex-shrink: 0` and rounded crop |
+| **Body** | `useMediaBodyRecipe()` | Text container with `flex-grow: 1` and safe `min-width: 0` |
+| **Title** | `useMediaTitleRecipe()` | Heading typography (element-agnostic) |
+
+Each part is a standalone recipe with its own size axis. The container's `orientation` and `align` props are independent of the size axis, so you can freely combine all three.
+
+```html
+<!-- All four parts working together -->
+<div class="media(...)">
+    <div class="mediaFigure(...)"><!-- avatar / image --></div>
+    <div class="mediaBody(...)">
+        <h3 class="mediaTitle(...)">Heading</h3>
+        <p>Body content</p>
+    </div>
+</div>
+```
+
+::tip
+**Pro tip:** The title recipe is element-agnostic &mdash; apply the `mediaTitle` class to whichever heading element fits your document outline (`<h2>`, `<h3>`, `<h4>`, or even `<strong>`). The recipe only sets typography, not semantics.
+::
+
+## Nesting
+
+Media objects can be nested inside one another to model parent-child relationships such as comment threads, social-post replies, or activity feeds. Place a `Media` inside another `Media`'s body and the layout naturally indents the child by the figure's width plus the container's gap.
+
+::story-preview
+---
+story: theme-recipes-media--nested
+panel: true
+---
+::
+
+```vue [src/components/CommentThread.vue]
+<template>
+	<Media>
+		<MediaFigure>
+			<img src="/avatar/alex.png" alt="Alex Grozav" />
+		</MediaFigure>
+		<MediaBody>
+			<MediaTitle>Alex Grozav</MediaTitle>
+			<p>Just shipped the new Media recipe...</p>
+
+			<!-- Nested reply -->
+			<Media>
+				<MediaFigure size="sm">
+					<img src="/avatar/jane.png" alt="Jane Smith" />
+				</MediaFigure>
+				<MediaBody size="sm">
+					<MediaTitle size="sm">Jane Smith</MediaTitle>
+					<p>Love it &mdash; the layout-only design...</p>
+				</MediaBody>
+			</Media>
+		</MediaBody>
+	</Media>
+</template>
+```
+
+::note
+**Good to know:** Drop the nested `Media` directly inside the parent's `MediaBody`. The parent body is already a flex column with `min-width: 0`, so child media items wrap correctly without extra wrappers. Reduce the nested media's `size` (e.g., `sm`) to visually distinguish replies from the parent thread.
+::
+
+## Accessibility
+
+- **Choose the right heading level.** `useMediaTitleRecipe` only styles typography &mdash; pick a heading element (`<h2>`, `<h3>`, `<h4>`) that fits the surrounding document outline. Don't skip levels just because the title is small.
+- **Provide alt text for figures.** When the figure contains an `<img>`, supply a meaningful `alt` attribute. Decorative figures should use `alt=""` and `aria-hidden="true"` so screen readers skip them.
+- **Group related media in a list.** Repeated media items (comments, feed posts) belong inside a `<ul>` / `<ol>` so assistive tech can announce the count.
+- **Don't lose focus order with `vertical` orientation.** Switching orientation with CSS doesn't reorder the DOM, so the figure is always announced before the body. Place actions and links inside the body for predictable keyboard navigation.
+
+## Customization
+
+### Overriding Defaults
+
+Each media composable accepts an optional second argument to override any part of the recipe configuration. Overrides are deep-merged with the defaults, so you only need to specify the properties you want to change:
+
+```ts [src/components/media.styleframe.ts]
+import { styleframe } from 'virtual:styleframe';
+import {
+    useMediaRecipe,
+    useMediaFigureRecipe,
+    useMediaBodyRecipe,
+    useMediaTitleRecipe,
+} from '@styleframe/theme';
+
+const s = styleframe();
+
+const media = useMediaRecipe(s, {
+    base: {
+        gap: '@1',
+    },
+    defaultVariants: {
+        orientation: 'horizontal',
+        align: 'center',
+        size: 'lg',
+    },
+});
+
+const mediaFigure = useMediaFigureRecipe(s, {
+    defaultVariants: {
+        size: 'lg',
+    },
+});
+
+const mediaBody = useMediaBodyRecipe(s, {
+    defaultVariants: {
+        size: 'lg',
+    },
+});
+
+const mediaTitle = useMediaTitleRecipe(s, {
+    base: {
+        fontWeight: '@font-weight.bold',
+    },
+    defaultVariants: {
+        size: 'lg',
+    },
+});
+
+export default s;
+```
+
+### Filtering Variants
+
+If you only need a subset of the available variants, use the `filter` option to limit which values are generated. This reduces the output CSS and keeps your component API focused:
+
+```ts [src/components/media.styleframe.ts]
+import { styleframe } from 'virtual:styleframe';
+import { useMediaRecipe } from '@styleframe/theme';
+
+const s = styleframe();
+
+// Only generate horizontal orientation with start and center alignment
+const media = useMediaRecipe(s, {
+    filter: {
+        orientation: ['horizontal'],
+        align: ['start', 'center'],
+    },
+});
+
+export default s;
+```
+
+::note
+**Good to know:** Filtering also adjusts default variants that reference filtered-out values, so your recipe stays consistent.
+::
+
+## API Reference
+
+### `useMediaRecipe(s, options?)`
+
+Creates the media container recipe with orientation, alignment, and gap.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `s` | `Styleframe` | The Styleframe instance |
+| `options` | `DeepPartial<RecipeConfig>` | Optional overrides for the recipe configuration |
+| `options.base` | `VariantDeclarationsBlock` | Custom base styles for the media container |
+| `options.variants` | `Variants` | Custom variant definitions for the recipe |
+| `options.defaultVariants` | `Record<keyof Variants, string>` | Default variant values for the recipe |
+| `options.filter` | `Record<string, string[]>` | Limit which variant values are generated |
+
+**Variants:**
+
+| Variant | Options | Default |
+|---------|---------|---------|
+| `orientation` | `horizontal`, `vertical` | `horizontal` |
+| `align` | `start`, `center`, `end` | `start` |
+| `size` | `sm`, `md`, `lg` | `md` |
+
+### `useMediaFigureRecipe(s, options?)`
+
+Creates the media figure recipe for the visual holder. The base styles set `flex-shrink: 0` so the figure never collapses, plus `overflow: hidden` so contained images crop to the rounded radius.
+
+**Variants:**
+
+| Variant | Options | Default |
+|---------|---------|---------|
+| `size` | `sm`, `md`, `lg` | `md` |
+
+### `useMediaBodyRecipe(s, options?)`
+
+Creates the media body recipe for the text content area. The base styles set `flex-grow: 1` and the critical `min-width: 0` so long titles wrap correctly inside the parent flex container instead of overflowing.
+
+**Variants:**
+
+| Variant | Options | Default |
+|---------|---------|---------|
+| `size` | `sm`, `md`, `lg` | `md` |
+
+### `useMediaTitleRecipe(s, options?)`
+
+Creates the media title recipe for heading typography. The base styles set semibold weight, snug line height, and zero margin. The recipe is element-agnostic &mdash; apply the class to any heading element (`<h2>`, `<h3>`, `<h4>`) that fits your document outline.
+
+**Variants:**
+
+| Variant | Options | Default |
+|---------|---------|---------|
+| `size` | `sm`, `md`, `lg` | `md` |
+
+[Learn more about recipes &rarr;](/docs/api/recipes)
+
+## Best Practices
+
+- **Pass `size` to every part**: The container, figure, body, and title each control their own size-scaled property. Pass the same `size` value to all four for visually consistent results.
+- **Use `align: "start"` for comments and posts**: Top-aligning the avatar with the title is the most readable pattern when the body has multiple lines of text. Reserve `center` for single-line list items.
+- **Pick a meaningful heading element**: `useMediaTitleRecipe` only styles typography &mdash; choose `<h3>` or `<h4>` based on where the media sits in your document outline.
+- **Use `vertical` orientation sparingly**: Vertical media is essentially a card-like figure-on-top layout. If your design needs that pattern, also consider whether [`useCardRecipe`](/docs/components/composables/card) is a better fit.
+- **Don't add background or border to the Media root**: Media is layout-only by design. Wrap it inside a Card, Callout, or other container if you need surface styling &mdash; this keeps composition predictable.
+- **Filter what you don't need**: If your component only uses one orientation or alignment, pass a `filter` option to reduce generated CSS.
+- **Reduce `size` for nested replies**: When nesting Media inside Media (comment threads, reply chains), drop the nested media's `size` to `sm` so the indentation hierarchy reads at a glance.
+
+## FAQ
+
+::accordion
+
+:::accordion-item{label="Why are there four separate recipes instead of one?" icon="i-lucide-circle-help"}
+The figure, body, and title each have distinct base styles &mdash; the figure needs `flex-shrink: 0` and rounded clipping, the body needs `min-width: 0` for safe text wrapping, and the title needs heading typography. Four separate recipes give each part its own focused base while sharing the `size` axis. This also means you can use a subset (just the body, just figure-plus-body) without paying for unused styles.
+:::
+
+:::accordion-item{label="Why doesn't the Media recipe include color variants?" icon="i-lucide-circle-help"}
+The Media is a layout primitive, not a surface. Adding color or background styling would conflict with whatever container (Card, Callout, etc.) wraps the media. Keeping Media layout-only means it composes cleanly inside any container without overriding background or border colors.
+:::
+
+:::accordion-item{label="What's the difference between the orientation and align axes?" icon="i-lucide-circle-help"}
+`orientation` controls the main flex axis: `horizontal` puts the figure to the left of the body, `vertical` stacks the figure on top. `align` controls the cross-axis alignment of the figure relative to the body &mdash; in horizontal orientation, `start` aligns the top of the figure with the top of the body; in vertical orientation, `start` left-aligns the figure within the column. The two axes are independent and can be combined freely.
+:::
+
+:::accordion-item{label="Why does the body need min-width: 0?" icon="i-lucide-circle-help"}
+This is a well-known flexbox gotcha. By default, flex items have `min-width: auto`, which means a long unbroken word or a child with `white-space: nowrap` can force the body to grow beyond its parent and break the layout. Setting `min-width: 0` lets the body shrink as needed and lets text wrap correctly. The Media body recipe sets this in its base styles automatically.
+:::
+
+:::accordion-item{label="Can I use the Media recipe inside a Card?" icon="i-lucide-circle-help"}
+Yes &mdash; this is the recommended composition pattern. Place a Media inside a `useCardBodyRecipe` to get a card with an image-and-content row, or use multiple Media items as list rows inside a Card. Because Media has no color or background, it will pick up the Card's surface styling without conflicts.
+:::
+
+:::accordion-item{label="What happens if I don't use the figure or title?" icon="i-lucide-circle-help"}
+Both are optional. A Media with only a body works as a flex layout primitive for plain content. A Media with only figure and body (no title) is the simplest avatar-plus-text pattern. Render only the parts you need &mdash; each recipe is independent.
+:::
+
+:::accordion-item{label="Can I nest Media components inside one another?" icon="i-lucide-circle-help"}
+Yes &mdash; this is the canonical pattern for comment threads, social-post replies, and activity feeds. Drop a `Media` directly inside another `Media`'s `MediaBody`; the body is already a flex column with `min-width: 0`, so the child wraps correctly and inherits the parent body's indentation. Drop the nested media's `size` to `sm` to visually distinguish replies from the parent thread. See the [Nesting](#nesting) section for an example.
+:::
+
+:::accordion-item{label="How does filtering affect the recipe?" icon="i-lucide-circle-help"}
+When you use the `filter` option, default variants that reference filtered-out values are automatically removed. For example, if you filter `orientation` to only `['horizontal']`, the `defaultVariants.orientation` is preserved (since `horizontal` is the default); but if you filter to `['vertical']`, the default is removed because `horizontal` is no longer available.
+:::
+
+:::accordion-item{label="Can I use the Media recipe without the design tokens preset?" icon="i-lucide-circle-help"}
+The Media recipes reference design tokens like `@0.75`, `@border-radius.md`, and `@font-size.md` through string refs. These tokens need to be defined in your Styleframe instance for the recipes to generate valid CSS. The easiest way is to use `useDesignTokensPreset(s)`, but you can also define the required tokens manually.
+:::
+
+::

--- a/apps/storybook/src/components/components/media/Media.vue
+++ b/apps/storybook/src/components/components/media/Media.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { media } from "virtual:styleframe";
+
+const props = withDefaults(
+	defineProps<{
+		orientation?: "horizontal" | "vertical";
+		align?: "start" | "center" | "end";
+		size?: "sm" | "md" | "lg";
+	}>(),
+	{},
+);
+
+const classes = computed(() =>
+	media({
+		orientation: props.orientation,
+		align: props.align,
+		size: props.size,
+	}),
+);
+</script>
+
+<template>
+	<div :class="classes">
+		<slot />
+	</div>
+</template>

--- a/apps/storybook/src/components/components/media/MediaBody.vue
+++ b/apps/storybook/src/components/components/media/MediaBody.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { mediaBody } from "virtual:styleframe";
+
+const props = withDefaults(
+	defineProps<{
+		size?: "sm" | "md" | "lg";
+	}>(),
+	{},
+);
+
+const classes = computed(() =>
+	mediaBody({
+		size: props.size,
+	}),
+);
+</script>
+
+<template>
+	<div :class="classes">
+		<slot />
+	</div>
+</template>

--- a/apps/storybook/src/components/components/media/MediaFigure.vue
+++ b/apps/storybook/src/components/components/media/MediaFigure.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { mediaFigure } from "virtual:styleframe";
+
+const props = withDefaults(
+	defineProps<{
+		size?: "sm" | "md" | "lg";
+	}>(),
+	{},
+);
+
+const classes = computed(() =>
+	mediaFigure({
+		size: props.size,
+	}),
+);
+</script>
+
+<template>
+	<div :class="classes">
+		<slot />
+	</div>
+</template>

--- a/apps/storybook/src/components/components/media/MediaTitle.vue
+++ b/apps/storybook/src/components/components/media/MediaTitle.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { mediaTitle } from "virtual:styleframe";
+
+const props = withDefaults(
+	defineProps<{
+		size?: "sm" | "md" | "lg";
+	}>(),
+	{},
+);
+
+const classes = computed(() =>
+	mediaTitle({
+		size: props.size,
+	}),
+);
+</script>
+
+<template>
+	<h3 :class="classes">
+		<slot />
+	</h3>
+</template>

--- a/apps/storybook/src/components/components/media/preview/MediaGrid.vue
+++ b/apps/storybook/src/components/components/media/preview/MediaGrid.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import Media from "../Media.vue";
+import MediaFigure from "../MediaFigure.vue";
+import MediaBody from "../MediaBody.vue";
+import MediaTitle from "../MediaTitle.vue";
+
+const orientations = ["horizontal", "vertical"] as const;
+const aligns = ["start", "center", "end"] as const;
+</script>
+
+<template>
+	<div class="media-section">
+		<div v-for="orientation in orientations" :key="orientation">
+			<div class="media-label">{{ orientation }}</div>
+			<div class="media-row">
+				<Media
+					v-for="align in aligns"
+					:key="`${orientation}-${align}`"
+					:orientation="orientation"
+					:align="align"
+					class="_max-width:[320px]"
+				>
+					<MediaFigure>
+						<div class="media-avatar _width:[40px] _height:[40px]">MA</div>
+					</MediaFigure>
+					<MediaBody>
+						<MediaTitle>{{ align.charAt(0).toUpperCase() + align.slice(1) }} aligned</MediaTitle>
+						<p class="_margin:0">A short body paragraph that follows the title in the media body.</p>
+					</MediaBody>
+				</Media>
+			</div>
+		</div>
+	</div>
+</template>

--- a/apps/storybook/src/components/components/media/preview/MediaSizeGrid.vue
+++ b/apps/storybook/src/components/components/media/preview/MediaSizeGrid.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import Media from "../Media.vue";
+import MediaFigure from "../MediaFigure.vue";
+import MediaBody from "../MediaBody.vue";
+import MediaTitle from "../MediaTitle.vue";
+
+const sizes = ["sm", "md", "lg"] as const;
+const sizeTitles: Record<string, string> = {
+	sm: "Small",
+	md: "Medium",
+	lg: "Large",
+};
+const sizeAvatarClass: Record<string, string> = {
+	sm: "_width:[32px] _height:[32px]",
+	md: "_width:[40px] _height:[40px]",
+	lg: "_width:[48px] _height:[48px]",
+};
+</script>
+
+<template>
+	<div class="media-section">
+		<div v-for="size in sizes" :key="size">
+			<div class="media-label">{{ size }}</div>
+			<div class="media-row">
+				<Media :size="size" class="_max-width:[360px]">
+					<MediaFigure :size="size">
+						<div :class="['media-avatar', sizeAvatarClass[size]]">
+							{{ sizeTitles[size]?.charAt(0) }}
+						</div>
+					</MediaFigure>
+					<MediaBody :size="size">
+						<MediaTitle :size="size">{{ sizeTitles[size] }} media</MediaTitle>
+						<p class="_margin:0">A {{ size }} media object with figure, body, and title.</p>
+					</MediaBody>
+				</Media>
+			</div>
+		</div>
+	</div>
+</template>

--- a/apps/storybook/src/components/components/media/preview/NestedMedia.vue
+++ b/apps/storybook/src/components/components/media/preview/NestedMedia.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+import Media from "../Media.vue";
+import MediaFigure from "../MediaFigure.vue";
+import MediaBody from "../MediaBody.vue";
+import MediaTitle from "../MediaTitle.vue";
+</script>
+
+<template>
+	<div class="media-section">
+		<Media class="_max-width:[480px]">
+			<MediaFigure>
+				<div class="media-avatar _width:[40px] _height:[40px]">AG</div>
+			</MediaFigure>
+			<MediaBody>
+				<MediaTitle>Alex Grozav</MediaTitle>
+				<p class="_margin:0">
+					Just shipped the new Media recipe — perfect for nested comment threads
+					and social-feed layouts.
+				</p>
+
+				<Media class="_margin-top:0.75">
+					<MediaFigure size="sm">
+						<div class="media-avatar _width:[32px] _height:[32px]">JS</div>
+					</MediaFigure>
+					<MediaBody size="sm">
+						<MediaTitle size="sm">Jane Smith</MediaTitle>
+						<p class="_margin:0">
+							Love it — the layout-only design means I can drop it inside any
+							Card without conflicts.
+						</p>
+
+						<Media class="_margin-top:0.75">
+							<MediaFigure size="sm">
+								<div class="media-avatar _width:[32px] _height:[32px]">
+									AG
+								</div>
+							</MediaFigure>
+							<MediaBody size="sm">
+								<MediaTitle size="sm">Alex Grozav</MediaTitle>
+								<p class="_margin:0">
+									Exactly the design intent — compose freely, no surface
+									opinions baked in.
+								</p>
+							</MediaBody>
+						</Media>
+					</MediaBody>
+				</Media>
+			</MediaBody>
+		</Media>
+	</div>
+</template>

--- a/apps/storybook/stories/components/media.stories.ts
+++ b/apps/storybook/stories/components/media.stories.ts
@@ -1,0 +1,145 @@
+import type { Meta, StoryObj } from "@storybook/vue3-vite";
+
+import Media from "@/components/components/media/Media.vue";
+import MediaFigure from "@/components/components/media/MediaFigure.vue";
+import MediaBody from "@/components/components/media/MediaBody.vue";
+import MediaTitle from "@/components/components/media/MediaTitle.vue";
+import MediaGrid from "@/components/components/media/preview/MediaGrid.vue";
+import MediaSizeGrid from "@/components/components/media/preview/MediaSizeGrid.vue";
+import NestedMedia from "@/components/components/media/preview/NestedMedia.vue";
+
+const orientations = ["horizontal", "vertical"] as const;
+const aligns = ["start", "center", "end"] as const;
+const sizes = ["sm", "md", "lg"] as const;
+
+const meta = {
+	title: "Theme/Recipes/Media",
+	component: Media,
+	tags: ["autodocs"],
+	parameters: {
+		layout: "padded",
+	},
+	argTypes: {
+		orientation: {
+			control: "select",
+			options: orientations,
+			description: "The orientation of the media object",
+		},
+		align: {
+			control: "select",
+			options: aligns,
+			description:
+				"The cross-axis alignment of the figure relative to the body",
+		},
+		size: {
+			control: "select",
+			options: sizes,
+			description: "The size of the media object",
+		},
+	},
+	render: (args) => ({
+		components: {
+			Media,
+			MediaFigure,
+			MediaBody,
+			MediaTitle,
+		},
+		setup() {
+			return { args };
+		},
+		template: `
+			<Media v-bind="args" class="_max-width:[360px]">
+				<MediaFigure :size="args.size">
+					<div class="media-avatar _width:[40px] _height:[40px]">MA</div>
+				</MediaFigure>
+				<MediaBody :size="args.size">
+					<MediaTitle :size="args.size">Featured story</MediaTitle>
+					<p class="_margin:0">A short body paragraph that follows the title in the media body.</p>
+				</MediaBody>
+			</Media>
+		`,
+	}),
+} satisfies Meta<typeof Media>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {
+		orientation: "horizontal",
+		align: "start",
+		size: "md",
+	},
+};
+
+export const AllVariants: StoryObj = {
+	render: () => ({
+		components: { MediaGrid },
+		template: "<MediaGrid />",
+	}),
+};
+
+export const AllSizes: StoryObj = {
+	render: () => ({
+		components: { MediaSizeGrid },
+		template: "<MediaSizeGrid />",
+	}),
+};
+
+export const Nested: StoryObj = {
+	render: () => ({
+		components: { NestedMedia },
+		template: "<NestedMedia />",
+	}),
+};
+
+// Orientation stories
+export const Horizontal: Story = {
+	args: {
+		orientation: "horizontal",
+	},
+};
+
+export const Vertical: Story = {
+	args: {
+		orientation: "vertical",
+	},
+};
+
+// Align stories
+export const AlignStart: Story = {
+	args: {
+		align: "start",
+	},
+};
+
+export const AlignCenter: Story = {
+	args: {
+		align: "center",
+	},
+};
+
+export const AlignEnd: Story = {
+	args: {
+		align: "end",
+	},
+};
+
+// Size stories
+export const Small: Story = {
+	args: {
+		size: "sm",
+	},
+};
+
+export const Medium: Story = {
+	args: {
+		size: "md",
+	},
+};
+
+export const Large: Story = {
+	args: {
+		size: "lg",
+	},
+};

--- a/apps/storybook/stories/components/media.styleframe.ts
+++ b/apps/storybook/stories/components/media.styleframe.ts
@@ -1,0 +1,53 @@
+import {
+	useMediaRecipe,
+	useMediaFigureRecipe,
+	useMediaBodyRecipe,
+	useMediaTitleRecipe,
+} from "@styleframe/theme";
+import { styleframe } from "virtual:styleframe";
+
+const s = styleframe();
+const { selector } = s;
+
+// Initialize media recipes
+export const media = useMediaRecipe(s);
+export const mediaFigure = useMediaFigureRecipe(s);
+export const mediaBody = useMediaBodyRecipe(s);
+export const mediaTitle = useMediaTitleRecipe(s);
+
+// Container styles for story layout
+selector(".media-section", {
+	display: "flex",
+	flexDirection: "column",
+	gap: "@spacing.lg",
+	padding: "@spacing.md",
+});
+
+selector(".media-row", {
+	display: "flex",
+	flexWrap: "wrap",
+	gap: "@spacing.md",
+	alignItems: "flex-start",
+});
+
+selector(".media-label", {
+	fontSize: "@font-size.sm",
+	fontWeight: "@font-weight.semibold",
+	marginBottom: "@spacing.sm",
+});
+
+// Placeholder avatar styling for story figures.
+// Width/height are intentionally omitted so consumers can size via utility
+// classes (e.g., `_width:[40px] _height:[40px]`) — see MediaSizeGrid.vue.
+selector(".media-avatar", {
+	display: "flex",
+	alignItems: "center",
+	justifyContent: "center",
+	background: "@color.primary-100",
+	color: "@color.primary-700",
+	fontSize: "@font-size.sm",
+	fontWeight: "@font-weight.semibold",
+	borderRadius: "@border-radius.full",
+});
+
+export default s;

--- a/theme/src/recipes/index.ts
+++ b/theme/src/recipes/index.ts
@@ -7,6 +7,7 @@ export * from "./chip";
 export * from "./dropdown";
 export * from "./hamburger-menu";
 export * from "./input";
+export * from "./media";
 export * from "./spinner";
 export * from "./modal";
 export * from "./nav";

--- a/theme/src/recipes/media/index.ts
+++ b/theme/src/recipes/media/index.ts
@@ -1,0 +1,4 @@
+export * from "./useMediaRecipe";
+export * from "./useMediaFigureRecipe";
+export * from "./useMediaBodyRecipe";
+export * from "./useMediaTitleRecipe";

--- a/theme/src/recipes/media/useMediaBodyRecipe.test.ts
+++ b/theme/src/recipes/media/useMediaBodyRecipe.test.ts
@@ -1,0 +1,98 @@
+import { styleframe } from "@styleframe/core";
+import { useMediaBodyRecipe } from "./useMediaBodyRecipe";
+
+function createInstance() {
+	const s = styleframe();
+	for (const name of [
+		"display",
+		"flexDirection",
+		"flexGrow",
+		"minWidth",
+		"gap",
+	]) {
+		s.utility(name, ({ value }) => ({ [name]: value }));
+	}
+	return s;
+}
+
+describe("useMediaBodyRecipe", () => {
+	it("should create a recipe with correct metadata", () => {
+		const s = createInstance();
+		const recipe = useMediaBodyRecipe(s);
+
+		expect(recipe.type).toBe("recipe");
+		expect(recipe.name).toBe("media-body");
+	});
+
+	it("should have correct base styles", () => {
+		const s = createInstance();
+		const recipe = useMediaBodyRecipe(s);
+
+		expect(recipe.base).toEqual({
+			display: "flex",
+			flexDirection: "column",
+			flexGrow: "1",
+			minWidth: "0",
+			gap: "@0.375",
+		});
+	});
+
+	it("should have size variants", () => {
+		const s = createInstance();
+		const recipe = useMediaBodyRecipe(s);
+
+		expect(recipe.variants!.size).toEqual({
+			sm: { gap: "@0.25" },
+			md: { gap: "@0.375" },
+			lg: { gap: "@0.5" },
+		});
+	});
+
+	it("should have correct default variants", () => {
+		const s = createInstance();
+		const recipe = useMediaBodyRecipe(s);
+
+		expect(recipe.defaultVariants).toEqual({
+			size: "md",
+		});
+	});
+
+	it("should not have compound variants", () => {
+		const s = createInstance();
+		const recipe = useMediaBodyRecipe(s);
+
+		expect(recipe.compoundVariants).toBeUndefined();
+	});
+
+	describe("config overrides", () => {
+		it("should allow overriding base styles", () => {
+			const s = createInstance();
+			const recipe = useMediaBodyRecipe(s, {
+				base: { gap: "@1" },
+			});
+
+			expect(recipe.base!.gap).toBe("@1");
+			expect(recipe.base!.minWidth).toBe("0");
+		});
+	});
+
+	describe("filter", () => {
+		it("should filter size variants", () => {
+			const s = createInstance();
+			const recipe = useMediaBodyRecipe(s, {
+				filter: { size: ["md"] },
+			});
+
+			expect(Object.keys(recipe.variants!.size)).toEqual(["md"]);
+		});
+
+		it("should adjust default variants when filtered out", () => {
+			const s = createInstance();
+			const recipe = useMediaBodyRecipe(s, {
+				filter: { size: ["sm"] },
+			});
+
+			expect(recipe.defaultVariants?.size).toBeUndefined();
+		});
+	});
+});

--- a/theme/src/recipes/media/useMediaBodyRecipe.ts
+++ b/theme/src/recipes/media/useMediaBodyRecipe.ts
@@ -1,0 +1,32 @@
+import { createUseRecipe } from "../../utils/createUseRecipe";
+
+/**
+ * Media body recipe — text content container. `minWidth: 0` is required
+ * so long titles or descriptions wrap correctly inside the parent flex
+ * container instead of forcing the row to overflow.
+ */
+export const useMediaBodyRecipe = createUseRecipe("media-body", {
+	base: {
+		display: "flex",
+		flexDirection: "column",
+		flexGrow: "1",
+		minWidth: "0",
+		gap: "@0.375",
+	},
+	variants: {
+		size: {
+			sm: {
+				gap: "@0.25",
+			},
+			md: {
+				gap: "@0.375",
+			},
+			lg: {
+				gap: "@0.5",
+			},
+		},
+	},
+	defaultVariants: {
+		size: "md",
+	},
+});

--- a/theme/src/recipes/media/useMediaFigureRecipe.test.ts
+++ b/theme/src/recipes/media/useMediaFigureRecipe.test.ts
@@ -1,0 +1,99 @@
+import { styleframe } from "@styleframe/core";
+import { useMediaFigureRecipe } from "./useMediaFigureRecipe";
+
+function createInstance() {
+	const s = styleframe();
+	for (const name of [
+		"display",
+		"flexShrink",
+		"alignItems",
+		"justifyContent",
+		"overflow",
+		"borderRadius",
+	]) {
+		s.utility(name, ({ value }) => ({ [name]: value }));
+	}
+	return s;
+}
+
+describe("useMediaFigureRecipe", () => {
+	it("should create a recipe with correct metadata", () => {
+		const s = createInstance();
+		const recipe = useMediaFigureRecipe(s);
+
+		expect(recipe.type).toBe("recipe");
+		expect(recipe.name).toBe("media-figure");
+	});
+
+	it("should have correct base styles", () => {
+		const s = createInstance();
+		const recipe = useMediaFigureRecipe(s);
+
+		expect(recipe.base).toEqual({
+			display: "flex",
+			flexShrink: "0",
+			alignItems: "center",
+			justifyContent: "center",
+			overflow: "hidden",
+		});
+	});
+
+	it("should have size variants", () => {
+		const s = createInstance();
+		const recipe = useMediaFigureRecipe(s);
+
+		expect(recipe.variants!.size).toEqual({
+			sm: { borderRadius: "@border-radius.sm" },
+			md: { borderRadius: "@border-radius.md" },
+			lg: { borderRadius: "@border-radius.lg" },
+		});
+	});
+
+	it("should have correct default variants", () => {
+		const s = createInstance();
+		const recipe = useMediaFigureRecipe(s);
+
+		expect(recipe.defaultVariants).toEqual({
+			size: "md",
+		});
+	});
+
+	it("should not have compound variants", () => {
+		const s = createInstance();
+		const recipe = useMediaFigureRecipe(s);
+
+		expect(recipe.compoundVariants).toBeUndefined();
+	});
+
+	describe("config overrides", () => {
+		it("should allow overriding base styles", () => {
+			const s = createInstance();
+			const recipe = useMediaFigureRecipe(s, {
+				base: { overflow: "visible" },
+			});
+
+			expect(recipe.base!.overflow).toBe("visible");
+			expect(recipe.base!.flexShrink).toBe("0");
+		});
+	});
+
+	describe("filter", () => {
+		it("should filter size variants", () => {
+			const s = createInstance();
+			const recipe = useMediaFigureRecipe(s, {
+				filter: { size: ["sm", "md"] },
+			});
+
+			expect(Object.keys(recipe.variants!.size)).toEqual(["sm", "md"]);
+		});
+
+		it("should adjust default variants when filtered out", () => {
+			const s = createInstance();
+			const recipe = useMediaFigureRecipe(s, {
+				filter: { size: ["lg"] },
+			});
+
+			expect(recipe.defaultVariants?.size).toBeUndefined();
+		});
+	});
+});

--- a/theme/src/recipes/media/useMediaFigureRecipe.ts
+++ b/theme/src/recipes/media/useMediaFigureRecipe.ts
@@ -1,0 +1,32 @@
+import { createUseRecipe } from "../../utils/createUseRecipe";
+
+/**
+ * Media figure recipe — visual content holder (image, avatar, icon).
+ * `flexShrink: 0` keeps the figure from collapsing on narrow viewports;
+ * `overflow: hidden` clips contained images to the rounded radius.
+ */
+export const useMediaFigureRecipe = createUseRecipe("media-figure", {
+	base: {
+		display: "flex",
+		flexShrink: "0",
+		alignItems: "center",
+		justifyContent: "center",
+		overflow: "hidden",
+	},
+	variants: {
+		size: {
+			sm: {
+				borderRadius: "@border-radius.sm",
+			},
+			md: {
+				borderRadius: "@border-radius.md",
+			},
+			lg: {
+				borderRadius: "@border-radius.lg",
+			},
+		},
+	},
+	defaultVariants: {
+		size: "md",
+	},
+});

--- a/theme/src/recipes/media/useMediaRecipe.test.ts
+++ b/theme/src/recipes/media/useMediaRecipe.test.ts
@@ -1,0 +1,136 @@
+import { styleframe } from "@styleframe/core";
+import { useMediaRecipe } from "./useMediaRecipe";
+
+function createInstance() {
+	const s = styleframe();
+	for (const name of ["display", "alignItems", "flexDirection", "gap"]) {
+		s.utility(name, ({ value }) => ({ [name]: value }));
+	}
+	return s;
+}
+
+describe("useMediaRecipe", () => {
+	it("should create a recipe with correct metadata", () => {
+		const s = createInstance();
+		const recipe = useMediaRecipe(s);
+
+		expect(recipe.type).toBe("recipe");
+		expect(recipe.name).toBe("media");
+	});
+
+	it("should have correct base styles", () => {
+		const s = createInstance();
+		const recipe = useMediaRecipe(s);
+
+		expect(recipe.base).toEqual({
+			display: "flex",
+			alignItems: "flex-start",
+			gap: "@0.75",
+		});
+	});
+
+	describe("variants", () => {
+		it("should have orientation variants", () => {
+			const s = createInstance();
+			const recipe = useMediaRecipe(s);
+
+			expect(recipe.variants!.orientation).toEqual({
+				horizontal: { flexDirection: "row" },
+				vertical: { flexDirection: "column" },
+			});
+		});
+
+		it("should have align variants", () => {
+			const s = createInstance();
+			const recipe = useMediaRecipe(s);
+
+			expect(recipe.variants!.align).toEqual({
+				start: { alignItems: "flex-start" },
+				center: { alignItems: "center" },
+				end: { alignItems: "flex-end" },
+			});
+		});
+
+		it("should have size variants", () => {
+			const s = createInstance();
+			const recipe = useMediaRecipe(s);
+
+			expect(recipe.variants!.size).toEqual({
+				sm: { gap: "@0.5" },
+				md: { gap: "@0.75" },
+				lg: { gap: "@1" },
+			});
+		});
+	});
+
+	it("should have correct default variants", () => {
+		const s = createInstance();
+		const recipe = useMediaRecipe(s);
+
+		expect(recipe.defaultVariants).toEqual({
+			orientation: "horizontal",
+			align: "start",
+			size: "md",
+		});
+	});
+
+	it("should not have compound variants", () => {
+		const s = createInstance();
+		const recipe = useMediaRecipe(s);
+
+		expect(recipe.compoundVariants).toBeUndefined();
+	});
+
+	describe("config overrides", () => {
+		it("should allow overriding base styles", () => {
+			const s = createInstance();
+			const recipe = useMediaRecipe(s, {
+				base: { display: "inline-flex" },
+			});
+
+			expect(recipe.base!.display).toBe("inline-flex");
+			expect(recipe.base!.alignItems).toBe("flex-start");
+			expect(recipe.base!.gap).toBe("@0.75");
+		});
+	});
+
+	describe("filter", () => {
+		it("should filter orientation variants", () => {
+			const s = createInstance();
+			const recipe = useMediaRecipe(s, {
+				filter: { orientation: ["horizontal"] },
+			});
+
+			expect(Object.keys(recipe.variants!.orientation)).toEqual(["horizontal"]);
+		});
+
+		it("should filter align variants", () => {
+			const s = createInstance();
+			const recipe = useMediaRecipe(s, {
+				filter: { align: ["start", "center"] },
+			});
+
+			expect(Object.keys(recipe.variants!.align)).toEqual(["start", "center"]);
+		});
+
+		it("should filter size variants", () => {
+			const s = createInstance();
+			const recipe = useMediaRecipe(s, {
+				filter: { size: ["md"] },
+			});
+
+			expect(Object.keys(recipe.variants!.size)).toEqual(["md"]);
+		});
+
+		it("should adjust default variants when filtered out", () => {
+			const s = createInstance();
+			const recipe = useMediaRecipe(s, {
+				filter: { orientation: ["vertical"] },
+			});
+
+			expect(recipe.defaultVariants?.orientation).toBeUndefined();
+			expect(recipe.defaultVariants?.align).toBe("start");
+			expect(recipe.defaultVariants?.size).toBe("md");
+		});
+	});
+});

--- a/theme/src/recipes/media/useMediaRecipe.ts
+++ b/theme/src/recipes/media/useMediaRecipe.ts
@@ -1,0 +1,51 @@
+import { createUseRecipe } from "../../utils/createUseRecipe";
+
+/**
+ * Media object recipe — flex layout primitive that places visual content
+ * (image/avatar/icon) alongside text content. Layout-only: no color or
+ * surface styling, so it composes cleanly inside other containers.
+ */
+export const useMediaRecipe = createUseRecipe("media", {
+	base: {
+		display: "flex",
+		alignItems: "flex-start",
+		gap: "@0.75",
+	},
+	variants: {
+		orientation: {
+			horizontal: {
+				flexDirection: "row",
+			},
+			vertical: {
+				flexDirection: "column",
+			},
+		},
+		align: {
+			start: {
+				alignItems: "flex-start",
+			},
+			center: {
+				alignItems: "center",
+			},
+			end: {
+				alignItems: "flex-end",
+			},
+		},
+		size: {
+			sm: {
+				gap: "@0.5",
+			},
+			md: {
+				gap: "@0.75",
+			},
+			lg: {
+				gap: "@1",
+			},
+		},
+	},
+	defaultVariants: {
+		orientation: "horizontal",
+		align: "start",
+		size: "md",
+	},
+});

--- a/theme/src/recipes/media/useMediaTitleRecipe.test.ts
+++ b/theme/src/recipes/media/useMediaTitleRecipe.test.ts
@@ -1,0 +1,90 @@
+import { styleframe } from "@styleframe/core";
+import { useMediaTitleRecipe } from "./useMediaTitleRecipe";
+
+function createInstance() {
+	const s = styleframe();
+	for (const name of ["fontWeight", "lineHeight", "margin", "fontSize"]) {
+		s.utility(name, ({ value }) => ({ [name]: value }));
+	}
+	return s;
+}
+
+describe("useMediaTitleRecipe", () => {
+	it("should create a recipe with correct metadata", () => {
+		const s = createInstance();
+		const recipe = useMediaTitleRecipe(s);
+
+		expect(recipe.type).toBe("recipe");
+		expect(recipe.name).toBe("media-title");
+	});
+
+	it("should have correct base styles", () => {
+		const s = createInstance();
+		const recipe = useMediaTitleRecipe(s);
+
+		expect(recipe.base).toEqual({
+			fontWeight: "@font-weight.semibold",
+			lineHeight: "@line-height.snug",
+			margin: "0",
+		});
+	});
+
+	it("should have size variants", () => {
+		const s = createInstance();
+		const recipe = useMediaTitleRecipe(s);
+
+		expect(recipe.variants!.size).toEqual({
+			sm: { fontSize: "@font-size.sm" },
+			md: { fontSize: "@font-size.md" },
+			lg: { fontSize: "@font-size.lg" },
+		});
+	});
+
+	it("should have correct default variants", () => {
+		const s = createInstance();
+		const recipe = useMediaTitleRecipe(s);
+
+		expect(recipe.defaultVariants).toEqual({
+			size: "md",
+		});
+	});
+
+	it("should not have compound variants", () => {
+		const s = createInstance();
+		const recipe = useMediaTitleRecipe(s);
+
+		expect(recipe.compoundVariants).toBeUndefined();
+	});
+
+	describe("config overrides", () => {
+		it("should allow overriding base styles", () => {
+			const s = createInstance();
+			const recipe = useMediaTitleRecipe(s, {
+				base: { fontWeight: "@font-weight.bold" },
+			});
+
+			expect(recipe.base!.fontWeight).toBe("@font-weight.bold");
+			expect(recipe.base!.margin).toBe("0");
+		});
+	});
+
+	describe("filter", () => {
+		it("should filter size variants", () => {
+			const s = createInstance();
+			const recipe = useMediaTitleRecipe(s, {
+				filter: { size: ["lg"] },
+			});
+
+			expect(Object.keys(recipe.variants!.size)).toEqual(["lg"]);
+		});
+
+		it("should adjust default variants when filtered out", () => {
+			const s = createInstance();
+			const recipe = useMediaTitleRecipe(s, {
+				filter: { size: ["sm"] },
+			});
+
+			expect(recipe.defaultVariants?.size).toBeUndefined();
+		});
+	});
+});

--- a/theme/src/recipes/media/useMediaTitleRecipe.ts
+++ b/theme/src/recipes/media/useMediaTitleRecipe.ts
@@ -1,0 +1,29 @@
+import { createUseRecipe } from "../../utils/createUseRecipe";
+
+/**
+ * Media title recipe — heading typography for the media body. Element-agnostic:
+ * apply to any heading tag (`<h3>`, `<h4>`, `<strong>`) chosen for document outline.
+ */
+export const useMediaTitleRecipe = createUseRecipe("media-title", {
+	base: {
+		fontWeight: "@font-weight.semibold",
+		lineHeight: "@line-height.snug",
+		margin: "0",
+	},
+	variants: {
+		size: {
+			sm: {
+				fontSize: "@font-size.sm",
+			},
+			md: {
+				fontSize: "@font-size.md",
+			},
+			lg: {
+				fontSize: "@font-size.lg",
+			},
+		},
+	},
+	defaultVariants: {
+		size: "md",
+	},
+});


### PR DESCRIPTION
## Summary

Adds a layout-only multi-part `Media` recipe modeled on the Bootstrap/Inkline media object — image/avatar alongside text content for comments, posts, and list items. Root recipe exposes `orientation` (horizontal/vertical), `align` (start/center/end), and `size` axes; sub-recipes for `media-figure`, `media-body` (with `minWidth: 0` for safe text wrapping), and `media-title` each expose a `size` axis. No color or surface styling — composes cleanly inside other containers. Vitest coverage for all four recipes (metadata, base, variants, defaults, config overrides, filter). Storybook showcase and docs pages will follow in subsequent commits to this branch.

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] `pnpm --filter @styleframe/theme test` passes (4 new test files)
- [ ] `pnpm lint` passes
- [ ] `import { media, mediaFigure, mediaBody, mediaTitle } from '@styleframe/theme'` resolves cleanly