### PR TITLE
ci: enable automatic npm publish in changesets workflow

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -57,7 +57,7 @@ jobs:
                   version: pnpm ci:version
                   commit: "chore: update versions"
                   title: "chore: update versions"
-                  # publish: pnpm run ci:release
+                  publish: pnpm exec changeset publish
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Replaces the commented-out `# publish: pnpm run ci:release` in `.github/workflows/changesets.yml` with `publish: pnpm exec changeset publish`, so the `changesets/action@v1` step automatically publishes to npm after a "Version Packages" PR is merged into `main`.
- Uses `pnpm exec changeset publish` directly (not `pnpm run ci:publish`) to avoid rebuilding — `pnpm run ci:prepublish` already runs in the preceding workflow step.
- The fix also corrects a stale script reference: the previous comment pointed at `ci:release`, which no longer exists in `package.json`.

No other changes are needed — `id-token: write`, `NPM_TOKEN` / `NODE_AUTH_TOKEN`, `registry-url`, and the release-info output step were already wired.

## Test plan
- [ ] CI passes (`actionlint` is part of lint).
- [ ] After merge, on the next changeset-bearing PR, confirm the workflow opens a "Version Packages" PR and skips publish (no changesets pending → no publish).
- [ ] After merging the "Version Packages" PR, confirm the workflow runs `changeset publish`, packages appear on npm, and the "Output release information" step prints the published packages.