### PR TITLE
chore: lint GitHub Actions with actionlint via lint-staged

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -486,6 +486,17 @@ Before renaming or changing a function signature, use `findReferences` to find a
 
 ---
 
+## Local Tooling
+
+**GitHub Actions linting:** Editing files under `.github/workflows/` runs [actionlint](https://github.com/rhysd/actionlint) via lint-staged on pre-commit. Install it once locally so the hook can run:
+
+- macOS: `brew install actionlint`
+- Other platforms: see https://github.com/rhysd/actionlint/blob/main/docs/install.md
+
+Run `pnpm lint:actions` to lint all workflows manually.
+
+---
+
 ## Package-Specific Guides
 
 Each package has its own AGENTS.md with detailed API reference, types, and conventions:

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"test:integration": "turbo run start --filter './testing/integration'",
 		"typecheck": "turbo run typecheck",
 		"lint": "oxlint",
+		"lint:actions": "actionlint",
 		"format:check": "biome format",
 		"format": "biome format --write",
 		"prepare": "husky",
@@ -63,6 +64,9 @@
 		],
 		"*.{js,ts,jsx,tsx}": [
 			"oxlint --fix"
+		],
+		".github/workflows/*.{yml,yaml}": [
+			"actionlint"
 		]
 	},
 	"license": "MIT"


### PR DESCRIPTION
## Summary

- Add a lint-staged glob for `.github/workflows/*.{yml,yaml}` that runs [actionlint](https://github.com/rhysd/actionlint) on pre-commit, so workflow bugs get caught locally before they reach CI.
- Add a `pnpm lint:actions` script for manual runs.
- Document the `brew install actionlint` prerequisite in `AGENTS.md`.

Local-only by design — no CI workflow changes, no new npm dependency, no new husky hooks (the existing `.husky/pre-commit` already runs `lint-staged`).

## Test plan

- [x] `pnpm lint:actions` runs cleanly on the existing two workflows
- [ ] Stage a deliberately broken workflow change → pre-commit fails with actionlint output
- [ ] Stage an unrelated source file change → actionlint is not invoked