### PR TITLE
docs: add Figma plugin demo video to figma page hero

### DIFF
--- a/apps/docs/content/figma.md
+++ b/apps/docs/content/figma.md
@@ -9,6 +9,16 @@ Hero Section -------------------------------------------------------------------
 
 ::gradient-page-hero
 
+:::video{ class="rounded" }
+---
+autoplay: true
+loop: true
+muted: true
+playsinline: true
+src: /assets/video/styleframe-figma.mp4
+---
+:::
+
 #title
 Export Styleframe Design Tokens [to Figma]{.text-primary} and Back
 


### PR DESCRIPTION
## Summary
- Embed the Figma plugin demo video (`/assets/video/styleframe-figma.mp4`) in the hero of `apps/docs/content/figma.md` using the existing `::video` content component (autoplay, loop, muted, playsinline).
- Adds the new MP4 asset under `apps/docs/public/assets/video/`.

## Test plan
- [ ] `pnpm --filter docs dev` and confirm the video renders and autoplays in the figma page hero across Chromium, Firefox, and Safari.