### PR TITLE
feat(theme): add breadcrumb recipe

### DIFF
--- a/.changeset/add-breadcrumb-recipe.md
+++ b/.changeset/add-breadcrumb-recipe.md
@@ -1,0 +1,5 @@
+---
+"@styleframe/theme": minor
+---
+
+Add `useBreadcrumbRecipe` and `useBreadcrumbItemRecipe` — a two-part breadcrumb recipe with `light`/`dark`/`neutral` color axes and `sm`/`md`/`lg` size variants. Separators are rendered as DOM nodes and auto-inserted between items; the separator character is configurable via a `separator` prop.

--- a/apps/docs/content/docs/04.components/02.composables/15.breadcrumb.md
+++ b/apps/docs/content/docs/04.components/02.composables/15.breadcrumb.md
@@ -1,0 +1,545 @@
+---
+title: Breadcrumb
+description: A navigation aid that displays the user's location within a site hierarchy. Supports three colors, three sizes, and active/disabled states through a two-part recipe system, with a CSS-variable-driven separator.
+---
+
+## Overview
+
+The **Breadcrumb** is a navigation aid that shows the user's current location inside a site or app hierarchy. It is composed of two recipe parts: `useBreadcrumbRecipe()` for the container that controls layout and spacing, and `useBreadcrumbItemRecipe()` for individual breadcrumb links with color, size, and active/disabled state options. Each composable creates a fully configured [recipe](/docs/api/recipes) with compound variants that handle every color combination automatically.
+
+The Breadcrumb recipes integrate directly with the default [design tokens preset](/docs/theme/design-tokens/presets) and generate type-safe utility classes at build time with zero runtime CSS. The separator between items is rendered via a `::after` pseudo-element on each non-last item and can be overridden through the `--breadcrumb--separator-content` CSS variable.
+
+## Why use the Breadcrumb recipe?
+
+The Breadcrumb recipe helps you:
+
+- **Ship faster with sensible defaults**: Get 3 colors, 3 sizes, and active/disabled states out of the box with a pair of composable calls.
+- **Compose flexible layouts**: Two coordinated recipes (container + item) share the size axis, so your breadcrumb stays internally consistent.
+- **Maintain consistency**: Compound variants ensure every color follows the same design rules, including hover, focus, active, and dark mode states.
+- **Customize without forking**: Override base styles, default variants, the separator glyph, or filter out options you don't need &mdash; all through the options API or the `--breadcrumb--separator-content` CSS variable.
+- **Stay type-safe**: Full TypeScript support means your editor catches invalid color, size, or state values at compile time.
+- **Integrate with your tokens**: Every value references the design tokens preset, so theme changes propagate automatically.
+
+## Usage
+
+::steps{level="4"}
+
+#### Register the recipes
+
+Add the Breadcrumb recipes to a local Styleframe instance. The global `styleframe.config.ts` provides design tokens and utilities, while the component-level file registers the recipes themselves:
+
+:::code-tree{default-value="src/components/breadcrumb.styleframe.ts"}
+
+```ts [src/components/breadcrumb.styleframe.ts]
+import { styleframe } from 'virtual:styleframe';
+import { useBreadcrumbRecipe, useBreadcrumbItemRecipe } from '@styleframe/theme';
+
+const s = styleframe();
+
+const breadcrumb = useBreadcrumbRecipe(s);
+const breadcrumbItem = useBreadcrumbItemRecipe(s);
+
+export default s;
+```
+
+```ts [styleframe.config.ts]
+import { styleframe } from 'styleframe';
+import { useDesignTokensPreset, useUtilitiesPreset } from '@styleframe/theme';
+
+const s = styleframe();
+
+useDesignTokensPreset(s);
+useUtilitiesPreset(s);
+
+export default s;
+```
+
+:::
+
+#### Build the component
+
+Import the `breadcrumb` and `breadcrumbItem` runtime functions from the virtual module and pass variant props to compute class names:
+
+:::tabs
+::::tabs-item{icon="i-devicon-react" label="React"}
+
+```ts [src/components/Breadcrumb.tsx]
+import { breadcrumb, breadcrumbItem } from "virtual:styleframe";
+
+interface BreadcrumbProps {
+	size?: "sm" | "md" | "lg";
+	children?: React.ReactNode;
+}
+
+interface BreadcrumbItemProps {
+	color?: "light" | "dark" | "neutral";
+	size?: "sm" | "md" | "lg";
+	active?: boolean;
+	disabled?: boolean;
+	href?: string;
+	children?: React.ReactNode;
+}
+
+export function Breadcrumb({ size = "md", children }: BreadcrumbProps) {
+	return (
+		<nav aria-label="Breadcrumb" className={breadcrumb({ size })}>
+			{children}
+		</nav>
+	);
+}
+
+export function BreadcrumbItem({
+	color = "neutral",
+	size = "md",
+	active = false,
+	disabled = false,
+	href,
+	children,
+}: BreadcrumbItemProps) {
+	const className = breadcrumbItem({
+		color,
+		size,
+		active: active ? "true" : "false",
+		disabled: disabled ? "true" : "false",
+	});
+
+	if (active) {
+		return (
+			<span className={className} aria-current="page">
+				{children}
+			</span>
+		);
+	}
+
+	return (
+		<a
+			href={href}
+			className={className}
+			aria-disabled={disabled || undefined}
+			tabIndex={disabled ? -1 : undefined}
+		>
+			{children}
+		</a>
+	);
+}
+```
+
+::::
+::::tabs-item{icon="i-devicon-vuejs" label="Vue"}
+
+```vue [src/components/Breadcrumb.vue]
+<script setup lang="ts">
+import { breadcrumb } from "virtual:styleframe";
+
+const { size = "md" } = defineProps<{
+	size?: "sm" | "md" | "lg";
+}>();
+</script>
+
+<template>
+	<nav aria-label="Breadcrumb" :class="breadcrumb({ size })">
+		<slot />
+	</nav>
+</template>
+```
+
+```vue [src/components/BreadcrumbItem.vue]
+<script setup lang="ts">
+import { computed } from "vue";
+import { breadcrumbItem } from "virtual:styleframe";
+
+const {
+	color = "neutral",
+	size = "md",
+	active = false,
+	disabled = false,
+	href,
+} = defineProps<{
+	color?: "light" | "dark" | "neutral";
+	size?: "sm" | "md" | "lg";
+	active?: boolean;
+	disabled?: boolean;
+	href?: string;
+}>();
+
+const tag = computed(() => (active ? "span" : "a"));
+</script>
+
+<template>
+	<component
+		:is="tag"
+		:class="breadcrumbItem({ color, size, active: active ? 'true' : 'false', disabled: disabled ? 'true' : 'false' })"
+		:href="!active ? href : undefined"
+		:aria-current="active ? 'page' : undefined"
+		:aria-disabled="disabled || undefined"
+		:tabindex="disabled ? -1 : undefined"
+	>
+		<slot />
+	</component>
+</template>
+```
+
+::::
+:::
+
+#### See it in action
+
+:::story-preview
+---
+story: theme-recipes-breadcrumb--default
+panel: true
+---
+:::
+
+::
+
+## Colors
+
+The Breadcrumb item recipe includes 3 color variants: `light`, `dark`, and `neutral`. Like the Nav recipe, Breadcrumb uses neutral-spectrum colors designed for structural navigation rather than status communication. Each color is paired with hover, focus, active, and dark-mode overrides through compound variants, so you get consistent styling across light and dark themes.
+
+The `neutral` color adapts automatically: it uses dark text in light mode and light text in dark mode, making it the safest default for most applications.
+
+::story-preview
+---
+story: theme-recipes-breadcrumb--neutral
+panel: true
+---
+::
+
+### Color Reference
+
+::story-preview
+---
+story: theme-recipes-breadcrumb--all-variants
+---
+::
+
+| Color | Token | Use Case |
+|-------|-------|----------|
+| `light` | `@color.text` / `@color.text-inverted` | Breadcrumbs on light backgrounds, stays light-text in dark mode |
+| `dark` | `@color.gray-200` / `@color.white` | Breadcrumbs on dark backgrounds, stays dark appearance in light mode |
+| `neutral` | Adaptive (light ↔ dark) | Default color, adapts to the current color scheme |
+
+::tip
+**Pro tip:** Use `neutral` as your default breadcrumb color. It adapts automatically to the user's color scheme, so you don't need to manage light and dark variants separately.
+::
+
+## Sizes
+
+Three size variants from `sm` to `lg` control the font size, gap, and padding of the breadcrumb. The `size` prop affects both the container (font size and gap between items) and individual items (font size and padding).
+
+::story-preview
+---
+story: theme-recipes-breadcrumb--all-sizes
+---
+::
+
+**Breadcrumb Container:**
+
+| Size | Font Size | Gap |
+|------|-----------|-----|
+| `sm` | `@font-size.xs` | `@0.25` |
+| `md` | `@font-size.sm` | `@0.5` |
+| `lg` | `@font-size.md` | `@0.75` |
+
+**Breadcrumb Item:**
+
+| Size | Font Size | Padding (V / H) |
+|------|-----------|-----------------|
+| `sm` | `@font-size.xs` | `@0.25` / `@0.5` |
+| `md` | `@font-size.sm` | `@0.375` / `@0.75` |
+| `lg` | `@font-size.md` | `@0.5` / `@1` |
+
+::note
+**Good to know:** The `size` prop must be passed to both the breadcrumb container and each breadcrumb item individually. The container controls font size and gap between items, while items control their own padding.
+::
+
+## Active
+
+The Breadcrumb item recipe includes an `active` boolean variant for marking the current page. Active items receive `font-weight: semibold`, switch the cursor to `default`, and drop the link-style hover underline so the current location is clearly distinguished from interactive ancestors.
+
+::story-preview
+---
+story: theme-recipes-breadcrumb--active
+panel: true
+---
+::
+
+```ts
+// Active item via variant prop
+breadcrumbItem({ color: "neutral", size: "md", active: "true" })
+```
+
+::tip
+**Good practice:** Always pair the active variant with `aria-current="page"` so both sighted users and screen reader users know which page is currently active. The recommended pattern is to render the active item as a `<span>` (not an `<a>`) since it has no destination.
+::
+
+## Disabled
+
+The Breadcrumb item recipe includes a `disabled` boolean variant that mirrors the `:disabled` pseudo-class for `<button>` elements. It reduces opacity to 0.5, sets `cursor: not-allowed`, and disables pointer events &mdash; useful when an ancestor exists but the user does not have permission to navigate there.
+
+::story-preview
+---
+story: theme-recipes-breadcrumb--disabled
+panel: true
+---
+::
+
+```ts
+// Disabled item via variant prop
+breadcrumbItem({ color: "neutral", size: "md", disabled: "true" })
+```
+
+## Separator
+
+The separator between breadcrumb items is rendered via a `::after` pseudo-element on every non-last item. Its content is read from the `--breadcrumb--separator-content` CSS variable, which defaults to `'/'`. Override it on the breadcrumb root, on individual items, or on any ancestor to swap the glyph without overriding the recipe.
+
+::story-preview
+---
+story: theme-recipes-breadcrumb--custom-separator
+panel: true
+---
+::
+
+```html
+<!-- Use a chevron via Unicode escape -->
+<nav aria-label="Breadcrumb" class="..." style="--breadcrumb--separator-content: '\203A'">
+    <a class="..." href="/">Home</a>
+    <a class="..." href="/library">Library</a>
+    <span class="..." aria-current="page">Current Page</span>
+</nav>
+```
+
+::tip
+**Pro tip:** The separator color uses `currentColor` with `opacity: 0.6`, so it inherits the item's text color while staying visually muted. To use a fully custom color, target `.breadcrumb-item::after` directly with your own CSS.
+::
+
+## Anatomy
+
+The Breadcrumb recipe is composed of two independent recipes that work together to form a navigation trail:
+
+| Part | Recipe | Role |
+|------|--------|------|
+| **Container** | `useBreadcrumbRecipe()` | Outer wrapper with flex layout and gap |
+| **Item** | `useBreadcrumbItemRecipe()` | Individual breadcrumb entry with color, size, active, and disabled states |
+
+Each part is a standalone recipe with its own set of variants. The `size` prop should be passed consistently to both the container and each item so that font sizes and spacing stay coordinated. The `color`, `active`, and `disabled` props only apply to items.
+
+```html
+<!-- Both parts working together -->
+<nav aria-label="Breadcrumb" class="breadcrumb(...)">
+    <a class="breadcrumbItem(...)" href="/">Home</a>
+    <a class="breadcrumbItem(...)" href="/library">Library</a>
+    <span class="breadcrumbItem({ active: 'true' })" aria-current="page">Current Page</span>
+</nav>
+```
+
+::tip
+**Pro tip:** The container recipe controls layout (flex direction, spacing) while the item recipe controls appearance (color, hover states, active/disabled states) and emits the separator. Items work without the container if you manage the layout yourself &mdash; the separator only relies on items being siblings under one parent.
+::
+
+## Accessibility
+
+- **Use semantic HTML.** Render the container as a `<nav>` element with `aria-label="Breadcrumb"` so the navigation landmark is named for assistive technology. Render each non-current item as an `<a>` with an `href`; render the current item as a `<span>` (or another non-link element) so it has no link affordance.
+
+```html
+<!-- Correct: nav landmark with label, current item is not a link -->
+<nav aria-label="Breadcrumb" class="...">
+    <a href="/" class="...">Home</a>
+    <a href="/library" class="...">Library</a>
+    <span class="breadcrumbItem({ active: 'true' })" aria-current="page">Current Page</span>
+</nav>
+
+<!-- Avoid: current item rendered as a self-referential link -->
+<a href="/library/current" aria-current="page">Current Page</a>
+```
+
+- **Mark the current page with `aria-current="page"`.** When a breadcrumb item represents the active page, add `aria-current="page"` alongside the `active: "true"` variant so screen readers announce it as the current location ([WCAG 2.4.8](https://www.w3.org/WAI/WCAG21/Understanding/location.html)).
+- **Hide decorative separators from assistive technology.** The `::after` separator is a CSS pseudo-element, which is already invisible to most screen readers. If you implement separators differently (for example, by inserting glyph characters in the DOM), wrap them in elements with `aria-hidden="true"`.
+- **Focus visibility.** The breadcrumb item recipe includes a `:focus-visible` outline (2px solid, primary color, 2px offset) that appears only during keyboard navigation ([WCAG 2.4.7](https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html)).
+- **Disabled state.** For `<a>` elements, pass `disabled: "true"` and add `aria-disabled="true"` and `tabindex="-1"` to remove the link from the tab order. The `:disabled` pseudo-class handles `<button>` elements automatically.
+
+```html
+<!-- Correct: disabled link with ARIA attributes -->
+<a href="#" class="breadcrumbItem({ disabled: 'true' })" aria-disabled="true" tabindex="-1">
+    Restricted
+</a>
+```
+
+::tip
+**Good practice:** If a page has multiple `<nav>` landmarks (main navigation, footer navigation, breadcrumb), give each a distinct `aria-label` so screen reader users can tell them apart at a glance.
+::
+
+## Customization
+
+### Overriding Defaults
+
+Each breadcrumb composable accepts an optional second argument to override any part of the recipe configuration. Overrides are deep-merged with the defaults, so you only specify the properties you want to change:
+
+```ts [src/components/breadcrumb.styleframe.ts]
+import { styleframe } from 'virtual:styleframe';
+import { useBreadcrumbRecipe, useBreadcrumbItemRecipe } from '@styleframe/theme';
+
+const s = styleframe();
+
+const breadcrumb = useBreadcrumbRecipe(s, {
+    base: {
+        gap: '@1',
+    },
+    defaultVariants: {
+        size: 'lg',
+    },
+});
+
+const breadcrumbItem = useBreadcrumbItemRecipe(s, {
+    base: {
+        borderRadius: '@border-radius.sm',
+    },
+    defaultVariants: {
+        color: 'light',
+        size: 'lg',
+    },
+});
+
+export default s;
+```
+
+### Filtering Variants
+
+If you only need a subset of the available variants, use the `filter` option to limit which values are generated. This reduces the output CSS and keeps your component API focused:
+
+```ts [src/components/breadcrumb.styleframe.ts]
+import { styleframe } from 'virtual:styleframe';
+import { useBreadcrumbRecipe, useBreadcrumbItemRecipe } from '@styleframe/theme';
+
+const s = styleframe();
+
+const breadcrumb = useBreadcrumbRecipe(s);
+
+// Only generate the neutral color
+const breadcrumbItem = useBreadcrumbItemRecipe(s, {
+    filter: {
+        color: ['neutral'],
+    },
+});
+
+export default s;
+```
+
+::note
+**Good to know:** Filtering also removes compound variants and adjusts default variants that reference filtered-out values, so your recipe stays consistent.
+::
+
+## API Reference
+
+### `useBreadcrumbRecipe(s, options?)`
+
+Creates the breadcrumb container recipe with flex layout and size-controlled gap and typography.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `s` | `Styleframe` | The Styleframe instance |
+| `options` | `DeepPartial<RecipeConfig>` | Optional overrides for the recipe configuration |
+| `options.base` | `VariantDeclarationsBlock` | Custom base styles for the breadcrumb container |
+| `options.variants` | `Variants` | Custom variant definitions for the recipe |
+| `options.defaultVariants` | `Record<keyof Variants, string>` | Default variant values for the recipe |
+| `options.compoundVariants` | `CompoundVariant[]` | Custom compound variant definitions for the recipe |
+| `options.filter` | `Record<string, string[]>` | Limit which variant values are generated |
+
+**Variants:**
+
+| Variant | Options | Default |
+|---------|---------|---------|
+| `size` | `sm`, `md`, `lg` | `md` |
+
+### `useBreadcrumbItemRecipe(s, options?)`
+
+Creates the breadcrumb item recipe with color, size, and active/disabled boolean variants. The setup callback registers a global `selector(".breadcrumb-item:not(:last-child)::after", ...)` that emits the separator glyph between siblings.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `s` | `Styleframe` | The Styleframe instance |
+| `options` | `DeepPartial<RecipeConfig>` | Optional overrides for the recipe configuration |
+| `options.base` | `VariantDeclarationsBlock` | Custom base styles for the breadcrumb item |
+| `options.variants` | `Variants` | Custom variant definitions for the recipe |
+| `options.defaultVariants` | `Record<keyof Variants, string>` | Default variant values for the recipe |
+| `options.compoundVariants` | `CompoundVariant[]` | Custom compound variant definitions for the recipe |
+| `options.filter` | `Record<string, string[]>` | Limit which variant values are generated |
+
+**Variants:**
+
+| Variant | Options | Default |
+|---------|---------|---------|
+| `color` | `light`, `dark`, `neutral` | `neutral` |
+| `size` | `sm`, `md`, `lg` | `md` |
+| `active` | `true`, `false` | `false` |
+| `disabled` | `true`, `false` | `false` |
+
+**CSS variables:**
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `--breadcrumb--separator-content` | `'/'` | The `content` value for the `::after` separator on each non-last item |
+
+[Learn more about recipes →](/docs/api/recipes)
+
+## Best Practices
+
+- **Pass `size` consistently to both recipes**: The container controls gap and font size, while items control their own padding. Mismatched sizes create visual inconsistency.
+- **Use `neutral` for general-purpose breadcrumbs**: The neutral color adapts to light and dark mode automatically, making it the safest default.
+- **Render the current page as a non-link**: Use a `<span>` with `aria-current="page"` and `active: "true"` rather than a self-referential `<a>`, so the current location reads correctly to assistive technology and avoids confusing hover affordance.
+- **Override the separator with a CSS variable, not the recipe**: `--breadcrumb--separator-content` lives at the consumer level and avoids forking the recipe just to swap a glyph.
+- **Filter what you don't need**: If your application only uses a single color, pass a `filter` option to reduce generated CSS.
+- **Override defaults at the recipe level**: Set your most common combination as `defaultVariants` so component consumers write less code.
+
+## FAQ
+
+::accordion
+
+:::accordion-item{label="Why are there two separate recipes instead of one?" icon="i-lucide-circle-help"}
+Breadcrumb has two distinct concerns: the container manages layout (flex direction, gap, alignment) while items manage appearance (color, hover states, active/disabled states) and the separator. Two separate recipes keep each concern focused and let you customize them independently. You can also use breadcrumb items without the container if you manage the layout yourself.
+:::
+
+:::accordion-item{label="How do I change the separator glyph?" icon="i-lucide-circle-help"}
+The separator content is read from the `--breadcrumb--separator-content` CSS variable, which defaults to `'/'`. Set the variable on the breadcrumb root, on individual items, or on any ancestor (for example, the page `<body>`):
+
+```html
+<nav aria-label="Breadcrumb" style="--breadcrumb--separator-content: '\203A'">
+    ...
+</nav>
+```
+
+`\203A` is the Unicode escape for `›`. Common alternatives are `\203A` (›), `\bb` (»), and `\2192` (→). For an SVG icon, use `url(...)` as the value.
+:::
+
+:::accordion-item{label="Why doesn't the Breadcrumb recipe include semantic colors like primary or success?" icon="i-lucide-circle-help"}
+Breadcrumb items are structural navigation elements, not status indicators. Semantic colors (primary, success, error) communicate meaning through color, which is better suited to focused elements like badges, buttons, and callouts. Breadcrumb uses `light`, `dark`, and `neutral` to provide surface-appropriate text colors without implying status.
+:::
+
+:::accordion-item{label="How does the active state work?" icon="i-lucide-circle-help"}
+The active state is controlled by the `active` boolean variant (`"true"` / `"false"`). It sets `font-weight: semibold`, switches the cursor to `default`, and drops the hover-underline link affordance. Pass `active: "true"` on the current page item and pair it with `aria-current="page"` for accessibility. The recommended pattern is to render the active item as a `<span>` rather than an `<a>` since it has no destination.
+:::
+
+:::accordion-item{label="How does the disabled state work for links?" icon="i-lucide-circle-help"}
+HTML `<a>` elements do not support the native `disabled` attribute. The Breadcrumb item recipe provides a `disabled` boolean variant that applies the same styles as the `:disabled` pseudo-class (reduced opacity, not-allowed cursor, no pointer events). Pass `disabled: "true"` as a variant prop and pair it with `aria-disabled="true"` and `tabindex="-1"` so the link is also inaccessible to keyboard and assistive technology users.
+:::
+
+:::accordion-item{label="How do compound variants work in the Breadcrumb item recipe?" icon="i-lucide-circle-help"}
+The Breadcrumb item recipe uses compound variants to map each color to text-color and hover/focus/active styles. For example, when `color` is `neutral`, the compound variant applies `color: @color.text` in light mode and `color: @color.gray-200` in dark mode, plus underline hover overrides. A separate compound matches `active: "true"` (regardless of color) to suppress the hover underline and switch the cursor to `default`. This keeps the individual `color` and `active` definitions minimal while handling all the cross-axis behavior centrally.
+
+[Learn more about compound variants →](/docs/api/recipes#compound-variants)
+:::
+
+:::accordion-item{label="How does filtering affect compound variants?" icon="i-lucide-circle-help"}
+When you use the `filter` option, compound variants that reference filtered-out values are automatically removed. For example, if you filter `color` to only `['neutral']`, the `light` and `dark` color compounds are excluded from the generated output. Default variants are also adjusted if they reference a removed value.
+:::
+
+:::accordion-item{label="Can I use the Breadcrumb recipe without the design tokens preset?" icon="i-lucide-circle-help"}
+The Breadcrumb recipe references design tokens like `@color.primary`, `@font-size.sm`, and `@font-weight.semibold` through string refs. These tokens need to be defined in your Styleframe instance for the recipe to generate valid CSS. The easiest way is to use `useDesignTokensPreset(s)`, but you can also define the required tokens manually.
+:::
+
+::

--- a/apps/storybook/src/components/components/breadcrumb/Breadcrumb.vue
+++ b/apps/storybook/src/components/components/breadcrumb/Breadcrumb.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { breadcrumb } from "virtual:styleframe";
+
+const props = withDefaults(
+	defineProps<{
+		size?: "sm" | "md" | "lg";
+		separator?: string;
+	}>(),
+	{
+		separator: "/",
+	},
+);
+
+const slots = defineSlots<{ default(): unknown }>();
+</script>
+
+<template>
+	<nav aria-label="Breadcrumb">
+		<ol
+			:class="
+				breadcrumb({
+					size: props.size,
+				})
+			"
+		>
+			<template v-for="(child, i) in slots.default()" :key="i">
+				<li v-if="i > 0" aria-hidden="true">
+					<span class="breadcrumb-separator">{{ props.separator }}</span>
+				</li>
+				<component :is="child" />
+			</template>
+		</ol>
+	</nav>
+</template>

--- a/apps/storybook/src/components/components/breadcrumb/BreadcrumbItem.vue
+++ b/apps/storybook/src/components/components/breadcrumb/BreadcrumbItem.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { breadcrumbItem } from "virtual:styleframe";
+
+const props = withDefaults(
+	defineProps<{
+		color?: "light" | "dark" | "neutral";
+		size?: "sm" | "md" | "lg";
+		active?: boolean;
+		disabled?: boolean;
+		href?: string;
+	}>(),
+	{},
+);
+
+const tag = computed(() => (props.active ? "span" : "a"));
+</script>
+
+<template>
+	<li>
+		<component
+			:is="tag"
+			:class="
+				breadcrumbItem({
+					color: props.color,
+					size: props.size,
+					active: props.active ? 'true' : 'false',
+					disabled: props.disabled ? 'true' : 'false',
+				})
+			"
+			:href="!props.active ? props.href : undefined"
+			:aria-current="props.active ? 'page' : undefined"
+			:aria-disabled="props.disabled || undefined"
+		>
+			<slot />
+		</component>
+	</li>
+</template>

--- a/apps/storybook/src/components/components/breadcrumb/preview/BreadcrumbGrid.vue
+++ b/apps/storybook/src/components/components/breadcrumb/preview/BreadcrumbGrid.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import Breadcrumb from "../Breadcrumb.vue";
+import BreadcrumbItem from "../BreadcrumbItem.vue";
+
+const colors = ["light", "dark", "neutral"] as const;
+</script>
+
+<template>
+	<div class="breadcrumb-section">
+		<div v-for="color in colors" :key="color">
+			<hr />
+			<div class="breadcrumb-label">{{ color }}</div>
+			<hr />
+			<div class="breadcrumb-row">
+				<Breadcrumb>
+					<BreadcrumbItem :color="color" href="#">Home</BreadcrumbItem>
+					<BreadcrumbItem :color="color" href="#">Library</BreadcrumbItem>
+					<BreadcrumbItem :color="color" href="#" disabled>
+						Archive
+					</BreadcrumbItem>
+					<BreadcrumbItem :color="color" active>Current</BreadcrumbItem>
+				</Breadcrumb>
+			</div>
+		</div>
+	</div>
+</template>

--- a/apps/storybook/src/components/components/breadcrumb/preview/BreadcrumbSizeGrid.vue
+++ b/apps/storybook/src/components/components/breadcrumb/preview/BreadcrumbSizeGrid.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import Breadcrumb from "../Breadcrumb.vue";
+import BreadcrumbItem from "../BreadcrumbItem.vue";
+
+const sizes = ["sm", "md", "lg"] as const;
+</script>
+
+<template>
+	<div class="breadcrumb-section">
+		<div v-for="size in sizes" :key="size">
+			<div class="breadcrumb-label">{{ size }}</div>
+			<Breadcrumb :size="size">
+				<BreadcrumbItem :size="size" href="#">Home</BreadcrumbItem>
+				<BreadcrumbItem :size="size" href="#">Library</BreadcrumbItem>
+				<BreadcrumbItem :size="size" active>Current</BreadcrumbItem>
+			</Breadcrumb>
+		</div>
+	</div>
+</template>

--- a/apps/storybook/stories/components/breadcrumb.stories.ts
+++ b/apps/storybook/stories/components/breadcrumb.stories.ts
@@ -1,0 +1,192 @@
+import type { Meta, StoryObj } from "@storybook/vue3-vite";
+
+import Breadcrumb from "../../src/components/components/breadcrumb/Breadcrumb.vue";
+import BreadcrumbItem from "../../src/components/components/breadcrumb/BreadcrumbItem.vue";
+import BreadcrumbGrid from "../../src/components/components/breadcrumb/preview/BreadcrumbGrid.vue";
+import BreadcrumbSizeGrid from "../../src/components/components/breadcrumb/preview/BreadcrumbSizeGrid.vue";
+
+const sizes = ["sm", "md", "lg"] as const;
+
+const meta = {
+	title: "Theme/Recipes/Breadcrumb",
+	component: Breadcrumb,
+	tags: ["autodocs"],
+	parameters: {
+		layout: "padded",
+	},
+	argTypes: {
+		size: {
+			control: "select",
+			options: sizes,
+			description: "The size of the breadcrumb",
+		},
+	},
+} satisfies Meta<typeof Breadcrumb>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	render: (args) => ({
+		components: { Breadcrumb, BreadcrumbItem },
+		setup() {
+			return { args };
+		},
+		template: `
+			<Breadcrumb v-bind="args">
+				<BreadcrumbItem href="#">Home</BreadcrumbItem>
+				<BreadcrumbItem href="#">Library</BreadcrumbItem>
+				<BreadcrumbItem active>Current Page</BreadcrumbItem>
+			</Breadcrumb>
+		`,
+	}),
+};
+
+export const AllVariants: StoryObj = {
+	render: () => ({
+		components: { BreadcrumbGrid },
+		template: "<BreadcrumbGrid />",
+	}),
+};
+
+export const AllSizes: StoryObj = {
+	render: () => ({
+		components: { BreadcrumbSizeGrid },
+		template: "<BreadcrumbSizeGrid />",
+	}),
+};
+
+// Color stories
+
+export const Light: Story = {
+	render: () => ({
+		components: { Breadcrumb, BreadcrumbItem },
+		template: `
+			<Breadcrumb>
+				<BreadcrumbItem color="light" href="#">Home</BreadcrumbItem>
+				<BreadcrumbItem color="light" href="#">Library</BreadcrumbItem>
+				<BreadcrumbItem color="light" active>Current Page</BreadcrumbItem>
+			</Breadcrumb>
+		`,
+	}),
+};
+
+export const Dark: Story = {
+	render: () => ({
+		components: { Breadcrumb, BreadcrumbItem },
+		template: `
+			<Breadcrumb>
+				<BreadcrumbItem color="dark" href="#">Home</BreadcrumbItem>
+				<BreadcrumbItem color="dark" href="#">Library</BreadcrumbItem>
+				<BreadcrumbItem color="dark" active>Current Page</BreadcrumbItem>
+			</Breadcrumb>
+		`,
+	}),
+};
+
+export const Neutral: Story = {
+	render: () => ({
+		components: { Breadcrumb, BreadcrumbItem },
+		template: `
+			<Breadcrumb>
+				<BreadcrumbItem color="neutral" href="#">Home</BreadcrumbItem>
+				<BreadcrumbItem color="neutral" href="#">Library</BreadcrumbItem>
+				<BreadcrumbItem color="neutral" active>Current Page</BreadcrumbItem>
+			</Breadcrumb>
+		`,
+	}),
+};
+
+// Size stories
+
+export const Small: Story = {
+	args: { size: "sm" },
+	render: (args) => ({
+		components: { Breadcrumb, BreadcrumbItem },
+		setup() {
+			return { args };
+		},
+		template: `
+			<Breadcrumb v-bind="args">
+				<BreadcrumbItem size="sm" href="#">Home</BreadcrumbItem>
+				<BreadcrumbItem size="sm" href="#">Library</BreadcrumbItem>
+				<BreadcrumbItem size="sm" active>Current</BreadcrumbItem>
+			</Breadcrumb>
+		`,
+	}),
+};
+
+export const Medium: Story = {
+	args: { size: "md" },
+	render: (args) => ({
+		components: { Breadcrumb, BreadcrumbItem },
+		setup() {
+			return { args };
+		},
+		template: `
+			<Breadcrumb v-bind="args">
+				<BreadcrumbItem size="md" href="#">Home</BreadcrumbItem>
+				<BreadcrumbItem size="md" href="#">Library</BreadcrumbItem>
+				<BreadcrumbItem size="md" active>Current</BreadcrumbItem>
+			</Breadcrumb>
+		`,
+	}),
+};
+
+export const Large: Story = {
+	args: { size: "lg" },
+	render: (args) => ({
+		components: { Breadcrumb, BreadcrumbItem },
+		setup() {
+			return { args };
+		},
+		template: `
+			<Breadcrumb v-bind="args">
+				<BreadcrumbItem size="lg" href="#">Home</BreadcrumbItem>
+				<BreadcrumbItem size="lg" href="#">Library</BreadcrumbItem>
+				<BreadcrumbItem size="lg" active>Current</BreadcrumbItem>
+			</Breadcrumb>
+		`,
+	}),
+};
+
+// Feature stories
+
+export const Active: Story = {
+	render: () => ({
+		components: { Breadcrumb, BreadcrumbItem },
+		template: `
+			<Breadcrumb>
+				<BreadcrumbItem href="#">Home</BreadcrumbItem>
+				<BreadcrumbItem href="#">Library</BreadcrumbItem>
+				<BreadcrumbItem active>Current Page</BreadcrumbItem>
+			</Breadcrumb>
+		`,
+	}),
+};
+
+export const Disabled: Story = {
+	render: () => ({
+		components: { Breadcrumb, BreadcrumbItem },
+		template: `
+			<Breadcrumb>
+				<BreadcrumbItem href="#">Home</BreadcrumbItem>
+				<BreadcrumbItem href="#" disabled>Disabled</BreadcrumbItem>
+				<BreadcrumbItem active>Current Page</BreadcrumbItem>
+			</Breadcrumb>
+		`,
+	}),
+};
+
+export const CustomSeparator: StoryObj = {
+	render: () => ({
+		components: { Breadcrumb, BreadcrumbItem },
+		template: `
+			<Breadcrumb separator="›">
+				<BreadcrumbItem href="#">Home</BreadcrumbItem>
+				<BreadcrumbItem href="#">Library</BreadcrumbItem>
+				<BreadcrumbItem active>Current Page</BreadcrumbItem>
+			</Breadcrumb>
+		`,
+	}),
+};

--- a/apps/storybook/stories/components/breadcrumb.styleframe.ts
+++ b/apps/storybook/stories/components/breadcrumb.styleframe.ts
@@ -1,0 +1,42 @@
+import {
+	useBreadcrumbItemRecipe,
+	useBreadcrumbRecipe,
+} from "@styleframe/theme";
+import { styleframe } from "virtual:styleframe";
+
+const s = styleframe();
+const { selector } = s;
+
+export const breadcrumb = useBreadcrumbRecipe(s);
+export const breadcrumbItem = useBreadcrumbItemRecipe(s);
+
+// Layout selectors for story grid previews
+selector(".breadcrumb-grid", {
+	display: "flex",
+	flexWrap: "wrap",
+	gap: "@spacing.md",
+	padding: "@spacing.md",
+	alignItems: "flex-start",
+});
+
+selector(".breadcrumb-section", {
+	display: "flex",
+	flexDirection: "column",
+	gap: "@spacing.lg",
+	padding: "@spacing.md",
+});
+
+selector(".breadcrumb-row", {
+	display: "flex",
+	flexWrap: "wrap",
+	gap: "@spacing.sm",
+	alignItems: "flex-start",
+});
+
+selector(".breadcrumb-label", {
+	fontSize: "@font-size.sm",
+	fontWeight: "@font-weight.semibold",
+	minWidth: "80px",
+});
+
+export default s;

--- a/theme/src/recipes/breadcrumb/index.ts
+++ b/theme/src/recipes/breadcrumb/index.ts
@@ -1,0 +1,2 @@
+export * from "./useBreadcrumbRecipe";
+export * from "./useBreadcrumbItemRecipe";

--- a/theme/src/recipes/breadcrumb/useBreadcrumbItemRecipe.test.ts
+++ b/theme/src/recipes/breadcrumb/useBreadcrumbItemRecipe.test.ts
@@ -1,0 +1,379 @@
+import { styleframe } from "@styleframe/core";
+import { useDisabledModifier } from "../../modifiers/useFormStateModifiers";
+import { useDarkModifier } from "../../modifiers/useMediaPreferenceModifiers";
+import {
+	useActiveModifier,
+	useFocusModifier,
+	useFocusVisibleModifier,
+	useHoverModifier,
+} from "../../modifiers/usePseudoStateModifiers";
+import { useBreadcrumbItemRecipe } from "./index";
+
+function createInstance() {
+	const s = styleframe();
+	for (const name of [
+		"display",
+		"alignItems",
+		"cursor",
+		"background",
+		"fontWeight",
+		"lineHeight",
+		"textDecoration",
+		"transitionProperty",
+		"transitionTimingFunction",
+		"transitionDuration",
+		"outline",
+		"outlineWidth",
+		"outlineStyle",
+		"outlineColor",
+		"outlineOffset",
+		"opacity",
+		"pointerEvents",
+		"fontSize",
+		"color",
+		"content",
+		"textUnderlineOffset",
+	]) {
+		s.utility(name, ({ value }) => ({ [name]: value }));
+	}
+	useDarkModifier(s);
+	useHoverModifier(s);
+	useFocusModifier(s);
+	useFocusVisibleModifier(s);
+	useActiveModifier(s);
+	useDisabledModifier(s);
+	return s;
+}
+
+describe("useBreadcrumbItemRecipe", () => {
+	it("should create a recipe with correct metadata", () => {
+		const s = createInstance();
+		const recipe = useBreadcrumbItemRecipe(s);
+
+		expect(recipe.type).toBe("recipe");
+		expect(recipe.name).toBe("breadcrumb-item");
+	});
+
+	it("should have correct base styles", () => {
+		const s = createInstance();
+		const recipe = useBreadcrumbItemRecipe(s);
+
+		expect(recipe.base).toEqual({
+			display: "inline-flex",
+			alignItems: "center",
+			cursor: "pointer",
+			background: "transparent",
+			fontWeight: "@font-weight.normal",
+			lineHeight: "@line-height.normal",
+			textDecoration: "none",
+			transitionProperty: "color, background-color",
+			transitionTimingFunction: "@easing.ease-in-out",
+			transitionDuration: "150ms",
+			outline: "none",
+			"&:hover": {
+				textDecoration: "none",
+			},
+			"&:focus": {
+				textDecoration: "none",
+			},
+			"&:focus-visible": {
+				outlineWidth: "2px",
+				outlineStyle: "solid",
+				outlineColor: "@color.primary",
+				outlineOffset: "2px",
+			},
+			"&:disabled": {
+				cursor: "not-allowed",
+				opacity: "0.5",
+				pointerEvents: "none",
+			},
+		});
+	});
+
+	describe("variants", () => {
+		it("should have all color variants", () => {
+			const s = createInstance();
+			const recipe = useBreadcrumbItemRecipe(s);
+
+			expect(Object.keys(recipe.variants!.color)).toEqual([
+				"light",
+				"dark",
+				"neutral",
+			]);
+		});
+
+		it("should have size variants with correct styles", () => {
+			const s = createInstance();
+			const recipe = useBreadcrumbItemRecipe(s);
+
+			expect(recipe.variants!.size).toEqual({
+				sm: {
+					fontSize: "@font-size.xs",
+				},
+				md: {
+					fontSize: "@font-size.sm",
+				},
+				lg: {
+					fontSize: "@font-size.md",
+				},
+			});
+		});
+
+		it("should have active variants", () => {
+			const s = createInstance();
+			const recipe = useBreadcrumbItemRecipe(s);
+
+			expect(recipe.variants!.active).toEqual({
+				true: {
+					fontWeight: "@font-weight.semibold",
+				},
+				false: {},
+			});
+		});
+
+		it("should have disabled variants", () => {
+			const s = createInstance();
+			const recipe = useBreadcrumbItemRecipe(s);
+
+			expect(recipe.variants!.disabled).toEqual({
+				true: {
+					cursor: "not-allowed",
+					opacity: "0.5",
+					pointerEvents: "none",
+				},
+				false: {},
+			});
+		});
+	});
+
+	it("should have correct default variants", () => {
+		const s = createInstance();
+		const recipe = useBreadcrumbItemRecipe(s);
+
+		expect(recipe.defaultVariants).toEqual({
+			color: "neutral",
+			size: "md",
+			active: "false",
+			disabled: "false",
+		});
+	});
+
+	describe("compound variants", () => {
+		it("should have 4 compound variants total", () => {
+			const s = createInstance();
+			const recipe = useBreadcrumbItemRecipe(s);
+
+			// 3 colors + 1 active override
+			expect(recipe.compoundVariants).toHaveLength(4);
+		});
+
+		it("should have correct light color compound variant", () => {
+			const s = createInstance();
+			const recipe = useBreadcrumbItemRecipe(s);
+
+			const light = recipe.compoundVariants!.find(
+				(cv) => cv.match.color === "light",
+			);
+
+			expect(light).toEqual({
+				match: { color: "light" },
+				css: {
+					color: "@color.text",
+					"&:hover": {
+						color: "@color.gray-900",
+						textDecoration: "underline",
+						textUnderlineOffset: "4px",
+					},
+					"&:focus": {
+						color: "@color.gray-900",
+						textDecoration: "underline",
+						textUnderlineOffset: "4px",
+					},
+					"&:active": {
+						color: "@color.gray-900",
+						textDecoration: "underline",
+						textUnderlineOffset: "4px",
+					},
+					"&:dark": {
+						color: "@color.text-inverted",
+					},
+					"&:dark:hover": {
+						color: "@color.gray-900",
+					},
+					"&:dark:focus": {
+						color: "@color.gray-900",
+					},
+					"&:dark:active": {
+						color: "@color.gray-900",
+					},
+				},
+			});
+		});
+
+		it("should have correct dark color compound variant", () => {
+			const s = createInstance();
+			const recipe = useBreadcrumbItemRecipe(s);
+
+			const dark = recipe.compoundVariants!.find(
+				(cv) => cv.match.color === "dark",
+			);
+
+			expect(dark).toEqual({
+				match: { color: "dark" },
+				css: {
+					color: "@color.gray-200",
+					"&:hover": {
+						color: "@color.white",
+						textDecoration: "underline",
+						textUnderlineOffset: "4px",
+					},
+					"&:focus": {
+						color: "@color.white",
+						textDecoration: "underline",
+						textUnderlineOffset: "4px",
+					},
+					"&:active": {
+						color: "@color.white",
+						textDecoration: "underline",
+						textUnderlineOffset: "4px",
+					},
+					"&:dark": {
+						color: "@color.gray-200",
+					},
+					"&:dark:hover": {
+						color: "@color.white",
+					},
+					"&:dark:focus": {
+						color: "@color.white",
+					},
+					"&:dark:active": {
+						color: "@color.white",
+					},
+				},
+			});
+		});
+
+		it("should have correct neutral color compound variant with adaptive dark mode", () => {
+			const s = createInstance();
+			const recipe = useBreadcrumbItemRecipe(s);
+
+			const neutral = recipe.compoundVariants!.find(
+				(cv) => cv.match.color === "neutral",
+			);
+
+			expect(neutral).toEqual({
+				match: { color: "neutral" },
+				css: {
+					color: "@color.text",
+					"&:hover": {
+						color: "@color.gray-900",
+						textDecoration: "underline",
+						textUnderlineOffset: "4px",
+					},
+					"&:focus": {
+						color: "@color.gray-900",
+						textDecoration: "underline",
+						textUnderlineOffset: "4px",
+					},
+					"&:active": {
+						color: "@color.gray-900",
+						textDecoration: "underline",
+						textUnderlineOffset: "4px",
+					},
+					"&:dark": {
+						color: "@color.gray-200",
+					},
+					"&:dark:hover": {
+						color: "@color.white",
+					},
+					"&:dark:focus": {
+						color: "@color.white",
+					},
+					"&:dark:active": {
+						color: "@color.white",
+					},
+				},
+			});
+		});
+
+		it("should have correct active compound variant that suppresses link affordance", () => {
+			const s = createInstance();
+			const recipe = useBreadcrumbItemRecipe(s);
+
+			const active = recipe.compoundVariants!.find(
+				(cv) => cv.match.active === "true",
+			);
+
+			expect(active).toEqual({
+				match: { active: "true" },
+				css: {
+					cursor: "default",
+					"&:hover": {
+						textDecoration: "none",
+					},
+					"&:focus": {
+						textDecoration: "none",
+					},
+					"&:active": {
+						textDecoration: "none",
+					},
+				},
+			});
+		});
+	});
+
+	describe("config overrides", () => {
+		it("should allow overriding base styles", () => {
+			const s = createInstance();
+			const recipe = useBreadcrumbItemRecipe(s, {
+				base: { display: "flex" },
+			});
+
+			expect(recipe.base!.display).toBe("flex");
+			expect(recipe.base!.cursor).toBe("pointer");
+		});
+	});
+
+	describe("filter", () => {
+		it("should filter color variants", () => {
+			const s = createInstance();
+			const recipe = useBreadcrumbItemRecipe(s, {
+				filter: { color: ["neutral"] },
+			});
+
+			expect(Object.keys(recipe.variants!.color)).toEqual(["neutral"]);
+		});
+
+		it("should prune compound variants when filtering colors", () => {
+			const s = createInstance();
+			const recipe = useBreadcrumbItemRecipe(s, {
+				filter: { color: ["neutral"] },
+			});
+
+			expect(
+				recipe.compoundVariants!.every(
+					(cv) => !cv.match.color || cv.match.color === "neutral",
+				),
+			).toBe(true);
+		});
+
+		it("should filter size variants", () => {
+			const s = createInstance();
+			const recipe = useBreadcrumbItemRecipe(s, {
+				filter: { size: ["sm", "lg"] },
+			});
+
+			expect(Object.keys(recipe.variants!.size)).toEqual(["sm", "lg"]);
+		});
+
+		it("should adjust default variants when filtered out", () => {
+			const s = createInstance();
+			const recipe = useBreadcrumbItemRecipe(s, {
+				filter: { color: ["light"] },
+			});
+
+			expect(recipe.defaultVariants?.color).toBeUndefined();
+			expect(recipe.defaultVariants?.size).toBe("md");
+		});
+	});
+});

--- a/theme/src/recipes/breadcrumb/useBreadcrumbItemRecipe.ts
+++ b/theme/src/recipes/breadcrumb/useBreadcrumbItemRecipe.ts
@@ -1,0 +1,202 @@
+import { createUseRecipe } from "../../utils/createUseRecipe";
+
+/**
+ * Breadcrumb item recipe for individual breadcrumb links.
+ * Supports color (light, dark, neutral), size, active, and disabled axes.
+ * The separator is registered via a setup callback as a global selector
+ * (`.breadcrumb-item:not(:last-child)::after`). Override the glyph by
+ * setting `--breadcrumb--separator-content` on the item or any ancestor.
+ */
+export const useBreadcrumbItemRecipe = createUseRecipe("breadcrumb-item", {
+	base: {
+		display: "inline-flex",
+		alignItems: "center",
+		cursor: "pointer",
+		background: "transparent",
+		fontWeight: "@font-weight.normal",
+		lineHeight: "@line-height.normal",
+		textDecoration: "none",
+		transitionProperty: "color, background-color",
+		transitionTimingFunction: "@easing.ease-in-out",
+		transitionDuration: "150ms",
+		outline: "none",
+		"&:hover": {
+			textDecoration: "none",
+		},
+		"&:focus": {
+			textDecoration: "none",
+		},
+		"&:focus-visible": {
+			outlineWidth: "2px",
+			outlineStyle: "solid",
+			outlineColor: "@color.primary",
+			outlineOffset: "2px",
+		},
+		"&:disabled": {
+			cursor: "not-allowed",
+			opacity: "0.5",
+			pointerEvents: "none",
+		},
+	},
+	variants: {
+		color: {
+			light: {},
+			dark: {},
+			neutral: {},
+		},
+		size: {
+			sm: {
+				fontSize: "@font-size.xs",
+			},
+			md: {
+				fontSize: "@font-size.sm",
+			},
+			lg: {
+				fontSize: "@font-size.md",
+			},
+		},
+		active: {
+			true: {
+				fontWeight: "@font-weight.semibold",
+			},
+			false: {},
+		},
+		disabled: {
+			true: {
+				cursor: "not-allowed",
+				opacity: "0.5",
+				pointerEvents: "none",
+			},
+			false: {},
+		},
+	},
+	compoundVariants: [
+		// Light color (fixed across themes — always dark text for light backgrounds)
+		{
+			match: { color: "light" as const },
+			css: {
+				color: "@color.text",
+				"&:hover": {
+					color: "@color.gray-900",
+					textDecoration: "underline",
+					textUnderlineOffset: "4px",
+				},
+				"&:focus": {
+					color: "@color.gray-900",
+					textDecoration: "underline",
+					textUnderlineOffset: "4px",
+				},
+				"&:active": {
+					color: "@color.gray-900",
+					textDecoration: "underline",
+					textUnderlineOffset: "4px",
+				},
+				"&:dark": {
+					color: "@color.text-inverted",
+				},
+				"&:dark:hover": {
+					color: "@color.gray-900",
+				},
+				"&:dark:focus": {
+					color: "@color.gray-900",
+				},
+				"&:dark:active": {
+					color: "@color.gray-900",
+				},
+			},
+		},
+
+		// Dark color (fixed across themes — matches neutral's dark mode appearance)
+		{
+			match: { color: "dark" as const },
+			css: {
+				color: "@color.gray-200",
+				"&:hover": {
+					color: "@color.white",
+					textDecoration: "underline",
+					textUnderlineOffset: "4px",
+				},
+				"&:focus": {
+					color: "@color.white",
+					textDecoration: "underline",
+					textUnderlineOffset: "4px",
+				},
+				"&:active": {
+					color: "@color.white",
+					textDecoration: "underline",
+					textUnderlineOffset: "4px",
+				},
+				"&:dark": {
+					color: "@color.gray-200",
+				},
+				"&:dark:hover": {
+					color: "@color.white",
+				},
+				"&:dark:focus": {
+					color: "@color.white",
+				},
+				"&:dark:active": {
+					color: "@color.white",
+				},
+			},
+		},
+
+		// Neutral color (adaptive: light in light mode, dark in dark mode)
+		{
+			match: { color: "neutral" as const },
+			css: {
+				color: "@color.text",
+				"&:hover": {
+					color: "@color.gray-900",
+					textDecoration: "underline",
+					textUnderlineOffset: "4px",
+				},
+				"&:focus": {
+					color: "@color.gray-900",
+					textDecoration: "underline",
+					textUnderlineOffset: "4px",
+				},
+				"&:active": {
+					color: "@color.gray-900",
+					textDecoration: "underline",
+					textUnderlineOffset: "4px",
+				},
+				"&:dark": {
+					color: "@color.gray-200",
+				},
+				"&:dark:hover": {
+					color: "@color.white",
+				},
+				"&:dark:focus": {
+					color: "@color.white",
+				},
+				"&:dark:active": {
+					color: "@color.white",
+				},
+			},
+		},
+
+		// Active item (current page) — suppress link affordance regardless of color
+		{
+			match: { active: "true" as const },
+			css: {
+				cursor: "default",
+				"&:hover": {
+					textDecoration: "none",
+				},
+				"&:focus": {
+					textDecoration: "none",
+				},
+				"&:active": {
+					textDecoration: "none",
+				},
+			},
+		},
+	],
+	defaultVariants: {
+		color: "neutral",
+		size: "md",
+		active: "false",
+		disabled: "false",
+	},
+});

--- a/theme/src/recipes/breadcrumb/useBreadcrumbRecipe.test.ts
+++ b/theme/src/recipes/breadcrumb/useBreadcrumbRecipe.test.ts
@@ -1,0 +1,111 @@
+import { styleframe } from "@styleframe/core";
+import { useBreadcrumbRecipe } from "./index";
+
+function createInstance() {
+	const s = styleframe();
+	for (const name of [
+		"display",
+		"flexDirection",
+		"flexWrap",
+		"alignItems",
+		"listStyle",
+		"paddingLeft",
+		"marginTop",
+		"marginBottom",
+		"fontSize",
+		"gap",
+	]) {
+		s.utility(name, ({ value }) => ({ [name]: value }));
+	}
+	return s;
+}
+
+describe("useBreadcrumbRecipe", () => {
+	it("should create a recipe with correct metadata", () => {
+		const s = createInstance();
+		const recipe = useBreadcrumbRecipe(s);
+
+		expect(recipe.type).toBe("recipe");
+		expect(recipe.name).toBe("breadcrumb");
+	});
+
+	it("should have correct base styles", () => {
+		const s = createInstance();
+		const recipe = useBreadcrumbRecipe(s);
+
+		expect(recipe.base).toEqual({
+			display: "flex",
+			flexDirection: "row",
+			flexWrap: "wrap",
+			alignItems: "center",
+			listStyle: "none",
+			paddingLeft: "0",
+			marginTop: "0",
+			marginBottom: "0",
+		});
+	});
+
+	describe("variants", () => {
+		it("should have size variants with correct styles", () => {
+			const s = createInstance();
+			const recipe = useBreadcrumbRecipe(s);
+
+			expect(recipe.variants!.size).toEqual({
+				sm: {
+					fontSize: "@font-size.xs",
+					gap: "@0.5",
+				},
+				md: {
+					fontSize: "@font-size.sm",
+					gap: "@0.75",
+				},
+				lg: {
+					fontSize: "@font-size.md",
+					gap: "@1",
+				},
+			});
+		});
+	});
+
+	it("should have correct default variants", () => {
+		const s = createInstance();
+		const recipe = useBreadcrumbRecipe(s);
+
+		expect(recipe.defaultVariants).toEqual({
+			size: "md",
+		});
+	});
+
+	describe("config overrides", () => {
+		it("should allow overriding base styles", () => {
+			const s = createInstance();
+			const recipe = useBreadcrumbRecipe(s, {
+				base: { display: "inline-flex" },
+			});
+
+			expect(recipe.base!.display).toBe("inline-flex");
+			expect(recipe.base!.flexDirection).toBe("row");
+			expect(recipe.base!.listStyle).toBe("none");
+		});
+	});
+
+	describe("filter", () => {
+		it("should filter size variants", () => {
+			const s = createInstance();
+			const recipe = useBreadcrumbRecipe(s, {
+				filter: { size: ["sm", "lg"] },
+			});
+
+			expect(Object.keys(recipe.variants!.size)).toEqual(["sm", "lg"]);
+		});
+
+		it("should adjust default variants when filtered out", () => {
+			const s = createInstance();
+			const recipe = useBreadcrumbRecipe(s, {
+				filter: { size: ["lg"] },
+			});
+
+			expect(recipe.defaultVariants?.size).toBeUndefined();
+		});
+	});
+});

--- a/theme/src/recipes/breadcrumb/useBreadcrumbRecipe.ts
+++ b/theme/src/recipes/breadcrumb/useBreadcrumbRecipe.ts
@@ -1,0 +1,49 @@
+import { createUseRecipe } from "../../utils/createUseRecipe";
+
+/**
+ * Breadcrumb container recipe for navigation hierarchies.
+ * Renders a horizontal list with size-controlled gap and typography.
+ */
+export const useBreadcrumbRecipe = createUseRecipe(
+	"breadcrumb",
+	{
+		base: {
+			display: "flex",
+			flexDirection: "row",
+			flexWrap: "wrap",
+			alignItems: "center",
+			listStyle: "none",
+			paddingLeft: "0",
+			marginTop: "0",
+			marginBottom: "0",
+		},
+		variants: {
+			size: {
+				sm: {
+					fontSize: "@font-size.xs",
+					gap: "@0.5",
+				},
+				md: {
+					fontSize: "@font-size.sm",
+					gap: "@0.75",
+				},
+				lg: {
+					fontSize: "@font-size.md",
+					gap: "@1",
+				},
+			},
+		},
+		defaultVariants: {
+			size: "md",
+		},
+	},
+	(s) => {
+		s.selector(".breadcrumb-separator", {
+			display: "flex",
+			alignItems: "center",
+			opacity: "0.6",
+			userSelect: "none",
+			pointerEvents: "none",
+		});
+	},
+);

--- a/theme/src/recipes/index.ts
+++ b/theme/src/recipes/index.ts
@@ -1,4 +1,5 @@
 export * from "./badge";
+export * from "./breadcrumb";
 export * from "./button";
 export * from "./button-group";
 export * from "./callout";


### PR DESCRIPTION
## Summary
- Add `useBreadcrumbRecipe` and `useBreadcrumbItemRecipe` composables in `theme/src/recipes/breadcrumb/` with unit tests.
- Showcase the recipe in Storybook (component + stories + previews) and document it at `apps/docs/content/docs/04.components/02.composables/15.breadcrumb.md`.
- Register the new recipe in the `theme/src/recipes/index.ts` barrel.

## Test plan
- [ ] `pnpm --filter @styleframe/theme test`
- [ ] `pnpm typecheck`
- [ ] Verify breadcrumb stories render in Storybook