### PR TITLE
feat(theme): add pagination recipe

### DIFF
--- a/.changeset/add-pagination-recipe.md
+++ b/.changeset/add-pagination-recipe.md
@@ -1,0 +1,6 @@
+---
+"@styleframe/theme": minor
+"styleframe": minor
+---
+
+Add pagination recipe with `usePaginationRecipe`, `usePaginationItemRecipe`, and `usePaginationEllipsisRecipe`. Supports 3 color modes (light, dark, neutral), 6 style variants (solid, outline, soft, subtle, ghost, link), 3 sizes (sm, md, lg), and active/disabled item states.

--- a/apps/docs/content/docs/04.components/02.composables/15.pagination.md
+++ b/apps/docs/content/docs/04.components/02.composables/15.pagination.md
@@ -1,0 +1,590 @@
+---
+title: Pagination
+description: A navigation component for moving between pages of content. Supports horizontal and vertical orientations, three colors, six visual styles, three sizes, and active/disabled states through a three-part recipe system.
+---
+
+## Overview
+
+The **Pagination** is a navigation component used for moving between pages of a result set such as tables, search results, and content listings. It is composed of three recipe parts: `usePaginationRecipe()` for the container that controls layout direction and spacing, `usePaginationItemRecipe()` for individual page-number buttons with color, variant, and interactive state options, and `usePaginationEllipsisRecipe()` for the non-interactive `…` element that collapses long page ranges. Each composable creates a fully configured [recipe](/docs/api/recipes) with compound variants that handle the color-variant combinations automatically.
+
+The Pagination recipes integrate directly with the default [design tokens preset](/docs/theme/design-tokens/presets) and generate type-safe utility classes at build time with zero runtime CSS.
+
+## Why use the Pagination recipe?
+
+The Pagination recipe helps you:
+
+- **Ship faster with sensible defaults**: Get 2 orientations, 3 colors, 6 visual styles, and 3 sizes out of the box with three composable calls.
+- **Compose flexible navigation**: Three coordinated recipes (container, item, ellipsis) share the size axis, so your pagination stays internally consistent.
+- **Maintain consistency**: Compound variants ensure every color-variant combination follows the same design rules, including hover, focus, active, and dark mode states.
+- **Customize without forking**: Override base styles, default variants, or filter out options you don't need &mdash; all through the options API.
+- **Stay type-safe**: Full TypeScript support means your editor catches invalid color, variant, or size values at compile time.
+- **Integrate with your tokens**: Every value references the design tokens preset, so theme changes propagate automatically.
+
+## Usage
+
+::steps{level="4"}
+
+#### Register the recipes
+
+Add the Pagination recipes to a local Styleframe instance. The global `styleframe.config.ts` provides design tokens and utilities, while the component-level file registers the recipes themselves:
+
+:::code-tree{default-value="src/components/pagination.styleframe.ts"}
+
+```ts [src/components/pagination.styleframe.ts]
+import { styleframe } from 'virtual:styleframe';
+import {
+    usePaginationRecipe,
+    usePaginationItemRecipe,
+    usePaginationEllipsisRecipe,
+} from '@styleframe/theme';
+
+const s = styleframe();
+
+const pagination = usePaginationRecipe(s);
+const paginationItem = usePaginationItemRecipe(s);
+const paginationEllipsis = usePaginationEllipsisRecipe(s);
+
+export default s;
+```
+
+```ts [styleframe.config.ts]
+import { styleframe } from 'styleframe';
+import { useDesignTokensPreset, useUtilitiesPreset } from '@styleframe/theme';
+
+const s = styleframe();
+
+useDesignTokensPreset(s);
+useUtilitiesPreset(s);
+
+export default s;
+```
+
+:::
+
+#### Build the component
+
+Import the `pagination`, `paginationItem`, and `paginationEllipsis` runtime functions from the virtual module and pass variant props to compute class names:
+
+:::tabs
+::::tabs-item{icon="i-devicon-react" label="React"}
+
+```ts [src/components/Pagination.tsx]
+import { pagination, paginationItem, paginationEllipsis } from "virtual:styleframe";
+
+interface PaginationProps {
+    orientation?: "horizontal" | "vertical";
+    size?: "sm" | "md" | "lg";
+    children?: React.ReactNode;
+}
+
+interface PaginationItemProps {
+    color?: "light" | "dark" | "neutral";
+    variant?: "solid" | "outline" | "soft" | "subtle" | "ghost" | "link";
+    size?: "sm" | "md" | "lg";
+    active?: boolean;
+    disabled?: boolean;
+    href?: string;
+    "aria-label"?: string;
+    children?: React.ReactNode;
+}
+
+export function Pagination({
+    orientation = "horizontal",
+    size = "md",
+    children,
+}: PaginationProps) {
+    return (
+        <nav
+            className={pagination({ orientation, size })}
+            role="navigation"
+            aria-label="Pagination"
+        >
+            {children}
+        </nav>
+    );
+}
+
+export function PaginationItem({
+    color = "neutral",
+    variant = "ghost",
+    size = "md",
+    active = false,
+    disabled = false,
+    href,
+    children,
+    ...rest
+}: PaginationItemProps) {
+    const classes = paginationItem({
+        color,
+        variant,
+        size,
+        active: active ? "true" : "false",
+        disabled: disabled ? "true" : "false",
+    });
+    const Tag = href ? "a" : "button";
+    return (
+        <Tag
+            className={classes}
+            href={href && !disabled ? href : undefined}
+            disabled={!href && disabled ? true : undefined}
+            aria-current={active ? "page" : undefined}
+            aria-disabled={disabled || undefined}
+            {...rest}
+        >
+            {children}
+        </Tag>
+    );
+}
+
+export function PaginationEllipsis({ size = "md" }: { size?: "sm" | "md" | "lg" }) {
+    return (
+        <span className={paginationEllipsis({ size })} aria-hidden="true">
+            …
+        </span>
+    );
+}
+```
+
+::::
+::::tabs-item{icon="i-devicon-vuejs" label="Vue"}
+
+```vue [src/components/Pagination.vue]
+<script setup lang="ts">
+import { pagination } from "virtual:styleframe";
+
+const {
+    orientation = "horizontal",
+    size = "md",
+} = defineProps<{
+    orientation?: "horizontal" | "vertical";
+    size?: "sm" | "md" | "lg";
+}>();
+</script>
+
+<template>
+    <nav
+        :class="pagination({ orientation, size })"
+        role="navigation"
+        aria-label="Pagination"
+    >
+        <slot />
+    </nav>
+</template>
+```
+
+```vue [src/components/PaginationItem.vue]
+<script setup lang="ts">
+import { paginationItem } from "virtual:styleframe";
+
+const {
+    color = "neutral",
+    variant = "ghost",
+    size = "md",
+    active = false,
+    disabled = false,
+    href,
+} = defineProps<{
+    color?: "light" | "dark" | "neutral";
+    variant?: "solid" | "outline" | "soft" | "subtle" | "ghost" | "link";
+    size?: "sm" | "md" | "lg";
+    active?: boolean;
+    disabled?: boolean;
+    href?: string;
+}>();
+</script>
+
+<template>
+    <a
+        v-if="href !== undefined"
+        :class="paginationItem({ color, variant, size, active: active ? 'true' : 'false', disabled: disabled ? 'true' : 'false' })"
+        :href="disabled ? undefined : href"
+        :aria-current="active ? 'page' : undefined"
+        :aria-disabled="disabled || undefined"
+    >
+        <slot />
+    </a>
+    <button
+        v-else
+        type="button"
+        :class="paginationItem({ color, variant, size, active: active ? 'true' : 'false', disabled: disabled ? 'true' : 'false' })"
+        :disabled="disabled"
+        :aria-current="active ? 'page' : undefined"
+    >
+        <slot />
+    </button>
+</template>
+```
+
+```vue [src/components/PaginationEllipsis.vue]
+<script setup lang="ts">
+import { paginationEllipsis } from "virtual:styleframe";
+
+const { size = "md" } = defineProps<{
+    size?: "sm" | "md" | "lg";
+}>();
+</script>
+
+<template>
+    <span :class="paginationEllipsis({ size })" aria-hidden="true">…</span>
+</template>
+```
+
+::::
+:::
+
+#### See it in action
+
+:::story-preview
+---
+story: theme-recipes-pagination--default
+panel: true
+---
+:::
+
+::
+
+## Orientation
+
+The Pagination container recipe supports two orientations that control the flex layout direction. Horizontal arranges items in a row (the default and most common pagination layout), while vertical stacks items in a column for sidebar-style page lists.
+
+::story-preview
+---
+story: theme-recipes-pagination--horizontal
+panel: true
+---
+::
+
+::story-preview
+---
+story: theme-recipes-pagination--vertical
+panel: true
+---
+::
+
+## Colors
+
+The Pagination Item recipe includes 3 color variants: `light`, `dark`, and `neutral`. These match the Container color pattern used by Card, Modal, and Tooltip &mdash; surface-spectrum colors designed for navigation chrome rather than status communication. Each color is combined with every visual style variant through compound variants, so you get consistent, predictable styling across all combinations &mdash; including hover, focus, active, and dark mode states.
+
+The `neutral` color adapts automatically: it uses a light appearance in light mode and a dark appearance in dark mode, making it the safest default for general-purpose pagination.
+
+::story-preview
+---
+story: theme-recipes-pagination--neutral
+panel: true
+---
+::
+
+### Color Reference
+
+::story-preview
+---
+story: theme-recipes-pagination--all-variants
+height: 480
+---
+::
+
+| Color | Token | Use Case |
+|-------|-------|----------|
+| `light` | `@color.white` / `@color.gray-*` | Light surfaces, stays light in dark mode |
+| `dark` | `@color.gray-900` | Dark surfaces, stays dark in light mode |
+| `neutral` | Adaptive (light &harr; dark) | Default color, adapts to the current color scheme |
+
+::tip
+**Pro tip:** Use `neutral` as your default pagination color. It adapts automatically to the user's color scheme, so you don't need to manage light and dark variants separately.
+::
+
+## Variants
+
+Six visual style variants control how the page-number items are rendered. Each variant is combined with the selected color through [compound variants](/docs/api/recipes#compound-variants), so you always get the correct background, text, and border colors for your chosen color.
+
+### Solid
+
+Filled background with contrasting text. The most prominent style, ideal when pagination is the primary navigation control on the page.
+
+::story-preview
+---
+story: theme-recipes-pagination--solid
+panel: true
+---
+::
+
+### Outline
+
+Transparent background with colored border and text. Useful when the pagination should remain visible without dominating the layout.
+
+::story-preview
+---
+story: theme-recipes-pagination--outline
+panel: true
+---
+::
+
+### Soft
+
+Light tinted background with no visible border. A subtle but visible style that works well for grouped pagination in dense table headers.
+
+::story-preview
+---
+story: theme-recipes-pagination--soft
+panel: true
+---
+::
+
+### Subtle
+
+Light tinted background with a matching border. Combines the softness of `soft` with added visual definition from a border.
+
+::story-preview
+---
+story: theme-recipes-pagination--subtle
+panel: true
+---
+::
+
+### Ghost
+
+Transparent background that reveals a tinted background on hover. The default variant &mdash; ideal when pagination should appear as plain text until interaction.
+
+::story-preview
+---
+story: theme-recipes-pagination--ghost
+panel: true
+---
+::
+
+### Link
+
+Styled as inline text links with no background or border. On hover, the text darkens and gains an underline. Use when pagination should look like ordinary navigation links.
+
+::story-preview
+---
+story: theme-recipes-pagination--link
+panel: true
+---
+::
+
+## Sizes
+
+Three size variants from `sm` to `lg` control the font size, padding, and gap of the items, the ellipsis, and the container. Pass the same `size` value to all three sub-recipes so heights stay aligned.
+
+::story-preview
+---
+story: theme-recipes-pagination--all-sizes
+height: 320
+---
+::
+
+| Size | Item Font Size | Item Padding (V / H) | Container Gap |
+|------|----------------|----------------------|---------------|
+| `sm` | `@font-size.sm` | `@0.375` / `@0.625` | `@0.25` |
+| `md` | `@font-size.sm` | `@0.5` / `@0.75` | `@0.375` |
+| `lg` | `@font-size.md` | `@0.625` / `@0.875` | `@0.5` |
+
+::note
+**Good to know:** The `size` prop must be passed to each sub-recipe individually. The container controls the gap and overall scale, while each item and ellipsis manages its own padding and font size.
+::
+
+## Anatomy
+
+The Pagination recipe is composed of three independent recipes that work together to form a navigation row:
+
+| Part | Recipe | Role |
+|------|--------|------|
+| **Container** | `usePaginationRecipe()` | Outer `<nav>` flex container that controls orientation and gap |
+| **Item** | `usePaginationItemRecipe()` | Individual page-number button (also used for prev/next/first/last with icon content) |
+| **Ellipsis** | `usePaginationEllipsisRecipe()` | Non-interactive `<span>` that renders `…` between page ranges |
+
+Each part is a standalone recipe with its own set of variants. The `color` and `variant` props belong to the item recipe, since the container is purely structural and the ellipsis is always neutral. Pass the `size` prop consistently to the container and every item / ellipsis so heights line up.
+
+```html
+<!-- All three parts working together -->
+<nav class="pagination(...)" role="navigation" aria-label="Pagination">
+    <button class="paginationItem(...)" aria-label="Previous page">‹</button>
+    <a class="paginationItem(...)" href="?page=1">1</a>
+    <a class="paginationItem(...) paginationItem--active-true" href="?page=2" aria-current="page">2</a>
+    <a class="paginationItem(...)" href="?page=3">3</a>
+    <span class="paginationEllipsis(...)" aria-hidden="true">…</span>
+    <a class="paginationItem(...)" href="?page=9">9</a>
+    <button class="paginationItem(...)" aria-label="Next page">›</button>
+</nav>
+```
+
+::tip
+**Pro tip:** Prev / Next / First / Last controls are not separate recipes &mdash; render them as `<PaginationItem>` instances with an icon child (`‹`, `›`, `«`, `»`) and an `aria-label`. The item recipe handles their styling automatically, including the disabled state for "previous on page 1" and "next on the last page".
+::
+
+## Accessibility
+
+- **Use a `<nav>` landmark.** The container should render as `<nav>` with `role="navigation"` (implicit on `<nav>`) and an `aria-label="Pagination"` so assistive technologies announce it as a distinct navigation region.
+- **Mark the current page.** Add `aria-current="page"` to the active item. Screen readers announce "current page" alongside the page number.
+- **Label the prev/next/first/last controls.** These items typically render with icon content (`‹`, `›`, `«`, `»`). Add an explicit `aria-label="Previous page"`, `"Next page"`, `"First page"`, or `"Last page"` so the control has an accessible name.
+- **Hide the ellipsis from assistive tech.** The ellipsis is purely visual. Set `aria-hidden="true"` so screen readers skip it instead of announcing "horizontal ellipsis".
+- **Disable, don't hide.** When the user is on the first page, mark the previous control with `disabled` (button) or `aria-disabled="true"` (anchor) instead of removing it. Layout stability prevents the page numbers from shifting.
+- **Keyboard navigation.** Items render as `<button>` or `<a>`, which are natively focusable and activatable with `Enter` / `Space`. The `:focus-visible` ring in the recipe base styles ensures the current focus is always visible.
+
+## Customization
+
+### Overriding Defaults
+
+Each pagination composable accepts an optional second argument to override any part of the recipe configuration. Overrides are deep-merged with the defaults, so you only need to specify the properties you want to change:
+
+```ts [src/components/pagination.styleframe.ts]
+import { styleframe } from 'virtual:styleframe';
+import {
+    usePaginationRecipe,
+    usePaginationItemRecipe,
+    usePaginationEllipsisRecipe,
+} from '@styleframe/theme';
+
+const s = styleframe();
+
+const pagination = usePaginationRecipe(s, {
+    defaultVariants: {
+        orientation: 'horizontal',
+        size: 'lg',
+    },
+});
+
+const paginationItem = usePaginationItemRecipe(s, {
+    base: { borderRadius: '@border-radius.full' },
+    defaultVariants: {
+        color: 'neutral',
+        variant: 'soft',
+        size: 'lg',
+        active: 'false',
+        disabled: 'false',
+    },
+});
+
+const paginationEllipsis = usePaginationEllipsisRecipe(s, {
+    defaultVariants: { size: 'lg' },
+});
+
+export default s;
+```
+
+### Filtering Variants
+
+If you only need a subset of the available variants, use the `filter` option to limit which values are generated. This reduces the output CSS and keeps your component API focused:
+
+```ts [src/components/pagination.styleframe.ts]
+import { styleframe } from 'virtual:styleframe';
+import { usePaginationItemRecipe } from '@styleframe/theme';
+
+const s = styleframe();
+
+// Only generate neutral color with ghost and solid styles
+const paginationItem = usePaginationItemRecipe(s, {
+    filter: {
+        color: ['neutral'],
+        variant: ['ghost', 'solid'],
+    },
+});
+
+export default s;
+```
+
+::note
+**Good to know:** Filtering also removes compound variants and adjusts default variants that reference filtered-out values, so your recipe stays consistent.
+::
+
+## API Reference
+
+### `usePaginationRecipe(s, options?)`
+
+Creates the pagination container recipe with `<nav>`-friendly base styles, an orientation axis, and a size axis.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `s` | `Styleframe` | The Styleframe instance |
+| `options` | `DeepPartial<RecipeConfig>` | Optional overrides for the recipe configuration |
+| `options.base` | `VariantDeclarationsBlock` | Custom base styles for the pagination container |
+| `options.variants` | `Variants` | Custom variant definitions for the recipe |
+| `options.defaultVariants` | `Record<keyof Variants, string>` | Default variant values for the recipe |
+| `options.compoundVariants` | `CompoundVariant[]` | Custom compound variant definitions for the recipe |
+| `options.filter` | `Record<string, string[]>` | Limit which variant values are generated |
+
+**Variants:**
+
+| Variant | Options | Default |
+|---------|---------|---------|
+| `orientation` | `horizontal`, `vertical` | `horizontal` |
+| `size` | `sm`, `md`, `lg` | `md` |
+
+### `usePaginationItemRecipe(s, options?)`
+
+Creates the pagination item recipe for individual page-number buttons. Renders consistently as a `<button>` or `<a>` and supports the full Interactive variant set plus boolean `active` and `disabled` axes.
+
+**Parameters:** identical to `usePaginationRecipe`.
+
+**Variants:**
+
+| Variant | Options | Default |
+|---------|---------|---------|
+| `color` | `light`, `dark`, `neutral` | `neutral` |
+| `variant` | `solid`, `outline`, `soft`, `subtle`, `ghost`, `link` | `ghost` |
+| `size` | `sm`, `md`, `lg` | `md` |
+| `active` | `true`, `false` | `false` |
+| `disabled` | `true`, `false` | `false` |
+
+### `usePaginationEllipsisRecipe(s, options?)`
+
+Creates the pagination ellipsis recipe for the non-interactive `…` element. Always renders with the `@color.text-weak` token; only the size axis is exposed.
+
+**Parameters:** identical to `usePaginationRecipe`.
+
+**Variants:**
+
+| Variant | Options | Default |
+|---------|---------|---------|
+| `size` | `sm`, `md`, `lg` | `md` |
+
+[Learn more about recipes &rarr;](/docs/api/recipes)
+
+## Best Practices
+
+- **Always wrap pagination in a `<nav>`**: The container renders as a navigation landmark with `aria-label="Pagination"` so assistive tech can jump straight to it.
+- **Mark the current page with `aria-current="page"`**: Set it on the item with `active=true` so screen readers announce the current position in the page list.
+- **Pass `size` to every sub-recipe**: The container, items, and ellipsis each manage their own dimensions. Skipping one breaks vertical alignment.
+- **Style the active page distinctly**: The default `active` axis only bumps font-weight to semibold. For a stronger highlight, pass `variant="solid"` to the active item while siblings stay on `ghost` &mdash; see the [active-vs-inactive contrast example](#).
+- **Disable, don't hide, the edge controls**: When the user is on the first or last page, set `disabled` on the corresponding prev/next/first/last item rather than removing it. Layout stability beats minor space savings.
+- **Filter what you don't need**: Pass a `filter` option (e.g., `color: ['neutral']`) to reduce generated CSS in projects that only use one color.
+- **Override defaults at the recipe level**: If your pagination is always large and outlined, set those as `defaultVariants` so component consumers write less code.
+
+## FAQ
+
+::accordion
+
+:::accordion-item{label="Why are there three separate recipes instead of one?" icon="i-lucide-circle-help"}
+Pagination items have a fundamentally different shape from the container and the ellipsis &mdash; items are interactive buttons with hover/focus/active/disabled states, the container is a structural flex layout, and the ellipsis is a low-emphasis static element. Three separate recipes give each part its own base styles and compound variants while sharing the same `size` axis, keeping each recipe focused and letting you compose only the parts you need.
+:::
+
+:::accordion-item{label="How do I render Previous, Next, First, and Last controls?" icon="i-lucide-circle-help"}
+There is no separate prev/next recipe &mdash; render those controls as ordinary `<PaginationItem>` instances with an icon child (`‹`, `›`, `«`, `»`) and an explicit `aria-label`. The item recipe handles their styling and disabled state automatically. The `WithControls` story demonstrates the full layout with both edge and step controls.
+:::
+
+:::accordion-item{label="Why doesn't the Pagination Item recipe include semantic colors like primary or success?" icon="i-lucide-circle-help"}
+Pagination is a navigation chrome element, not a status indicator. Semantic colors (primary, success, error) communicate meaning through color, which is better suited to action-oriented elements like buttons and badges. Pagination uses `light`, `dark`, and `neutral` to provide surface variations that work across all content types without implying a specific status.
+:::
+
+:::accordion-item{label="What's the difference between the active boolean axis and passing a different variant for the current page?" icon="i-lucide-circle-help"}
+Both work. The `active` axis bumps the item's `font-weight` to `semibold` &mdash; a subtle highlight that stays consistent with the rest of the row. For a stronger visual treatment, pass a different `variant` to the active item (for example, `solid` while siblings stay on `ghost`). The two approaches compose: you can set both `active=true` and a different `variant` on the same item.
+:::
+
+:::accordion-item{label="How do I keep the ellipsis vertically aligned with the page numbers?" icon="i-lucide-circle-help"}
+Pass the same `size` prop to `<PaginationEllipsis>` as to your `<PaginationItem>` instances. The ellipsis recipe sets `display: inline-flex` with `align-items: center` and matches the items' vertical padding, so passing the same size keeps everything on the same baseline.
+:::
+
+:::accordion-item{label="How do compound variants work in this recipe?" icon="i-lucide-circle-help"}
+The Pagination Item recipe uses compound variants to map each color-variant combination to specific styles. For example, when `color` is `neutral` and `variant` is `ghost`, the compound variant applies `color: @color.text` plus hover, focus, and active backgrounds, with dark mode overrides that switch text color and backgrounds. This keeps the individual `color` and `variant` definitions clean while handling all 18 combinations (3 colors &times; 6 variants) automatically.
+
+[Learn more about compound variants &rarr;](/docs/api/recipes#compound-variants)
+:::
+
+:::accordion-item{label="How does filtering affect compound variants?" icon="i-lucide-circle-help"}
+When you use the `filter` option, compound variants that reference filtered-out values are automatically removed. For example, if you filter `variant` to only `['ghost', 'solid']`, all compound variants matching `outline`, `soft`, `subtle`, or `link` are excluded from the generated output. Default variants are also adjusted if they reference a removed value.
+:::
+
+::

--- a/apps/storybook/src/components/components/pagination/Pagination.vue
+++ b/apps/storybook/src/components/components/pagination/Pagination.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import { pagination } from "virtual:styleframe";
+
+const props = withDefaults(
+	defineProps<{
+		orientation?: "horizontal" | "vertical";
+		size?: "sm" | "md" | "lg";
+	}>(),
+	{},
+);
+</script>
+
+<template>
+	<nav
+		:class="
+			pagination({
+				orientation: props.orientation,
+				size: props.size,
+			})
+		"
+		role="navigation"
+		aria-label="Pagination"
+	>
+		<slot />
+	</nav>
+</template>

--- a/apps/storybook/src/components/components/pagination/PaginationEllipsis.vue
+++ b/apps/storybook/src/components/components/pagination/PaginationEllipsis.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import { paginationEllipsis } from "virtual:styleframe";
+
+const props = withDefaults(
+	defineProps<{
+		size?: "sm" | "md" | "lg";
+	}>(),
+	{},
+);
+</script>
+
+<template>
+	<span
+		:class="paginationEllipsis({ size: props.size })"
+		aria-hidden="true"
+	>
+		<slot>…</slot>
+	</span>
+</template>

--- a/apps/storybook/src/components/components/pagination/PaginationItem.vue
+++ b/apps/storybook/src/components/components/pagination/PaginationItem.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import { paginationItem } from "virtual:styleframe";
+
+const props = withDefaults(
+	defineProps<{
+		color?: "light" | "dark" | "neutral";
+		variant?: "solid" | "outline" | "soft" | "subtle" | "ghost" | "link";
+		size?: "sm" | "md" | "lg";
+		active?: boolean;
+		disabled?: boolean;
+		href?: string;
+		ariaLabel?: string;
+	}>(),
+	{},
+);
+</script>
+
+<template>
+	<a
+		v-if="props.href !== undefined"
+		:class="
+			paginationItem({
+				color: props.color,
+				variant: props.variant,
+				size: props.size,
+				active: props.active ? 'true' : 'false',
+				disabled: props.disabled ? 'true' : 'false',
+			})
+		"
+		:href="props.disabled ? undefined : props.href"
+		:aria-current="props.active ? 'page' : undefined"
+		:aria-disabled="props.disabled || undefined"
+		:aria-label="props.ariaLabel"
+	>
+		<slot />
+	</a>
+	<button
+		v-else
+		type="button"
+		:class="
+			paginationItem({
+				color: props.color,
+				variant: props.variant,
+				size: props.size,
+				active: props.active ? 'true' : 'false',
+				disabled: props.disabled ? 'true' : 'false',
+			})
+		"
+		:disabled="props.disabled"
+		:aria-current="props.active ? 'page' : undefined"
+		:aria-label="props.ariaLabel"
+	>
+		<slot />
+	</button>
+</template>

--- a/apps/storybook/src/components/components/pagination/preview/PaginationGrid.vue
+++ b/apps/storybook/src/components/components/pagination/preview/PaginationGrid.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import Pagination from "../Pagination.vue";
+import PaginationItem from "../PaginationItem.vue";
+import PaginationEllipsis from "../PaginationEllipsis.vue";
+
+const colors = ["light", "dark", "neutral"] as const;
+const variants = [
+	"solid",
+	"outline",
+	"soft",
+	"subtle",
+	"ghost",
+	"link",
+] as const;
+</script>
+
+<template>
+	<div class="pagination-section">
+		<div v-for="variant in variants" :key="variant">
+			<hr />
+			<div class="pagination-label">{{ variant }}</div>
+			<hr />
+			<div class="pagination-row">
+				<div v-for="color in colors" :key="`${variant}-${color}`">
+					<Pagination>
+						<PaginationItem
+							:color="color"
+							:variant="variant"
+							href="#"
+							aria-label="Previous page"
+						>
+							‹
+						</PaginationItem>
+						<PaginationItem :color="color" :variant="variant" href="#">
+							1
+						</PaginationItem>
+						<PaginationItem :color="color" :variant="variant" href="#" active>
+							2
+						</PaginationItem>
+						<PaginationItem :color="color" :variant="variant" href="#">
+							3
+						</PaginationItem>
+						<PaginationEllipsis />
+						<PaginationItem :color="color" :variant="variant" href="#">
+							9
+						</PaginationItem>
+						<PaginationItem
+							:color="color"
+							:variant="variant"
+							href="#"
+							aria-label="Next page"
+						>
+							›
+						</PaginationItem>
+					</Pagination>
+				</div>
+			</div>
+		</div>
+	</div>
+</template>

--- a/apps/storybook/src/components/components/pagination/preview/PaginationSizeGrid.vue
+++ b/apps/storybook/src/components/components/pagination/preview/PaginationSizeGrid.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import Pagination from "../Pagination.vue";
+import PaginationItem from "../PaginationItem.vue";
+import PaginationEllipsis from "../PaginationEllipsis.vue";
+
+const sizes = ["sm", "md", "lg"] as const;
+</script>
+
+<template>
+	<div class="pagination-section">
+		<div v-for="size in sizes" :key="size">
+			<div class="pagination-label">{{ size }}</div>
+			<Pagination :size="size">
+				<PaginationItem :size="size" href="#" aria-label="Previous page">
+					‹
+				</PaginationItem>
+				<PaginationItem :size="size" href="#">1</PaginationItem>
+				<PaginationItem :size="size" href="#" active>2</PaginationItem>
+				<PaginationItem :size="size" href="#">3</PaginationItem>
+				<PaginationEllipsis :size="size" />
+				<PaginationItem :size="size" href="#">9</PaginationItem>
+				<PaginationItem :size="size" href="#" aria-label="Next page">
+					›
+				</PaginationItem>
+			</Pagination>
+		</div>
+	</div>
+</template>

--- a/apps/storybook/stories/components/pagination.stories.ts
+++ b/apps/storybook/stories/components/pagination.stories.ts
@@ -1,0 +1,380 @@
+import type { Meta, StoryObj } from "@storybook/vue3-vite";
+
+import Pagination from "../../src/components/components/pagination/Pagination.vue";
+import PaginationItem from "../../src/components/components/pagination/PaginationItem.vue";
+import PaginationEllipsis from "../../src/components/components/pagination/PaginationEllipsis.vue";
+import PaginationGrid from "../../src/components/components/pagination/preview/PaginationGrid.vue";
+import PaginationSizeGrid from "../../src/components/components/pagination/preview/PaginationSizeGrid.vue";
+
+const colors = ["light", "dark", "neutral"] as const;
+const variants = [
+	"solid",
+	"outline",
+	"soft",
+	"subtle",
+	"ghost",
+	"link",
+] as const;
+const sizes = ["sm", "md", "lg"] as const;
+const orientations = ["horizontal", "vertical"] as const;
+
+const meta = {
+	title: "Theme/Recipes/Pagination",
+	component: Pagination,
+	tags: ["autodocs"],
+	parameters: {
+		layout: "padded",
+	},
+	argTypes: {
+		orientation: {
+			control: "select",
+			options: orientations,
+			description: "The orientation of the pagination",
+		},
+		size: {
+			control: "select",
+			options: sizes,
+			description: "The size",
+		},
+	},
+} satisfies Meta<typeof Pagination>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	render: (args) => ({
+		components: { Pagination, PaginationItem, PaginationEllipsis },
+		setup() {
+			return { args };
+		},
+		template: `
+			<Pagination v-bind="args">
+				<PaginationItem href="#" aria-label="Previous page">‹</PaginationItem>
+				<PaginationItem href="#">1</PaginationItem>
+				<PaginationItem href="#" active>2</PaginationItem>
+				<PaginationItem href="#">3</PaginationItem>
+				<PaginationEllipsis />
+				<PaginationItem href="#">9</PaginationItem>
+				<PaginationItem href="#" aria-label="Next page">›</PaginationItem>
+			</Pagination>
+		`,
+	}),
+};
+
+export const AllVariants: StoryObj = {
+	render: () => ({
+		components: { PaginationGrid },
+		template: "<PaginationGrid />",
+	}),
+};
+
+export const AllSizes: StoryObj = {
+	render: () => ({
+		components: { PaginationSizeGrid },
+		template: "<PaginationSizeGrid />",
+	}),
+};
+
+// Orientation stories
+
+export const Horizontal: Story = {
+	args: {
+		orientation: "horizontal",
+	},
+	render: (args) => ({
+		components: { Pagination, PaginationItem, PaginationEllipsis },
+		setup() {
+			return { args };
+		},
+		template: `
+			<Pagination v-bind="args">
+				<PaginationItem href="#">1</PaginationItem>
+				<PaginationItem href="#" active>2</PaginationItem>
+				<PaginationItem href="#">3</PaginationItem>
+				<PaginationEllipsis />
+				<PaginationItem href="#">9</PaginationItem>
+			</Pagination>
+		`,
+	}),
+};
+
+export const Vertical: Story = {
+	args: {
+		orientation: "vertical",
+	},
+	render: (args) => ({
+		components: { Pagination, PaginationItem, PaginationEllipsis },
+		setup() {
+			return { args };
+		},
+		template: `
+			<Pagination v-bind="args">
+				<PaginationItem href="#">1</PaginationItem>
+				<PaginationItem href="#" active>2</PaginationItem>
+				<PaginationItem href="#">3</PaginationItem>
+				<PaginationEllipsis />
+				<PaginationItem href="#">9</PaginationItem>
+			</Pagination>
+		`,
+	}),
+};
+
+// Color stories
+
+export const Light: Story = {
+	render: () => ({
+		components: { Pagination, PaginationItem, PaginationEllipsis },
+		template: `
+			<Pagination>
+				<PaginationItem color="light" href="#">1</PaginationItem>
+				<PaginationItem color="light" href="#" active>2</PaginationItem>
+				<PaginationItem color="light" href="#">3</PaginationItem>
+				<PaginationEllipsis />
+				<PaginationItem color="light" href="#">9</PaginationItem>
+			</Pagination>
+		`,
+	}),
+};
+
+export const Dark: Story = {
+	render: () => ({
+		components: { Pagination, PaginationItem, PaginationEllipsis },
+		template: `
+			<Pagination>
+				<PaginationItem color="dark" href="#">1</PaginationItem>
+				<PaginationItem color="dark" href="#" active>2</PaginationItem>
+				<PaginationItem color="dark" href="#">3</PaginationItem>
+				<PaginationEllipsis />
+				<PaginationItem color="dark" href="#">9</PaginationItem>
+			</Pagination>
+		`,
+	}),
+};
+
+export const Neutral: Story = {
+	render: () => ({
+		components: { Pagination, PaginationItem, PaginationEllipsis },
+		template: `
+			<Pagination>
+				<PaginationItem color="neutral" href="#">1</PaginationItem>
+				<PaginationItem color="neutral" href="#" active>2</PaginationItem>
+				<PaginationItem color="neutral" href="#">3</PaginationItem>
+				<PaginationEllipsis />
+				<PaginationItem color="neutral" href="#">9</PaginationItem>
+			</Pagination>
+		`,
+	}),
+};
+
+// Variant stories
+
+export const Solid: Story = {
+	render: () => ({
+		components: { Pagination, PaginationItem, PaginationEllipsis },
+		template: `
+			<Pagination>
+				<PaginationItem variant="solid" href="#">1</PaginationItem>
+				<PaginationItem variant="solid" href="#" active>2</PaginationItem>
+				<PaginationItem variant="solid" href="#">3</PaginationItem>
+				<PaginationEllipsis />
+				<PaginationItem variant="solid" href="#">9</PaginationItem>
+			</Pagination>
+		`,
+	}),
+};
+
+export const Outline: Story = {
+	render: () => ({
+		components: { Pagination, PaginationItem, PaginationEllipsis },
+		template: `
+			<Pagination>
+				<PaginationItem variant="outline" href="#">1</PaginationItem>
+				<PaginationItem variant="outline" href="#" active>2</PaginationItem>
+				<PaginationItem variant="outline" href="#">3</PaginationItem>
+				<PaginationEllipsis />
+				<PaginationItem variant="outline" href="#">9</PaginationItem>
+			</Pagination>
+		`,
+	}),
+};
+
+export const Soft: Story = {
+	render: () => ({
+		components: { Pagination, PaginationItem, PaginationEllipsis },
+		template: `
+			<Pagination>
+				<PaginationItem variant="soft" href="#">1</PaginationItem>
+				<PaginationItem variant="soft" href="#" active>2</PaginationItem>
+				<PaginationItem variant="soft" href="#">3</PaginationItem>
+				<PaginationEllipsis />
+				<PaginationItem variant="soft" href="#">9</PaginationItem>
+			</Pagination>
+		`,
+	}),
+};
+
+export const Subtle: Story = {
+	render: () => ({
+		components: { Pagination, PaginationItem, PaginationEllipsis },
+		template: `
+			<Pagination>
+				<PaginationItem variant="subtle" href="#">1</PaginationItem>
+				<PaginationItem variant="subtle" href="#" active>2</PaginationItem>
+				<PaginationItem variant="subtle" href="#">3</PaginationItem>
+				<PaginationEllipsis />
+				<PaginationItem variant="subtle" href="#">9</PaginationItem>
+			</Pagination>
+		`,
+	}),
+};
+
+export const Ghost: Story = {
+	render: () => ({
+		components: { Pagination, PaginationItem, PaginationEllipsis },
+		template: `
+			<Pagination>
+				<PaginationItem variant="ghost" href="#">1</PaginationItem>
+				<PaginationItem variant="ghost" href="#" active>2</PaginationItem>
+				<PaginationItem variant="ghost" href="#">3</PaginationItem>
+				<PaginationEllipsis />
+				<PaginationItem variant="ghost" href="#">9</PaginationItem>
+			</Pagination>
+		`,
+	}),
+};
+
+export const Link: Story = {
+	render: () => ({
+		components: { Pagination, PaginationItem, PaginationEllipsis },
+		template: `
+			<Pagination>
+				<PaginationItem variant="link" href="#">1</PaginationItem>
+				<PaginationItem variant="link" href="#" active>2</PaginationItem>
+				<PaginationItem variant="link" href="#">3</PaginationItem>
+				<PaginationEllipsis />
+				<PaginationItem variant="link" href="#">9</PaginationItem>
+			</Pagination>
+		`,
+	}),
+};
+
+// Size stories
+
+export const Small: Story = {
+	args: {
+		size: "sm",
+	},
+	render: (args) => ({
+		components: { Pagination, PaginationItem, PaginationEllipsis },
+		setup() {
+			return { args };
+		},
+		template: `
+			<Pagination v-bind="args">
+				<PaginationItem size="sm" href="#">1</PaginationItem>
+				<PaginationItem size="sm" href="#" active>2</PaginationItem>
+				<PaginationItem size="sm" href="#">3</PaginationItem>
+				<PaginationEllipsis size="sm" />
+				<PaginationItem size="sm" href="#">9</PaginationItem>
+			</Pagination>
+		`,
+	}),
+};
+
+export const Medium: Story = {
+	args: {
+		size: "md",
+	},
+	render: (args) => ({
+		components: { Pagination, PaginationItem, PaginationEllipsis },
+		setup() {
+			return { args };
+		},
+		template: `
+			<Pagination v-bind="args">
+				<PaginationItem size="md" href="#">1</PaginationItem>
+				<PaginationItem size="md" href="#" active>2</PaginationItem>
+				<PaginationItem size="md" href="#">3</PaginationItem>
+				<PaginationEllipsis size="md" />
+				<PaginationItem size="md" href="#">9</PaginationItem>
+			</Pagination>
+		`,
+	}),
+};
+
+export const Large: Story = {
+	args: {
+		size: "lg",
+	},
+	render: (args) => ({
+		components: { Pagination, PaginationItem, PaginationEllipsis },
+		setup() {
+			return { args };
+		},
+		template: `
+			<Pagination v-bind="args">
+				<PaginationItem size="lg" href="#">1</PaginationItem>
+				<PaginationItem size="lg" href="#" active>2</PaginationItem>
+				<PaginationItem size="lg" href="#">3</PaginationItem>
+				<PaginationEllipsis size="lg" />
+				<PaginationItem size="lg" href="#">9</PaginationItem>
+			</Pagination>
+		`,
+	}),
+};
+
+// Feature stories
+
+export const WithControls: Story = {
+	render: () => ({
+		components: { Pagination, PaginationItem, PaginationEllipsis },
+		template: `
+			<Pagination>
+				<PaginationItem href="#" aria-label="First page">«</PaginationItem>
+				<PaginationItem href="#" aria-label="Previous page">‹</PaginationItem>
+				<PaginationItem href="#">1</PaginationItem>
+				<PaginationItem href="#" active>2</PaginationItem>
+				<PaginationItem href="#">3</PaginationItem>
+				<PaginationEllipsis />
+				<PaginationItem href="#">9</PaginationItem>
+				<PaginationItem href="#" aria-label="Next page">›</PaginationItem>
+				<PaginationItem href="#" aria-label="Last page">»</PaginationItem>
+			</Pagination>
+		`,
+	}),
+};
+
+export const Disabled: Story = {
+	render: () => ({
+		components: { Pagination, PaginationItem, PaginationEllipsis },
+		template: `
+			<Pagination>
+				<PaginationItem href="#" aria-label="Previous page" disabled>‹</PaginationItem>
+				<PaginationItem href="#" active>1</PaginationItem>
+				<PaginationItem href="#">2</PaginationItem>
+				<PaginationItem href="#">3</PaginationItem>
+				<PaginationEllipsis />
+				<PaginationItem href="#">9</PaginationItem>
+				<PaginationItem href="#" aria-label="Next page">›</PaginationItem>
+			</Pagination>
+		`,
+	}),
+};
+
+export const ActiveSolidContrast: Story = {
+	render: () => ({
+		components: { Pagination, PaginationItem, PaginationEllipsis },
+		template: `
+			<Pagination>
+				<PaginationItem href="#" aria-label="Previous page">‹</PaginationItem>
+				<PaginationItem variant="ghost" href="#">1</PaginationItem>
+				<PaginationItem variant="solid" href="#" active>2</PaginationItem>
+				<PaginationItem variant="ghost" href="#">3</PaginationItem>
+				<PaginationEllipsis />
+				<PaginationItem variant="ghost" href="#">9</PaginationItem>
+				<PaginationItem href="#" aria-label="Next page">›</PaginationItem>
+			</Pagination>
+		`,
+	}),
+};

--- a/apps/storybook/stories/components/pagination.styleframe.ts
+++ b/apps/storybook/stories/components/pagination.styleframe.ts
@@ -1,0 +1,44 @@
+import {
+	usePaginationRecipe,
+	usePaginationItemRecipe,
+	usePaginationEllipsisRecipe,
+} from "@styleframe/theme";
+import { styleframe } from "virtual:styleframe";
+
+const s = styleframe();
+const { selector } = s;
+
+export const pagination = usePaginationRecipe(s);
+export const paginationItem = usePaginationItemRecipe(s);
+export const paginationEllipsis = usePaginationEllipsisRecipe(s);
+
+// Layout selectors for story grid previews
+selector(".pagination-grid", {
+	display: "flex",
+	flexWrap: "wrap",
+	gap: "@spacing.md",
+	padding: "@spacing.md",
+	alignItems: "flex-start",
+});
+
+selector(".pagination-section", {
+	display: "flex",
+	flexDirection: "column",
+	gap: "@spacing.lg",
+	padding: "@spacing.md",
+});
+
+selector(".pagination-row", {
+	display: "flex",
+	flexWrap: "wrap",
+	gap: "@spacing.sm",
+	alignItems: "center",
+});
+
+selector(".pagination-label", {
+	fontSize: "@font-size.sm",
+	fontWeight: "@font-weight.semibold",
+	minWidth: "80px",
+});
+
+export default s;

--- a/theme/src/recipes/index.ts
+++ b/theme/src/recipes/index.ts
@@ -10,6 +10,7 @@ export * from "./input";
 export * from "./spinner";
 export * from "./modal";
 export * from "./nav";
+export * from "./pagination";
 export * from "./placeholder";
 export * from "./popover";
 export * from "./progress";

--- a/theme/src/recipes/pagination/index.ts
+++ b/theme/src/recipes/pagination/index.ts
@@ -1,0 +1,3 @@
+export * from "./usePaginationRecipe";
+export * from "./usePaginationItemRecipe";
+export * from "./usePaginationEllipsisRecipe";

--- a/theme/src/recipes/pagination/usePaginationEllipsisRecipe.test.ts
+++ b/theme/src/recipes/pagination/usePaginationEllipsisRecipe.test.ts
@@ -1,0 +1,159 @@
+import { styleframe } from "@styleframe/core";
+import { useDarkModifier } from "../../modifiers/useMediaPreferenceModifiers";
+import { usePaginationEllipsisRecipe } from "./index";
+
+function createInstance() {
+	const s = styleframe();
+	for (const name of [
+		"display",
+		"alignItems",
+		"justifyContent",
+		"color",
+		"lineHeight",
+		"userSelect",
+		"fontSize",
+		"paddingTop",
+		"paddingBottom",
+		"paddingLeft",
+		"paddingRight",
+	]) {
+		s.utility(name, ({ value }) => ({ [name]: value }));
+	}
+	useDarkModifier(s);
+	return s;
+}
+
+describe("usePaginationEllipsisRecipe", () => {
+	it("should create a recipe with correct metadata", () => {
+		const s = createInstance();
+		const recipe = usePaginationEllipsisRecipe(s);
+
+		expect(recipe.type).toBe("recipe");
+		expect(recipe.name).toBe("pagination-ellipsis");
+	});
+
+	it("should have correct base styles", () => {
+		const s = createInstance();
+		const recipe = usePaginationEllipsisRecipe(s);
+
+		expect(recipe.base).toEqual({
+			display: "inline-flex",
+			alignItems: "center",
+			justifyContent: "center",
+			color: "@color.text-weak",
+			lineHeight: "@line-height.normal",
+			userSelect: "none",
+		});
+	});
+
+	describe("variants", () => {
+		it("should have size variants with correct styles", () => {
+			const s = createInstance();
+			const recipe = usePaginationEllipsisRecipe(s);
+
+			expect(recipe.variants!.size).toEqual({
+				sm: {
+					fontSize: "@font-size.sm",
+					paddingTop: "@0.375",
+					paddingBottom: "@0.375",
+					paddingLeft: "@0.625",
+					paddingRight: "@0.625",
+				},
+				md: {
+					fontSize: "@font-size.sm",
+					paddingTop: "@0.5",
+					paddingBottom: "@0.5",
+					paddingLeft: "@0.75",
+					paddingRight: "@0.75",
+				},
+				lg: {
+					fontSize: "@font-size.md",
+					paddingTop: "@0.625",
+					paddingBottom: "@0.625",
+					paddingLeft: "@0.875",
+					paddingRight: "@0.875",
+				},
+			});
+		});
+	});
+
+	it("should have correct default variants", () => {
+		const s = createInstance();
+		const recipe = usePaginationEllipsisRecipe(s);
+
+		expect(recipe.defaultVariants).toEqual({
+			color: "neutral",
+			size: "md",
+		});
+	});
+
+	it("should have all color variants", () => {
+		const s = createInstance();
+		const recipe = usePaginationEllipsisRecipe(s);
+
+		expect(Object.keys(recipe.variants!.color)).toEqual([
+			"light",
+			"dark",
+			"neutral",
+		]);
+	});
+
+	it("should have correct color compound variants", () => {
+		const s = createInstance();
+		const recipe = usePaginationEllipsisRecipe(s);
+
+		const light = recipe.compoundVariants!.find(
+			(v) => v.match.color === "light",
+		);
+		expect(light).toEqual({
+			match: { color: "light" },
+			css: { color: "@color.gray-600", "&:dark": { color: "@color.gray-600" } },
+		});
+
+		const dark = recipe.compoundVariants!.find((v) => v.match.color === "dark");
+		expect(dark).toEqual({
+			match: { color: "dark" },
+			css: { color: "@color.gray-400", "&:dark": { color: "@color.gray-400" } },
+		});
+
+		const neutral = recipe.compoundVariants!.find(
+			(v) => v.match.color === "neutral",
+		);
+		expect(neutral).toEqual({
+			match: { color: "neutral" },
+			css: { color: "@color.gray-600", "&:dark": { color: "@color.gray-400" } },
+		});
+	});
+
+	describe("config overrides", () => {
+		it("should allow overriding base styles", () => {
+			const s = createInstance();
+			const recipe = usePaginationEllipsisRecipe(s, {
+				base: { display: "flex" },
+			});
+
+			expect(recipe.base!.display).toBe("flex");
+			expect(recipe.base!.alignItems).toBe("center");
+		});
+	});
+
+	describe("filter", () => {
+		it("should filter size variants", () => {
+			const s = createInstance();
+			const recipe = usePaginationEllipsisRecipe(s, {
+				filter: { size: ["md"] },
+			});
+
+			expect(Object.keys(recipe.variants!.size)).toEqual(["md"]);
+		});
+
+		it("should adjust default variants when filtered out", () => {
+			const s = createInstance();
+			const recipe = usePaginationEllipsisRecipe(s, {
+				filter: { size: ["sm"] },
+			});
+
+			expect(recipe.defaultVariants?.size).toBeUndefined();
+		});
+	});
+});

--- a/theme/src/recipes/pagination/usePaginationEllipsisRecipe.ts
+++ b/theme/src/recipes/pagination/usePaginationEllipsisRecipe.ts
@@ -1,0 +1,76 @@
+import { createUseRecipe } from "../../utils/createUseRecipe";
+
+/**
+ * Pagination ellipsis recipe for non-interactive "…" elements
+ * placed between page-number ranges to indicate skipped pages.
+ */
+export const usePaginationEllipsisRecipe = createUseRecipe(
+	"pagination-ellipsis",
+	{
+		base: {
+			display: "inline-flex",
+			alignItems: "center",
+			justifyContent: "center",
+			color: "@color.text-weak",
+			lineHeight: "@line-height.normal",
+			userSelect: "none",
+		},
+		variants: {
+			color: {
+				light: {},
+				dark: {},
+				neutral: {},
+			},
+			size: {
+				sm: {
+					fontSize: "@font-size.sm",
+					paddingTop: "@0.375",
+					paddingBottom: "@0.375",
+					paddingLeft: "@0.625",
+					paddingRight: "@0.625",
+				},
+				md: {
+					fontSize: "@font-size.sm",
+					paddingTop: "@0.5",
+					paddingBottom: "@0.5",
+					paddingLeft: "@0.75",
+					paddingRight: "@0.75",
+				},
+				lg: {
+					fontSize: "@font-size.md",
+					paddingTop: "@0.625",
+					paddingBottom: "@0.625",
+					paddingLeft: "@0.875",
+					paddingRight: "@0.875",
+				},
+			},
+		},
+		compoundVariants: [
+			{
+				match: { color: "light" as const },
+				css: {
+					color: "@color.gray-600",
+					"&:dark": { color: "@color.gray-600" },
+				},
+			},
+			{
+				match: { color: "dark" as const },
+				css: {
+					color: "@color.gray-400",
+					"&:dark": { color: "@color.gray-400" },
+				},
+			},
+			{
+				match: { color: "neutral" as const },
+				css: {
+					color: "@color.gray-600",
+					"&:dark": { color: "@color.gray-400" },
+				},
+			},
+		],
+		defaultVariants: {
+			color: "neutral",
+			size: "md",
+		},
+	},
+);

--- a/theme/src/recipes/pagination/usePaginationItemRecipe.test.ts
+++ b/theme/src/recipes/pagination/usePaginationItemRecipe.test.ts
@@ -1,0 +1,432 @@
+import { styleframe } from "@styleframe/core";
+import { useDarkModifier } from "../../modifiers/useMediaPreferenceModifiers";
+import {
+	useHoverModifier,
+	useFocusModifier,
+	useFocusVisibleModifier,
+	useActiveModifier,
+} from "../../modifiers/usePseudoStateModifiers";
+import { useDisabledModifier } from "../../modifiers/useFormStateModifiers";
+import { usePaginationItemRecipe } from "./index";
+
+function createInstance() {
+	const s = styleframe();
+	for (const name of [
+		"display",
+		"alignItems",
+		"justifyContent",
+		"fontWeight",
+		"fontSize",
+		"borderWidth",
+		"borderStyle",
+		"borderColor",
+		"borderRadius",
+		"lineHeight",
+		"paddingTop",
+		"paddingBottom",
+		"paddingLeft",
+		"paddingRight",
+		"gap",
+		"cursor",
+		"transitionProperty",
+		"transitionTimingFunction",
+		"transitionDuration",
+		"textDecoration",
+		"whiteSpace",
+		"userSelect",
+		"outline",
+		"outlineWidth",
+		"outlineStyle",
+		"outlineColor",
+		"outlineOffset",
+		"opacity",
+		"pointerEvents",
+		"background",
+		"color",
+		"textUnderlineOffset",
+	]) {
+		s.utility(name, ({ value }) => ({ [name]: value }));
+	}
+	useDarkModifier(s);
+	useHoverModifier(s);
+	useFocusModifier(s);
+	useFocusVisibleModifier(s);
+	useActiveModifier(s);
+	useDisabledModifier(s);
+	return s;
+}
+
+describe("usePaginationItemRecipe", () => {
+	it("should create a recipe with correct metadata", () => {
+		const s = createInstance();
+		const recipe = usePaginationItemRecipe(s);
+
+		expect(recipe.type).toBe("recipe");
+		expect(recipe.name).toBe("pagination-item");
+	});
+
+	it("should have correct base styles", () => {
+		const s = createInstance();
+		const recipe = usePaginationItemRecipe(s);
+
+		expect(recipe.base).toEqual({
+			display: "inline-flex",
+			alignItems: "center",
+			justifyContent: "center",
+			fontWeight: "@font-weight.medium",
+			fontSize: "@font-size.sm",
+			borderWidth: "@border-width.thin",
+			borderStyle: "@border-style.solid",
+			borderColor: "transparent",
+			borderRadius: "@border-radius.md",
+			lineHeight: "@line-height.normal",
+			paddingTop: "@0.5",
+			paddingBottom: "@0.5",
+			paddingLeft: "@0.75",
+			paddingRight: "@0.75",
+			cursor: "pointer",
+			transitionProperty: "color, background-color, border-color",
+			transitionTimingFunction: "@easing.ease-in-out",
+			transitionDuration: "150ms",
+			textDecoration: "none",
+			"&:hover": { textDecoration: "none" },
+			"&:focus": { textDecoration: "none" },
+			"&:active": { textDecoration: "none" },
+			whiteSpace: "nowrap",
+			userSelect: "none",
+			outline: "none",
+			"&:focus-visible": {
+				outlineWidth: "2px",
+				outlineStyle: "solid",
+				outlineColor: "@color.primary",
+				outlineOffset: "2px",
+			},
+			"&:disabled": {
+				cursor: "not-allowed",
+				opacity: "0.75",
+				pointerEvents: "none",
+			},
+		});
+	});
+
+	describe("variants", () => {
+		it("should have all color variants", () => {
+			const s = createInstance();
+			const recipe = usePaginationItemRecipe(s);
+
+			expect(Object.keys(recipe.variants!.color)).toEqual([
+				"light",
+				"dark",
+				"neutral",
+			]);
+		});
+
+		it("should have all style variants", () => {
+			const s = createInstance();
+			const recipe = usePaginationItemRecipe(s);
+
+			expect(Object.keys(recipe.variants!.variant)).toEqual([
+				"solid",
+				"outline",
+				"soft",
+				"subtle",
+				"ghost",
+				"link",
+			]);
+		});
+
+		it("should have size variants with correct styles", () => {
+			const s = createInstance();
+			const recipe = usePaginationItemRecipe(s);
+
+			expect(Object.keys(recipe.variants!.size)).toEqual(["sm", "md", "lg"]);
+			expect(recipe.variants!.size.md).toEqual({
+				fontSize: "@font-size.sm",
+				paddingTop: "@0.5",
+				paddingBottom: "@0.5",
+				paddingLeft: "@0.75",
+				paddingRight: "@0.75",
+				gap: "@0.375",
+				borderRadius: "@border-radius.md",
+			});
+		});
+	});
+
+	it("should have active variants", () => {
+		const s = createInstance();
+		const recipe = usePaginationItemRecipe(s);
+
+		expect(recipe.variants!.active).toEqual({
+			true: {
+				fontWeight: "@font-weight.semibold",
+			},
+			false: {},
+		});
+	});
+
+	it("should have disabled variants", () => {
+		const s = createInstance();
+		const recipe = usePaginationItemRecipe(s);
+
+		expect(recipe.variants!.disabled).toEqual({
+			true: {
+				cursor: "not-allowed",
+				opacity: "0.75",
+				pointerEvents: "none",
+			},
+			false: {},
+		});
+	});
+
+	it("should have correct default variants", () => {
+		const s = createInstance();
+		const recipe = usePaginationItemRecipe(s);
+
+		expect(recipe.defaultVariants).toEqual({
+			color: "neutral",
+			variant: "ghost",
+			size: "md",
+			active: "false",
+			disabled: "false",
+		});
+	});
+
+	describe("compound variants", () => {
+		it("should have 18 compound variants total", () => {
+			const s = createInstance();
+			const recipe = usePaginationItemRecipe(s);
+
+			// 3 colors × 6 variants = 18
+			expect(recipe.compoundVariants).toHaveLength(18);
+		});
+
+		it("should have correct light solid compound variant", () => {
+			const s = createInstance();
+			const recipe = usePaginationItemRecipe(s);
+
+			const cv = recipe.compoundVariants!.find(
+				(v) => v.match.color === "light" && v.match.variant === "solid",
+			);
+
+			expect(cv).toEqual({
+				match: { color: "light", variant: "solid" },
+				css: {
+					background: "@color.white",
+					color: "@color.text",
+					borderColor: "@color.gray-200",
+					"&:hover": { background: "@color.gray-100" },
+					"&:focus": { background: "@color.gray-100" },
+					"&:active": { background: "@color.gray-200" },
+					"&:dark": {
+						background: "@color.white",
+						color: "@color.text-inverted",
+						borderColor: "@color.gray-200",
+					},
+				},
+			});
+		});
+
+		it("should have correct light ghost compound variant", () => {
+			const s = createInstance();
+			const recipe = usePaginationItemRecipe(s);
+
+			const cv = recipe.compoundVariants!.find(
+				(v) => v.match.color === "light" && v.match.variant === "ghost",
+			);
+
+			expect(cv).toEqual({
+				match: { color: "light", variant: "ghost" },
+				css: {
+					color: "@color.text",
+					"&:hover": { background: "@color.gray-100" },
+					"&:focus": { background: "@color.gray-100" },
+					"&:active": { background: "@color.gray-200" },
+					"&:dark": {
+						color: "@color.text-inverted",
+					},
+					"&:dark:hover": { background: "@color.gray-100" },
+					"&:dark:focus": { background: "@color.gray-100" },
+					"&:dark:active": { background: "@color.gray-200" },
+				},
+			});
+		});
+
+		it("should have correct dark solid compound variant", () => {
+			const s = createInstance();
+			const recipe = usePaginationItemRecipe(s);
+
+			const cv = recipe.compoundVariants!.find(
+				(v) => v.match.color === "dark" && v.match.variant === "solid",
+			);
+
+			expect(cv).toEqual({
+				match: { color: "dark", variant: "solid" },
+				css: {
+					background: "@color.gray-900",
+					color: "@color.white",
+					borderColor: "@color.gray-800",
+					"&:hover": { background: "@color.gray-800", color: "@color.white" },
+					"&:focus": { background: "@color.gray-800", color: "@color.white" },
+					"&:active": { background: "@color.gray-750", color: "@color.white" },
+					"&:dark": {
+						background: "@color.gray-900",
+						color: "@color.white",
+						borderColor: "@color.gray-800",
+					},
+				},
+			});
+		});
+
+		it("should have correct neutral ghost compound variant with adaptive dark mode", () => {
+			const s = createInstance();
+			const recipe = usePaginationItemRecipe(s);
+
+			const cv = recipe.compoundVariants!.find(
+				(v) => v.match.color === "neutral" && v.match.variant === "ghost",
+			);
+
+			expect(cv).toEqual({
+				match: { color: "neutral", variant: "ghost" },
+				css: {
+					color: "@color.text",
+					"&:hover": { background: "@color.gray-100" },
+					"&:focus": { background: "@color.gray-100" },
+					"&:active": { background: "@color.gray-200" },
+					"&:dark": {
+						color: "@color.gray-200",
+					},
+					"&:dark:hover": {
+						background: "@color.gray-800",
+						color: "@color.gray-200",
+					},
+					"&:dark:focus": {
+						background: "@color.gray-800",
+						color: "@color.gray-200",
+					},
+					"&:dark:active": {
+						background: "@color.gray-750",
+						color: "@color.gray-200",
+					},
+				},
+			});
+		});
+
+		it("should have correct neutral solid compound variant with adaptive dark mode", () => {
+			const s = createInstance();
+			const recipe = usePaginationItemRecipe(s);
+
+			const cv = recipe.compoundVariants!.find(
+				(v) => v.match.color === "neutral" && v.match.variant === "solid",
+			);
+
+			expect(cv).toEqual({
+				match: { color: "neutral", variant: "solid" },
+				css: {
+					background: "@color.white",
+					color: "@color.text",
+					borderColor: "@color.gray-200",
+					"&:hover": { background: "@color.gray-100" },
+					"&:focus": { background: "@color.gray-100" },
+					"&:active": { background: "@color.gray-200" },
+					"&:dark": {
+						background: "@color.gray-900",
+						color: "@color.white",
+						borderColor: "@color.gray-800",
+					},
+					"&:dark:hover": {
+						background: "@color.gray-800",
+						color: "@color.white",
+					},
+					"&:dark:focus": {
+						background: "@color.gray-800",
+						color: "@color.white",
+					},
+					"&:dark:active": {
+						background: "@color.gray-750",
+						color: "@color.white",
+					},
+				},
+			});
+		});
+
+		it("should have a compound variant entry for every color × variant pair", () => {
+			const s = createInstance();
+			const recipe = usePaginationItemRecipe(s);
+
+			const colors = ["light", "dark", "neutral"];
+			const variants = ["solid", "outline", "soft", "subtle", "ghost", "link"];
+			for (const color of colors) {
+				for (const variant of variants) {
+					const cv = recipe.compoundVariants!.find(
+						(v) => v.match.color === color && v.match.variant === variant,
+					);
+					expect(cv, `${color} + ${variant}`).toBeDefined();
+				}
+			}
+		});
+	});
+
+	describe("config overrides", () => {
+		it("should allow overriding base styles", () => {
+			const s = createInstance();
+			const recipe = usePaginationItemRecipe(s, {
+				base: { display: "flex" },
+			});
+
+			expect(recipe.base!.display).toBe("flex");
+			expect(recipe.base!.cursor).toBe("pointer");
+		});
+	});
+
+	describe("filter", () => {
+		it("should filter color variants", () => {
+			const s = createInstance();
+			const recipe = usePaginationItemRecipe(s, {
+				filter: { color: ["neutral"] },
+			});
+
+			expect(Object.keys(recipe.variants!.color)).toEqual(["neutral"]);
+		});
+
+		it("should prune compound variants when filtering colors", () => {
+			const s = createInstance();
+			const recipe = usePaginationItemRecipe(s, {
+				filter: { color: ["neutral"] },
+			});
+
+			expect(
+				recipe.compoundVariants!.every(
+					(cv) => !cv.match.color || cv.match.color === "neutral",
+				),
+			).toBe(true);
+		});
+
+		it("should filter variant axis", () => {
+			const s = createInstance();
+			const recipe = usePaginationItemRecipe(s, {
+				filter: { variant: ["ghost", "solid"] },
+			});
+
+			expect(Object.keys(recipe.variants!.variant)).toEqual(["solid", "ghost"]);
+			expect(
+				recipe.compoundVariants!.every(
+					(cv) =>
+						!cv.match.variant ||
+						cv.match.variant === "ghost" ||
+						cv.match.variant === "solid",
+				),
+			).toBe(true);
+		});
+
+		it("should adjust default variants when filtered out", () => {
+			const s = createInstance();
+			const recipe = usePaginationItemRecipe(s, {
+				filter: { color: ["light"] },
+			});
+
+			expect(recipe.defaultVariants?.color).toBeUndefined();
+			expect(recipe.defaultVariants?.variant).toBe("ghost");
+			expect(recipe.defaultVariants?.size).toBe("md");
+		});
+	});
+});

--- a/theme/src/recipes/pagination/usePaginationItemRecipe.ts
+++ b/theme/src/recipes/pagination/usePaginationItemRecipe.ts
@@ -1,0 +1,500 @@
+import { createUseRecipe } from "../../utils/createUseRecipe";
+
+/**
+ * Pagination item recipe for individual page-number buttons.
+ * Supports color (light, dark, neutral), variant (solid, outline, soft, subtle, ghost, link),
+ * size (sm, md, lg), and active/disabled boolean axes.
+ *
+ * Items are also used for prev/next/first/last controls — render them as the same item
+ * with icon content (e.g., a chevron) instead of a page number.
+ */
+export const usePaginationItemRecipe = createUseRecipe("pagination-item", {
+	base: {
+		display: "inline-flex",
+		alignItems: "center",
+		justifyContent: "center",
+		fontWeight: "@font-weight.medium",
+		fontSize: "@font-size.sm",
+		borderWidth: "@border-width.thin",
+		borderStyle: "@border-style.solid",
+		borderColor: "transparent",
+		borderRadius: "@border-radius.md",
+		lineHeight: "@line-height.normal",
+		paddingTop: "@0.5",
+		paddingBottom: "@0.5",
+		paddingLeft: "@0.75",
+		paddingRight: "@0.75",
+		cursor: "pointer",
+		transitionProperty: "color, background-color, border-color",
+		transitionTimingFunction: "@easing.ease-in-out",
+		transitionDuration: "150ms",
+		textDecoration: "none",
+		"&:hover": { textDecoration: "none" },
+		"&:focus": { textDecoration: "none" },
+		"&:active": { textDecoration: "none" },
+		whiteSpace: "nowrap",
+		userSelect: "none",
+		outline: "none",
+		"&:focus-visible": {
+			outlineWidth: "2px",
+			outlineStyle: "solid",
+			outlineColor: "@color.primary",
+			outlineOffset: "2px",
+		},
+		"&:disabled": {
+			cursor: "not-allowed",
+			opacity: "0.75",
+			pointerEvents: "none",
+		},
+	},
+	variants: {
+		color: {
+			light: {},
+			dark: {},
+			neutral: {},
+		},
+		variant: {
+			solid: {},
+			outline: {},
+			soft: {},
+			subtle: {},
+			ghost: {
+				background: "transparent",
+			},
+			link: {
+				background: "transparent",
+				borderColor: "transparent",
+				borderWidth: "0",
+			},
+		},
+		size: {
+			sm: {
+				fontSize: "@font-size.sm",
+				paddingTop: "@0.375",
+				paddingBottom: "@0.375",
+				paddingLeft: "@0.625",
+				paddingRight: "@0.625",
+				gap: "@0.375",
+				borderRadius: "@border-radius.md",
+			},
+			md: {
+				fontSize: "@font-size.sm",
+				paddingTop: "@0.5",
+				paddingBottom: "@0.5",
+				paddingLeft: "@0.75",
+				paddingRight: "@0.75",
+				gap: "@0.375",
+				borderRadius: "@border-radius.md",
+			},
+			lg: {
+				fontSize: "@font-size.md",
+				paddingTop: "@0.625",
+				paddingBottom: "@0.625",
+				paddingLeft: "@0.875",
+				paddingRight: "@0.875",
+				gap: "@0.5",
+				borderRadius: "@border-radius.md",
+			},
+		},
+		active: {
+			true: {
+				fontWeight: "@font-weight.semibold",
+			},
+			false: {},
+		},
+		disabled: {
+			true: {
+				cursor: "not-allowed",
+				opacity: "0.75",
+				pointerEvents: "none",
+			},
+			false: {},
+		},
+	},
+	compoundVariants: [
+		// Light color (fixed across themes — light-themed appearance, always)
+		{
+			match: { color: "light" as const, variant: "solid" as const },
+			css: {
+				background: "@color.white",
+				color: "@color.text",
+				borderColor: "@color.gray-200",
+				"&:hover": { background: "@color.gray-100" },
+				"&:focus": { background: "@color.gray-100" },
+				"&:active": { background: "@color.gray-200" },
+				"&:dark": {
+					background: "@color.white",
+					color: "@color.text-inverted",
+					borderColor: "@color.gray-200",
+				},
+			},
+		},
+		{
+			match: { color: "light" as const, variant: "outline" as const },
+			css: {
+				color: "@color.gray-900",
+				borderColor: "@color.gray-300",
+				"&:hover": { background: "@color.gray-100" },
+				"&:focus": { background: "@color.gray-100" },
+				"&:active": { background: "@color.gray-200" },
+				"&:dark": {
+					color: "@color.gray-900",
+					borderColor: "@color.gray-300",
+				},
+			},
+		},
+		{
+			match: { color: "light" as const, variant: "soft" as const },
+			css: {
+				background: "@color.gray-100",
+				color: "@color.gray-700",
+				"&:hover": { background: "@color.gray-150" },
+				"&:focus": { background: "@color.gray-150" },
+				"&:active": { background: "@color.gray-200" },
+				"&:dark": {
+					background: "@color.gray-100",
+					color: "@color.gray-700",
+				},
+			},
+		},
+		{
+			match: { color: "light" as const, variant: "subtle" as const },
+			css: {
+				background: "@color.gray-100",
+				color: "@color.gray-700",
+				borderColor: "@color.gray-300",
+				"&:hover": { background: "@color.gray-150" },
+				"&:focus": { background: "@color.gray-150" },
+				"&:active": { background: "@color.gray-200" },
+				"&:dark": {
+					background: "@color.gray-100",
+					color: "@color.gray-700",
+					borderColor: "@color.gray-300",
+				},
+			},
+		},
+		{
+			match: { color: "light" as const, variant: "ghost" as const },
+			css: {
+				color: "@color.text",
+				"&:hover": { background: "@color.gray-100" },
+				"&:focus": { background: "@color.gray-100" },
+				"&:active": { background: "@color.gray-200" },
+				"&:dark": {
+					color: "@color.text-inverted",
+				},
+				"&:dark:hover": { background: "@color.gray-100" },
+				"&:dark:focus": { background: "@color.gray-100" },
+				"&:dark:active": { background: "@color.gray-200" },
+			},
+		},
+		{
+			match: { color: "light" as const, variant: "link" as const },
+			css: {
+				color: "@color.text",
+				"&:hover": {
+					color: "@color.gray-900",
+					textDecoration: "underline",
+					textUnderlineOffset: "4px",
+				},
+				"&:focus": {
+					color: "@color.gray-900",
+					textDecoration: "underline",
+					textUnderlineOffset: "4px",
+				},
+				"&:active": {
+					color: "@color.gray-900",
+					textDecoration: "underline",
+					textUnderlineOffset: "4px",
+				},
+				"&:dark": {
+					color: "@color.text-inverted",
+				},
+				"&:dark:hover": { color: "@color.gray-900" },
+				"&:dark:focus": { color: "@color.gray-900" },
+				"&:dark:active": { color: "@color.gray-900" },
+			},
+		},
+
+		// Dark color (fixed across themes — dark-themed appearance, always)
+		{
+			match: { color: "dark" as const, variant: "solid" as const },
+			css: {
+				background: "@color.gray-900",
+				color: "@color.white",
+				borderColor: "@color.gray-800",
+				"&:hover": { background: "@color.gray-800", color: "@color.white" },
+				"&:focus": { background: "@color.gray-800", color: "@color.white" },
+				"&:active": { background: "@color.gray-750", color: "@color.white" },
+				"&:dark": {
+					background: "@color.gray-900",
+					color: "@color.white",
+					borderColor: "@color.gray-800",
+				},
+			},
+		},
+		{
+			match: { color: "dark" as const, variant: "outline" as const },
+			css: {
+				color: "@color.gray-200",
+				borderColor: "@color.gray-600",
+				"&:hover": {
+					background: "@color.gray-800",
+					color: "@color.white",
+				},
+				"&:focus": {
+					background: "@color.gray-800",
+					color: "@color.white",
+				},
+				"&:active": {
+					background: "@color.gray-750",
+					color: "@color.white",
+				},
+				"&:dark": {
+					color: "@color.gray-200",
+					borderColor: "@color.gray-600",
+				},
+			},
+		},
+		{
+			match: { color: "dark" as const, variant: "soft" as const },
+			css: {
+				background: "@color.gray-800",
+				color: "@color.gray-300",
+				"&:hover": { background: "@color.gray-750", color: "@color.gray-300" },
+				"&:focus": { background: "@color.gray-750", color: "@color.gray-300" },
+				"&:active": { background: "@color.gray-700", color: "@color.gray-300" },
+				"&:dark": {
+					background: "@color.gray-800",
+					color: "@color.gray-300",
+				},
+			},
+		},
+		{
+			match: { color: "dark" as const, variant: "subtle" as const },
+			css: {
+				background: "@color.gray-800",
+				color: "@color.gray-300",
+				borderColor: "@color.gray-600",
+				"&:hover": { background: "@color.gray-750", color: "@color.gray-300" },
+				"&:focus": { background: "@color.gray-750", color: "@color.gray-300" },
+				"&:active": { background: "@color.gray-700", color: "@color.gray-300" },
+				"&:dark": {
+					background: "@color.gray-800",
+					color: "@color.gray-300",
+					borderColor: "@color.gray-600",
+				},
+			},
+		},
+		{
+			match: { color: "dark" as const, variant: "ghost" as const },
+			css: {
+				color: "@color.gray-200",
+				"&:hover": { background: "@color.gray-800", color: "@color.gray-200" },
+				"&:focus": { background: "@color.gray-800", color: "@color.gray-200" },
+				"&:active": { background: "@color.gray-750", color: "@color.gray-200" },
+				"&:dark": {
+					color: "@color.gray-200",
+				},
+				"&:dark:hover": { background: "@color.gray-800" },
+				"&:dark:focus": { background: "@color.gray-800" },
+				"&:dark:active": { background: "@color.gray-750" },
+			},
+		},
+		{
+			match: { color: "dark" as const, variant: "link" as const },
+			css: {
+				color: "@color.gray-200",
+				"&:hover": {
+					color: "@color.white",
+					textDecoration: "underline",
+					textUnderlineOffset: "4px",
+				},
+				"&:focus": {
+					color: "@color.white",
+					textDecoration: "underline",
+					textUnderlineOffset: "4px",
+				},
+				"&:active": {
+					color: "@color.white",
+					textDecoration: "underline",
+					textUnderlineOffset: "4px",
+				},
+				"&:dark": {
+					color: "@color.gray-200",
+				},
+				"&:dark:hover": { color: "@color.white" },
+				"&:dark:focus": { color: "@color.white" },
+				"&:dark:active": { color: "@color.white" },
+			},
+		},
+
+		// Neutral color (adaptive: light in light mode, dark in dark mode)
+		{
+			match: { color: "neutral" as const, variant: "solid" as const },
+			css: {
+				background: "@color.white",
+				color: "@color.text",
+				borderColor: "@color.gray-200",
+				"&:hover": { background: "@color.gray-100" },
+				"&:focus": { background: "@color.gray-100" },
+				"&:active": { background: "@color.gray-200" },
+				"&:dark": {
+					background: "@color.gray-900",
+					color: "@color.white",
+					borderColor: "@color.gray-800",
+				},
+				"&:dark:hover": {
+					background: "@color.gray-800",
+					color: "@color.white",
+				},
+				"&:dark:focus": {
+					background: "@color.gray-800",
+					color: "@color.white",
+				},
+				"&:dark:active": {
+					background: "@color.gray-750",
+					color: "@color.white",
+				},
+			},
+		},
+		{
+			match: { color: "neutral" as const, variant: "outline" as const },
+			css: {
+				color: "@color.gray-900",
+				borderColor: "@color.gray-300",
+				"&:hover": { background: "@color.gray-100" },
+				"&:focus": { background: "@color.gray-100" },
+				"&:active": { background: "@color.gray-200" },
+				"&:dark": {
+					color: "@color.gray-200",
+					borderColor: "@color.gray-600",
+				},
+				"&:dark:hover": {
+					background: "@color.gray-800",
+					color: "@color.white",
+				},
+				"&:dark:focus": {
+					background: "@color.gray-800",
+					color: "@color.white",
+				},
+				"&:dark:active": {
+					background: "@color.gray-750",
+					color: "@color.white",
+				},
+			},
+		},
+		{
+			match: { color: "neutral" as const, variant: "soft" as const },
+			css: {
+				background: "@color.gray-100",
+				color: "@color.gray-700",
+				"&:hover": { background: "@color.gray-150" },
+				"&:focus": { background: "@color.gray-150" },
+				"&:active": { background: "@color.gray-200" },
+				"&:dark": {
+					background: "@color.gray-800",
+					color: "@color.gray-300",
+				},
+				"&:dark:hover": {
+					background: "@color.gray-750",
+					color: "@color.gray-300",
+				},
+				"&:dark:focus": {
+					background: "@color.gray-750",
+					color: "@color.gray-300",
+				},
+				"&:dark:active": {
+					background: "@color.gray-700",
+					color: "@color.gray-300",
+				},
+			},
+		},
+		{
+			match: { color: "neutral" as const, variant: "subtle" as const },
+			css: {
+				background: "@color.gray-100",
+				color: "@color.gray-700",
+				borderColor: "@color.gray-300",
+				"&:hover": { background: "@color.gray-150" },
+				"&:focus": { background: "@color.gray-150" },
+				"&:active": { background: "@color.gray-200" },
+				"&:dark": {
+					background: "@color.gray-800",
+					color: "@color.gray-300",
+					borderColor: "@color.gray-600",
+				},
+				"&:dark:hover": {
+					background: "@color.gray-750",
+					color: "@color.gray-300",
+				},
+				"&:dark:focus": {
+					background: "@color.gray-750",
+					color: "@color.gray-300",
+				},
+				"&:dark:active": {
+					background: "@color.gray-700",
+					color: "@color.gray-300",
+				},
+			},
+		},
+		{
+			match: { color: "neutral" as const, variant: "ghost" as const },
+			css: {
+				color: "@color.text",
+				"&:hover": { background: "@color.gray-100" },
+				"&:focus": { background: "@color.gray-100" },
+				"&:active": { background: "@color.gray-200" },
+				"&:dark": {
+					color: "@color.gray-200",
+				},
+				"&:dark:hover": {
+					background: "@color.gray-800",
+					color: "@color.gray-200",
+				},
+				"&:dark:focus": {
+					background: "@color.gray-800",
+					color: "@color.gray-200",
+				},
+				"&:dark:active": {
+					background: "@color.gray-750",
+					color: "@color.gray-200",
+				},
+			},
+		},
+		{
+			match: { color: "neutral" as const, variant: "link" as const },
+			css: {
+				color: "@color.text",
+				"&:hover": {
+					color: "@color.gray-900",
+					textDecoration: "underline",
+					textUnderlineOffset: "4px",
+				},
+				"&:focus": {
+					color: "@color.gray-900",
+					textDecoration: "underline",
+					textUnderlineOffset: "4px",
+				},
+				"&:active": {
+					color: "@color.gray-900",
+					textDecoration: "underline",
+					textUnderlineOffset: "4px",
+				},
+				"&:dark": {
+					color: "@color.gray-200",
+				},
+				"&:dark:hover": { color: "@color.white" },
+				"&:dark:focus": { color: "@color.white" },
+				"&:dark:active": { color: "@color.white" },
+			},
+		},
+	],
+	defaultVariants: {
+		color: "neutral",
+		variant: "ghost",
+		size: "md",
+		active: "false",
+		disabled: "false",
+	},
+});

--- a/theme/src/recipes/pagination/usePaginationRecipe.test.ts
+++ b/theme/src/recipes/pagination/usePaginationRecipe.test.ts
@@ -1,0 +1,186 @@
+import { styleframe } from "@styleframe/core";
+import { usePaginationRecipe } from "./index";
+
+function createInstance() {
+	const s = styleframe();
+	for (const name of [
+		"display",
+		"flexWrap",
+		"alignItems",
+		"listStyle",
+		"paddingLeft",
+		"marginTop",
+		"marginBottom",
+		"flexDirection",
+		"fontSize",
+		"gap",
+	]) {
+		s.utility(name, ({ value }) => ({ [name]: value }));
+	}
+	return s;
+}
+
+describe("usePaginationRecipe", () => {
+	it("should create a recipe with correct metadata", () => {
+		const s = createInstance();
+		const recipe = usePaginationRecipe(s);
+
+		expect(recipe.type).toBe("recipe");
+		expect(recipe.name).toBe("pagination");
+	});
+
+	it("should have correct base styles", () => {
+		const s = createInstance();
+		const recipe = usePaginationRecipe(s);
+
+		expect(recipe.base).toEqual({
+			display: "flex",
+			flexWrap: "wrap",
+			alignItems: "center",
+			listStyle: "none",
+			paddingLeft: "0",
+			marginTop: "0",
+			marginBottom: "0",
+		});
+	});
+
+	describe("variants", () => {
+		it("should have orientation variants", () => {
+			const s = createInstance();
+			const recipe = usePaginationRecipe(s);
+
+			expect(recipe.variants!.orientation).toEqual({
+				horizontal: {
+					flexDirection: "row",
+				},
+				vertical: {
+					flexDirection: "column",
+					alignItems: "flex-start",
+				},
+			});
+		});
+
+		it("should have size variants with correct styles", () => {
+			const s = createInstance();
+			const recipe = usePaginationRecipe(s);
+
+			expect(recipe.variants!.size).toEqual({
+				sm: {
+					fontSize: "@font-size.xs",
+					gap: "@0.25",
+				},
+				md: {
+					fontSize: "@font-size.sm",
+					gap: "@0.375",
+				},
+				lg: {
+					fontSize: "@font-size.md",
+					gap: "@0.5",
+				},
+			});
+		});
+	});
+
+	it("should have correct default variants", () => {
+		const s = createInstance();
+		const recipe = usePaginationRecipe(s);
+
+		expect(recipe.defaultVariants).toEqual({
+			orientation: "horizontal",
+			size: "md",
+		});
+	});
+
+	describe("compound variants", () => {
+		it("should have 2 compound variants total", () => {
+			const s = createInstance();
+			const recipe = usePaginationRecipe(s);
+
+			expect(recipe.compoundVariants).toHaveLength(2);
+		});
+
+		it("should have horizontal className compound variant", () => {
+			const s = createInstance();
+			const recipe = usePaginationRecipe(s);
+
+			const horizontal = recipe.compoundVariants!.find(
+				(cv) => cv.match.orientation === "horizontal",
+			);
+
+			expect(horizontal).toEqual({
+				match: { orientation: "horizontal" },
+				className: "-horizontal",
+			});
+		});
+
+		it("should have vertical className compound variant", () => {
+			const s = createInstance();
+			const recipe = usePaginationRecipe(s);
+
+			const vertical = recipe.compoundVariants!.find(
+				(cv) => cv.match.orientation === "vertical",
+			);
+
+			expect(vertical).toEqual({
+				match: { orientation: "vertical" },
+				className: "-vertical",
+			});
+		});
+	});
+
+	describe("config overrides", () => {
+		it("should allow overriding base styles", () => {
+			const s = createInstance();
+			const recipe = usePaginationRecipe(s, {
+				base: { display: "inline-flex" },
+			});
+
+			expect(recipe.base!.display).toBe("inline-flex");
+			expect(recipe.base!.flexWrap).toBe("wrap");
+			expect(recipe.base!.listStyle).toBe("none");
+		});
+	});
+
+	describe("filter", () => {
+		it("should filter orientation variants", () => {
+			const s = createInstance();
+			const recipe = usePaginationRecipe(s, {
+				filter: { orientation: ["horizontal"] },
+			});
+
+			expect(Object.keys(recipe.variants!.orientation)).toEqual(["horizontal"]);
+		});
+
+		it("should prune compound variants when filtering orientation", () => {
+			const s = createInstance();
+			const recipe = usePaginationRecipe(s, {
+				filter: { orientation: ["horizontal"] },
+			});
+
+			const orientationCompounds = recipe.compoundVariants!.filter(
+				(cv) => cv.match.orientation !== undefined,
+			);
+			expect(orientationCompounds).toHaveLength(1);
+			expect(orientationCompounds[0]!.match.orientation).toBe("horizontal");
+		});
+
+		it("should filter size variants", () => {
+			const s = createInstance();
+			const recipe = usePaginationRecipe(s, {
+				filter: { size: ["sm", "lg"] },
+			});
+
+			expect(Object.keys(recipe.variants!.size)).toEqual(["sm", "lg"]);
+		});
+
+		it("should adjust default variants when filtered out", () => {
+			const s = createInstance();
+			const recipe = usePaginationRecipe(s, {
+				filter: { orientation: ["vertical"] },
+			});
+
+			expect(recipe.defaultVariants?.orientation).toBeUndefined();
+			expect(recipe.defaultVariants?.size).toBe("md");
+		});
+	});
+});

--- a/theme/src/recipes/pagination/usePaginationRecipe.ts
+++ b/theme/src/recipes/pagination/usePaginationRecipe.ts
@@ -1,0 +1,56 @@
+import { createUseRecipe } from "../../utils/createUseRecipe";
+
+/**
+ * Pagination root container recipe for navigation between pages of content.
+ * Supports orientation (horizontal/vertical) and size axes.
+ */
+export const usePaginationRecipe = createUseRecipe("pagination", {
+	base: {
+		display: "flex",
+		flexWrap: "wrap",
+		alignItems: "center",
+		listStyle: "none",
+		paddingLeft: "0",
+		marginTop: "0",
+		marginBottom: "0",
+	},
+	variants: {
+		orientation: {
+			horizontal: {
+				flexDirection: "row",
+			},
+			vertical: {
+				flexDirection: "column",
+				alignItems: "flex-start",
+			},
+		},
+		size: {
+			sm: {
+				fontSize: "@font-size.xs",
+				gap: "@0.25",
+			},
+			md: {
+				fontSize: "@font-size.sm",
+				gap: "@0.375",
+			},
+			lg: {
+				fontSize: "@font-size.md",
+				gap: "@0.5",
+			},
+		},
+	},
+	compoundVariants: [
+		{
+			match: { orientation: "horizontal" as const },
+			className: "-horizontal",
+		},
+		{
+			match: { orientation: "vertical" as const },
+			className: "-vertical",
+		},
+	],
+	defaultVariants: {
+		orientation: "horizontal",
+		size: "md",
+	},
+});


### PR DESCRIPTION
## Summary

- Adds a multi-part pagination recipe (`usePaginationRecipe`, `usePaginationItemRecipe`, `usePaginationEllipsisRecipe`) to `theme/src/recipes/pagination/`
- Items support 3 color modes (light/dark/neutral), 6 style variants (solid/outline/soft/subtle/ghost/link), 3 sizes (sm/md/lg), and active/disabled boolean axes; neutral is fully adaptive (identical to `light` in light mode, identical to `dark` in dark mode)
- Includes Storybook showcase (Vue components + stories), Vitest tests (2430 passing), and a docs page at `apps/docs/content/docs/04.components/02.composables/15.pagination.md`

## Test plan

- [ ] `pnpm --filter @styleframe/theme test` — all 2430 tests pass
- [ ] `pnpm typecheck` — no type errors
- [ ] `pnpm storybook` → open `Theme/Recipes/Pagination` and verify all color × variant × size combos render correctly in both light and dark mode