### PR TITLE
ci: add dedicated build jobs for playground, storybook, and app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,7 @@ jobs:
     build-playground:
         name: Build Playground
         runs-on: ubuntu-latest
+        needs: build
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -122,6 +123,12 @@ jobs:
 
             - name: Install dependencies
               run: pnpm install --frozen-lockfile
+
+            - name: Download build artifacts
+              uses: actions/download-artifact@v5
+              with:
+                  name: build-artifacts
+                  path: .
 
             - name: Build playground
               run: pnpm build --filter '@styleframe/playground'
@@ -139,6 +146,7 @@ jobs:
     build-storybook:
         name: Build Storybook
         runs-on: ubuntu-latest
+        needs: build
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -156,6 +164,12 @@ jobs:
 
             - name: Install dependencies
               run: pnpm install --frozen-lockfile
+
+            - name: Download build artifacts
+              uses: actions/download-artifact@v5
+              with:
+                  name: build-artifacts
+                  path: .
 
             - name: Build storybook
               run: pnpm build --filter '@styleframe/storybook'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
               run: pnpm install --frozen-lockfile
 
             - name: Build packages
-              run: pnpm build --filter '!@styleframe/docs'
+              run: pnpm build --filter '!@styleframe/docs' --filter '!@styleframe/playground' --filter '!@styleframe/storybook' --filter '!@styleframe/app'
               env:
                   NODE_ENV: production
 
@@ -94,11 +94,115 @@ jobs:
 
             - name: Upload docs build
               uses: actions/upload-artifact@v4
-              with: 
+              with:
                   name: docs-build
                   path: |
                       apps/docs/.nuxt
                       apps/docs/.output
+                  retention-days: 7
+
+    # Build playground separately
+    build-playground:
+        name: Build Playground
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v4
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ env.NODE_VERSION }}
+                  cache: "pnpm"
+
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Build playground
+              run: pnpm build --filter '@styleframe/playground'
+              env:
+                  NODE_ENV: production
+
+            - name: Upload playground build
+              uses: actions/upload-artifact@v4
+              with:
+                  name: playground-build
+                  path: apps/playground/dist
+                  retention-days: 7
+
+    # Build storybook separately
+    build-storybook:
+        name: Build Storybook
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v4
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ env.NODE_VERSION }}
+                  cache: "pnpm"
+
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Build storybook
+              run: pnpm build --filter '@styleframe/storybook'
+              env:
+                  NODE_ENV: production
+
+            - name: Upload storybook build
+              uses: actions/upload-artifact@v4
+              with:
+                  name: storybook-build
+                  path: apps/storybook/storybook-static
+                  retention-days: 7
+
+    # Build app separately
+    build-app:
+        name: Build App
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v4
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ env.NODE_VERSION }}
+                  cache: "pnpm"
+
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Build app
+              run: pnpm build --filter '@styleframe/app'
+              env:
+                  NODE_ENV: production
+
+            - name: Upload app build
+              uses: actions/upload-artifact@v4
+              with:
+                  name: app-build
+                  path: |
+                      apps/app/.nuxt
+                      apps/app/.output
                   retention-days: 7
 
     # Lint job - runs oxlint and biome format check
@@ -254,7 +358,17 @@ jobs:
         name: CI Success
         runs-on: ubuntu-latest
         needs:
-            [build, build-docs, lint, typecheck, unit-tests, integration-tests]
+            [
+                build,
+                build-docs,
+                build-playground,
+                build-storybook,
+                build-app,
+                lint,
+                typecheck,
+                unit-tests,
+                integration-tests,
+            ]
         if: always()
         steps:
             - name: Check job status


### PR DESCRIPTION
## Summary

- Adds three new CI jobs — `build-playground`, `build-storybook`, and `build-app` — mirroring the existing `build-docs` pattern, each producing its own status check and uploading its output as a named artifact (`playground-build`, `storybook-build`, `app-build`).
- Narrows the main `build` job filter to exclude docs, playground, storybook, and app, since those now have dedicated jobs.
- Adds the new jobs to the `ci-success` gate.

## Test plan

- [ ] CI run on this PR shows three new checks: Build Playground, Build Storybook, Build App
- [ ] Each new job uploads its artifact and succeeds
- [ ] `CI Success` reflects all five build jobs in its `needs` list