### PR TITLE
feat(theme): add chat-message recipe with avatar, content, actions sub-parts

### DIFF
--- a/.changeset/chat-message-side-alignment.md
+++ b/.changeset/chat-message-side-alignment.md
@@ -1,0 +1,12 @@
+---
+"@styleframe/theme": patch
+"styleframe": patch
+---
+
+Fix `chat-message` recipe `side="end"` alignment.
+
+The `side="end"` variant now correctly packs the avatar and content group to the right side of the container. Three issues were resolved:
+
+- Root recipe: `justify-content` was `flex-end` which, combined with `flex-direction: row-reverse`, pushed items to the left. Changed to `flex-start`.
+- Content recipe: added `side` variant with `alignSelf: flex-end` so the bubble right-aligns within its column stack.
+- Actions recipe: added `side` variant with `justifyContent: flex-end` so action buttons align under the bubble.

--- a/apps/docs/content/docs/04.components/02.composables/16.chat-message.md
+++ b/apps/docs/content/docs/04.components/02.composables/16.chat-message.md
@@ -1,0 +1,517 @@
+---
+title: ChatMessage
+description: A chat-bubble component for AI chat transcripts with optional leading avatar, content bubble, and hover-revealed actions row. Side-aware layout with logical start/end alignment, plus compound variants that handle every color-variant combination.
+---
+
+## Overview
+
+The **ChatMessage** is a chat-bubble container used to render a single turn in an AI chat transcript. It is composed of four recipe parts: `useChatMessageRecipe()` for the side-aware root wrapper, `useChatMessageAvatarRecipe()` for the leading avatar slot, `useChatMessageContentRecipe()` for the bubble itself, and `useChatMessageActionsRecipe()` for the hover-revealed action row beneath the bubble. Each composable creates a fully configured [recipe](/docs/api/recipes) with color, variant, and size options &mdash; plus compound variants on the content recipe that handle every color-variant combination automatically.
+
+The ChatMessage recipes integrate directly with the default [design tokens preset](/docs/theme/design-tokens/presets) and generate type-safe utility classes at build time with zero runtime CSS.
+
+## Why use the ChatMessage recipe?
+
+The ChatMessage recipe helps you:
+
+- **Ship faster with sensible defaults**: Get 3 colors, 5 visual styles, 3 sizes, and start/end side alignment out of the box with a single set of composable calls.
+- **Compose flexible chat layouts**: Four coordinated recipes (root, avatar, content, actions) share the same variant axes, so messages stay internally consistent as you mix user and assistant turns.
+- **Stay i18n-friendly**: The `side` axis uses logical `start` and `end` values that flip automatically under `dir="rtl"`, so right-to-left layouts work without extra code.
+- **Customize without forking**: Override base styles, default variants, or filter out options you don't need &mdash; all through the options API.
+- **Stay type-safe**: Full TypeScript support means your editor catches invalid color, variant, size, or side values at compile time.
+- **Integrate with your tokens**: Every value references the design tokens preset, so theme changes propagate automatically.
+
+## Usage
+
+::steps{level="4"}
+
+#### Register the recipes
+
+Add the ChatMessage recipes to a local Styleframe instance. The global `styleframe.config.ts` provides design tokens and utilities, while the component-level file registers the recipes themselves:
+
+:::code-tree{default-value="src/components/chat-message.styleframe.ts"}
+
+```ts [src/components/chat-message.styleframe.ts]
+import { styleframe } from 'virtual:styleframe';
+import {
+    useChatMessageRecipe,
+    useChatMessageAvatarRecipe,
+    useChatMessageContentRecipe,
+    useChatMessageActionsRecipe,
+} from '@styleframe/theme';
+
+const s = styleframe();
+
+const chatMessage = useChatMessageRecipe(s);
+const chatMessageAvatar = useChatMessageAvatarRecipe(s);
+const chatMessageContent = useChatMessageContentRecipe(s);
+const chatMessageActions = useChatMessageActionsRecipe(s);
+
+export default s;
+```
+
+```ts [styleframe.config.ts]
+import { styleframe } from 'styleframe';
+import { useDesignTokensPreset, useUtilitiesPreset } from '@styleframe/theme';
+
+const s = styleframe();
+
+useDesignTokensPreset(s);
+useUtilitiesPreset(s);
+
+export default s;
+```
+
+:::
+
+#### Build the component
+
+Import the `chatMessage`, `chatMessageAvatar`, `chatMessageContent`, and `chatMessageActions` runtime functions from the virtual module and pass variant props to compute class names:
+
+:::tabs
+::::tabs-item{icon="i-devicon-react" label="React"}
+
+```ts [src/components/ChatMessage.tsx]
+import {
+    chatMessage,
+    chatMessageAvatar,
+    chatMessageContent,
+    chatMessageActions,
+} from "virtual:styleframe";
+
+interface ChatMessageProps {
+    color?: "light" | "dark" | "neutral";
+    variant?: "solid" | "outline" | "soft" | "subtle" | "naked";
+    size?: "sm" | "md" | "lg";
+    side?: "start" | "end";
+    avatar?: React.ReactNode;
+    actions?: React.ReactNode;
+    children?: React.ReactNode;
+}
+
+export function ChatMessage({
+    color = "neutral",
+    variant = "subtle",
+    size = "md",
+    side = "start",
+    avatar,
+    actions,
+    children,
+}: ChatMessageProps) {
+    return (
+        <article className={chatMessage({ color, variant, size, side })}>
+            {avatar && (
+                <div className={chatMessageAvatar({ color, variant, size })}>
+                    {avatar}
+                </div>
+            )}
+            <div>
+                <div className={chatMessageContent({ color, variant, size })}>
+                    {children}
+                </div>
+                {actions && (
+                    <div className={chatMessageActions({ color, variant, size })}>
+                        {actions}
+                    </div>
+                )}
+            </div>
+        </article>
+    );
+}
+```
+
+::::
+::::tabs-item{icon="i-devicon-vuejs" label="Vue"}
+
+```vue [src/components/ChatMessage.vue]
+<script setup lang="ts">
+import {
+    chatMessage,
+    chatMessageAvatar,
+    chatMessageContent,
+    chatMessageActions,
+} from "virtual:styleframe";
+
+const {
+    color = "neutral",
+    variant = "subtle",
+    size = "md",
+    side = "start",
+} = defineProps<{
+    color?: "light" | "dark" | "neutral";
+    variant?: "solid" | "outline" | "soft" | "subtle" | "naked";
+    size?: "sm" | "md" | "lg";
+    side?: "start" | "end";
+}>();
+</script>
+
+<template>
+    <article :class="chatMessage({ color, variant, size, side })">
+        <div :class="chatMessageAvatar({ color, variant, size })">
+            <slot name="avatar" />
+        </div>
+        <div>
+            <div :class="chatMessageContent({ color, variant, size })">
+                <slot />
+            </div>
+            <div :class="chatMessageActions({ color, variant, size })">
+                <slot name="actions" />
+            </div>
+        </div>
+    </article>
+</template>
+```
+
+::::
+:::
+
+#### See it in action
+
+:::story-preview
+---
+story: theme-recipes-chat-message--default
+panel: true
+---
+:::
+
+::
+
+## Colors
+
+The ChatMessage recipe includes 3 color variants: `light`, `dark`, and `neutral`. Like the Card recipe, ChatMessage uses neutral-spectrum colors designed for content surfaces rather than status communication &mdash; chat sides aren't semantic states, they're conversational roles. The content recipe combines each color with every visual style variant through compound variants, so you get consistent, predictable styling across all combinations &mdash; including dark mode overrides.
+
+The `neutral` color adapts automatically: it uses a light appearance in light mode and a dark appearance in dark mode, making it the safest default for general-purpose chat UIs.
+
+::story-preview
+---
+story: theme-recipes-chat-message--neutral
+panel: true
+---
+::
+
+### Color Reference
+
+::story-preview
+---
+story: theme-recipes-chat-message--all-variants
+height: 480
+---
+::
+
+| Color | Token | Use Case |
+|-------|-------|----------|
+| `light` | `@color.white` / `@color.gray-*` | Light surfaces, stays light in dark mode |
+| `dark` | `@color.gray-900` | Dark surfaces, stays dark in light mode |
+| `neutral` | Adaptive (light &harr; dark) | Default color, adapts to the current color scheme |
+
+::tip
+**Pro tip:** Use `neutral` as your default chat-message color. It adapts to the user's color scheme automatically, so you don't need to manage light and dark variants separately.
+::
+
+## Variants
+
+Five visual style variants control how the message bubble is rendered. Each variant is combined with the selected color through [compound variants](/docs/api/recipes#compound-variants) on the content recipe, so you always get the correct background, text, and border colors for your chosen color.
+
+### Solid
+
+Filled background with a subtle border. The most prominent style, ideal for emphasizing a single message in a transcript.
+
+::story-preview
+---
+story: theme-recipes-chat-message--solid
+panel: true
+---
+::
+
+### Outline
+
+Transparent background with a colored border and matching text. A lightweight, definitionful style that works well for system or meta messages.
+
+::story-preview
+---
+story: theme-recipes-chat-message--outline
+panel: true
+---
+::
+
+### Soft
+
+Light tinted background with no visible border. A gentle, borderless style that reads like a typical user chat bubble.
+
+::story-preview
+---
+story: theme-recipes-chat-message--soft
+panel: true
+---
+::
+
+### Subtle
+
+Light tinted background with a matching border. Combines the softness of the `soft` variant with added visual definition from a border &mdash; the recommended default for both user and assistant turns.
+
+::story-preview
+---
+story: theme-recipes-chat-message--subtle
+panel: true
+---
+::
+
+### Naked
+
+No background, no border, no padding. Strips the bubble entirely so the message reads as inline prose. Use for assistant turns that should feel like part of the page rather than a discrete bubble.
+
+::story-preview
+---
+story: theme-recipes-chat-message--naked
+panel: true
+---
+::
+
+## Sizes
+
+Three size variants from `sm` to `lg` control the avatar dimensions, the bubble padding and border radius, and the gap between the avatar and the bubble.
+
+::story-preview
+---
+story: theme-recipes-chat-message--all-sizes
+height: 520
+---
+::
+
+### Size Reference
+
+| Size | Avatar | Bubble Border Radius | Bubble Padding (V / H) | Root Gap | Actions Gap / Margin |
+|------|--------|----------------------|------------------------|----------|----------------------|
+| `sm` | `@1.5` | `@border-radius.sm` | `@0.5` / `@0.75` | `@0.5` | `@0.125` |
+| `md` | `@2` | `@border-radius.md` | `@0.75` / `@1` | `@0.75` | `@0.25` |
+| `lg` | `@2.5` | `@border-radius.lg` | `@1` / `@1.25` | `@1` | `@0.375` |
+
+::note
+**Good to know:** The `size` prop must be passed to each sub-recipe individually so the avatar, bubble, and actions row stay visually balanced. The root recipe controls the gap; the sub-recipes manage their own dimensions and padding.
+::
+
+## Side
+
+The `side` axis on the root recipe controls how the message aligns within its container. Logical values mean both work correctly under `dir="rtl"`.
+
+| Side | Behavior | Use Case |
+|------|----------|----------|
+| `start` | `justifyContent: flex-start`, default flex direction | Assistant or system messages |
+| `end` | `justifyContent: flex-end`, `flexDirection: row-reverse` | User messages &mdash; avatar appears on the inline-end |
+
+::story-preview
+---
+story: theme-recipes-chat-message--side-end
+panel: true
+---
+::
+
+::tip
+**Pro tip:** Set `side` based on the message author, not on a fixed left/right position. Logical values keep your UI correct in right-to-left languages without changes.
+::
+
+## Anatomy
+
+The ChatMessage recipe is composed of four independent recipes that work together to form the bubble:
+
+| Part | Recipe | Role |
+|------|--------|------|
+| **Root** | `useChatMessageRecipe()` | Outer `<article>` flex container; owns the `side` axis for alignment |
+| **Avatar** | `useChatMessageAvatarRecipe()` | Leading slot for an avatar or icon &mdash; rounded, shrink-0, with a neutral placeholder background |
+| **Content** | `useChatMessageContentRecipe()` | The bubble itself &mdash; background, padding, border, and the color &times; variant compound matrix |
+| **Actions** | `useChatMessageActionsRecipe()` | Action button row beneath the bubble &mdash; flex layout with size-aware gap and margin |
+
+The `chat-message-avatar` recipe is independent of the `media` recipe: drop a raw `<img>` or icon inside an element styled by `chatMessageAvatar()` and you get correct sizing and shape without pulling in any other recipe. Pass `color`, `variant`, and `size` consistently to all four sub-recipes so they stay visually balanced.
+
+```html
+<!-- All four parts working together -->
+<article class="chatMessage(...)">
+    <div class="chatMessageAvatar(...)">A</div>
+    <div>
+        <div class="chatMessageContent(...)">Message body</div>
+        <div class="chatMessageActions(...)">Action buttons</div>
+    </div>
+</article>
+```
+
+::tip
+**Pro tip:** You don't have to use all four parts. A minimal chat-message is just `useChatMessageRecipe()` wrapping `useChatMessageContentRecipe()`. Add the avatar and actions only when your design needs them.
+::
+
+## Accessibility
+
+- **Use semantic markup.** The root renders as an `<article>` element, which communicates a self-contained message to assistive technology. Don't replace it with a `<div>` unless you have a strong reason.
+- **Announce streaming updates.** If your chat UI streams assistant responses, wrap the message list in a region with `aria-live="polite"` so screen readers hear new content without interrupting the user.
+- **Provide accessible names for action buttons.** Buttons in the actions row should have visible text or an `aria-label` (`"Copy message"`, `"Regenerate response"`) so users on assistive tech know what each action does.
+- **Verify contrast ratios.** The `solid` variant with `dark` color places light text on a dark background. Default tokens meet WCAG AA 4.5:1 contrast. If you override colors, verify with the [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/).
+- **Don't rely on side alone to convey author.** Pair `side="end"` with author text or an avatar so the role is communicated to users who don't perceive the layout (screen reader, low-vision, RTL contexts).
+
+## Customization
+
+### Overriding Defaults
+
+Each chat-message composable accepts an optional second argument to override any part of the recipe configuration. Overrides are deep-merged with the defaults, so you only need to specify the properties you want to change:
+
+```ts [src/components/chat-message.styleframe.ts]
+import { styleframe } from 'virtual:styleframe';
+import {
+    useChatMessageRecipe,
+    useChatMessageContentRecipe,
+} from '@styleframe/theme';
+
+const s = styleframe();
+
+const chatMessage = useChatMessageRecipe(s, {
+    base: { gap: '@1' },
+    defaultVariants: {
+        color: 'neutral',
+        variant: 'soft',
+        size: 'lg',
+        side: 'start',
+    },
+});
+
+const chatMessageContent = useChatMessageContentRecipe(s, {
+    base: { maxWidth: '60%' },
+});
+
+export default s;
+```
+
+### Filtering Variants
+
+If you only need a subset of the available variants, use the `filter` option to limit which values are generated. This reduces the output CSS and keeps your component API focused:
+
+```ts [src/components/chat-message.styleframe.ts]
+import { styleframe } from 'virtual:styleframe';
+import { useChatMessageContentRecipe } from '@styleframe/theme';
+
+const s = styleframe();
+
+// Only generate neutral color with the bubble variants you actually use
+const chatMessageContent = useChatMessageContentRecipe(s, {
+    filter: {
+        color: ['neutral'],
+        variant: ['subtle', 'naked'],
+    },
+});
+
+export default s;
+```
+
+::note
+**Good to know:** Filtering also removes compound variants and adjusts default variants that reference filtered-out values, so your recipe stays consistent.
+::
+
+## API Reference
+
+### `useChatMessageRecipe(s, options?)`
+
+Creates the chat-message root recipe &mdash; a flex container with logical side alignment. Owns the `side` axis; the other axes are exposed for prop spreading but produce no styles at the root.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `s` | `Styleframe` | The Styleframe instance |
+| `options` | `DeepPartial<RecipeConfig>` | Optional overrides for the recipe configuration |
+| `options.base` | `VariantDeclarationsBlock` | Custom base styles for the root container |
+| `options.variants` | `Variants` | Custom variant definitions for the recipe |
+| `options.defaultVariants` | `Record<keyof Variants, string>` | Default variant values for the recipe |
+| `options.compoundVariants` | `CompoundVariant[]` | Custom compound variant definitions for the recipe |
+| `options.filter` | `Record<string, string[]>` | Limit which variant values are generated |
+
+**Variants:**
+
+| Variant | Options | Default |
+|---------|---------|---------|
+| `color` | `light`, `dark`, `neutral` | `neutral` |
+| `variant` | `solid`, `outline`, `soft`, `subtle`, `naked` | `subtle` |
+| `size` | `sm`, `md`, `lg` | `md` |
+| `side` | `start`, `end` | `start` |
+
+### `useChatMessageAvatarRecipe(s, options?)`
+
+Creates the chat-message avatar recipe &mdash; a fixed-size leading slot with a circular placeholder. Independent of the `media` recipe. Accepts the same parameters as `useChatMessageRecipe`.
+
+**Variants:**
+
+| Variant | Options | Default |
+|---------|---------|---------|
+| `color` | `light`, `dark`, `neutral` | `neutral` |
+| `variant` | `solid`, `outline`, `soft`, `subtle`, `naked` | `subtle` |
+| `size` | `sm`, `md`, `lg` | `md` |
+
+### `useChatMessageContentRecipe(s, options?)`
+
+Creates the chat-message content recipe &mdash; the bubble itself. Owns the 12-entry color &times; variant compound matrix (3 colors &times; 4 visual variants). The `naked` variant strips bubble chrome regardless of color, so it has no compound entries. Accepts the same parameters as `useChatMessageRecipe`.
+
+**Variants:**
+
+| Variant | Options | Default |
+|---------|---------|---------|
+| `color` | `light`, `dark`, `neutral` | `neutral` |
+| `variant` | `solid`, `outline`, `soft`, `subtle`, `naked` | `subtle` |
+| `size` | `sm`, `md`, `lg` | `md` |
+
+### `useChatMessageActionsRecipe(s, options?)`
+
+Creates the chat-message actions row recipe &mdash; a flex layout for action buttons displayed beneath the bubble. Hover-reveal is a markup concern (toggle opacity on the parent), not a recipe variant. Accepts the same parameters as `useChatMessageRecipe`.
+
+**Variants:**
+
+| Variant | Options | Default |
+|---------|---------|---------|
+| `color` | `light`, `dark`, `neutral` | `neutral` |
+| `variant` | `solid`, `outline`, `soft`, `subtle`, `naked` | `subtle` |
+| `size` | `sm`, `md`, `lg` | `md` |
+
+[Learn more about recipes &rarr;](/docs/api/recipes)
+
+## Best Practices
+
+- **Pass `color`, `variant`, and `size` consistently**: All four sub-recipes accept the same axes. Spread the same props to each so the avatar, bubble, and actions row stay visually balanced.
+- **Choose `side` by author, not by position**: Use `side="start"` for assistant turns and `side="end"` for user turns. Logical values keep your UI correct in right-to-left languages.
+- **Use `naked` for assistant prose, `subtle` for user replies**: Naked reads like part of the page; subtle reads like a discrete message. The contrast helps users distinguish authorship at a glance.
+- **Filter what you don't need**: If your chat UI uses only `subtle` and `naked`, pass a `filter` option to remove the other variants from the generated CSS.
+- **Override defaults at the recipe level**: Set your most common variant combination as `defaultVariants` so component consumers write less code.
+- **Don't put hover reveal on the recipe**: Toggle action opacity in your component template (`group-hover` in CSS, `:hover` in your wrapper). Keep the recipe declarative.
+
+## FAQ
+
+::accordion
+
+:::accordion-item{label="Why are there four separate recipes instead of one?" icon="i-lucide-circle-help"}
+Chat messages have distinct structural parts (avatar, bubble, actions) that need independent styling &mdash; different sizing, layout, and visual treatment. Four separate recipes give each part its own base styles and variant axes while sharing the same color, variant, and size axes. This approach keeps each recipe focused and lets you compose only the parts you need.
+:::
+
+:::accordion-item{label="Do I have to use all four sub-recipes?" icon="i-lucide-circle-help"}
+No. The minimal chat-message is `useChatMessageRecipe()` wrapping `useChatMessageContentRecipe()` &mdash; just an aligned bubble with no avatar or actions row. Add the avatar and actions recipes only when your design needs them.
+:::
+
+:::accordion-item{label="Why doesn't the ChatMessage recipe include semantic colors like primary or success?" icon="i-lucide-circle-help"}
+Chat messages are conversational containers, not status indicators. Semantic colors (primary, success, error) communicate meaning through color, which is better suited to smaller, focused elements like badges, buttons, and callouts. ChatMessage uses `light`, `dark`, and `neutral` to provide surface variations that work across both user and assistant turns without implying status.
+:::
+
+:::accordion-item{label="What's the difference between the subtle and naked variants?" icon="i-lucide-circle-help"}
+`subtle` renders a tinted background with a matching border &mdash; a discrete bubble. `naked` strips background, border, and padding entirely so the message reads as inline prose. Use `subtle` when the message should feel like a chat bubble; use `naked` when an assistant response should feel like part of the surrounding page (typical for long-form generated content).
+:::
+
+:::accordion-item{label="Why use `start` and `end` instead of `left` and `right`?" icon="i-lucide-circle-help"}
+Logical sides flip automatically under `dir="rtl"`. If your app supports right-to-left languages (Arabic, Hebrew, Persian), `side="end"` keeps user messages on the user's natural side without you writing any directional code. If you never plan to support RTL, the values still read clearly: `start` is where the conversation begins (typically the assistant), `end` is where the user replies.
+:::
+
+:::accordion-item{label="How do compound variants work in the ChatMessage recipe?" icon="i-lucide-circle-help"}
+Compound variants live on the content recipe (`useChatMessageContentRecipe`). They map each color-variant combination to specific styles. For example, when `color` is `neutral` and `variant` is `subtle`, the compound variant applies `background: @color.gray-100`, `color: @color.gray-700`, and `borderColor: @color.gray-200`, along with dark mode overrides. The recipe has 12 compound entries (3 colors &times; 4 visual variants &mdash; the `naked` variant strips chrome regardless of color, so it needs no compound entries).
+
+[Learn more about compound variants &rarr;](/docs/api/recipes#compound-variants)
+:::
+
+:::accordion-item{label="How does filtering affect compound variants?" icon="i-lucide-circle-help"}
+When you use the `filter` option on the content recipe, compound variants that reference filtered-out values are automatically removed. For example, if you filter `variant` to only `['subtle', 'naked']`, all compound variants matching `solid`, `outline`, or `soft` are excluded from the generated output. Default variants are also adjusted if they reference a removed value.
+:::
+
+:::accordion-item{label="How do I show a hover-revealed actions row?" icon="i-lucide-circle-help"}
+The actions recipe handles only layout (gap, margin). Hover reveal is a markup concern: add a CSS rule that toggles opacity on the actions row when the message wrapper is hovered, e.g., `.chat-message:hover .chat-message-actions { opacity: 1 }`. Keeping reveal logic out of the recipe lets you choose between hover, focus-within, always-visible, or other patterns without changing the recipe.
+:::
+
+::

--- a/apps/storybook/src/components/components/chat-message/ChatMessage.vue
+++ b/apps/storybook/src/components/components/chat-message/ChatMessage.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { chatMessage } from "virtual:styleframe";
+
+const props = withDefaults(
+	defineProps<{
+		color?: "light" | "dark" | "neutral";
+		variant?: "solid" | "outline" | "soft" | "subtle" | "naked";
+		size?: "sm" | "md" | "lg";
+		side?: "start" | "end";
+	}>(),
+	{},
+);
+
+const classes = computed(() =>
+	chatMessage({
+		color: props.color,
+		variant: props.variant,
+		size: props.size,
+		side: props.side,
+	}),
+);
+</script>
+
+<template>
+	<article :class="classes">
+		<slot />
+	</article>
+</template>

--- a/apps/storybook/src/components/components/chat-message/ChatMessageActions.vue
+++ b/apps/storybook/src/components/components/chat-message/ChatMessageActions.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { chatMessageActions } from "virtual:styleframe";
+
+const props = withDefaults(
+	defineProps<{
+		color?: "light" | "dark" | "neutral";
+		variant?: "solid" | "outline" | "soft" | "subtle" | "naked";
+		size?: "sm" | "md" | "lg";
+	}>(),
+	{},
+);
+
+const classes = computed(() =>
+	chatMessageActions({
+		color: props.color,
+		variant: props.variant,
+		size: props.size,
+	}),
+);
+</script>
+
+<template>
+	<div :class="classes">
+		<slot />
+	</div>
+</template>

--- a/apps/storybook/src/components/components/chat-message/ChatMessageAvatar.vue
+++ b/apps/storybook/src/components/components/chat-message/ChatMessageAvatar.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { chatMessageAvatar } from "virtual:styleframe";
+
+const props = withDefaults(
+	defineProps<{
+		color?: "light" | "dark" | "neutral";
+		variant?: "solid" | "outline" | "soft" | "subtle" | "naked";
+		size?: "sm" | "md" | "lg";
+	}>(),
+	{},
+);
+
+const classes = computed(() =>
+	chatMessageAvatar({
+		color: props.color,
+		variant: props.variant,
+		size: props.size,
+	}),
+);
+</script>
+
+<template>
+	<div :class="classes">
+		<slot />
+	</div>
+</template>

--- a/apps/storybook/src/components/components/chat-message/ChatMessageContent.vue
+++ b/apps/storybook/src/components/components/chat-message/ChatMessageContent.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { chatMessageContent } from "virtual:styleframe";
+
+const props = withDefaults(
+	defineProps<{
+		color?: "light" | "dark" | "neutral";
+		variant?: "solid" | "outline" | "soft" | "subtle" | "naked";
+		size?: "sm" | "md" | "lg";
+	}>(),
+	{},
+);
+
+const classes = computed(() =>
+	chatMessageContent({
+		color: props.color,
+		variant: props.variant,
+		size: props.size,
+	}),
+);
+</script>
+
+<template>
+	<div :class="classes">
+		<slot />
+	</div>
+</template>

--- a/apps/storybook/src/components/components/chat-message/preview/ChatMessageGrid.vue
+++ b/apps/storybook/src/components/components/chat-message/preview/ChatMessageGrid.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import ChatMessage from "../ChatMessage.vue";
+import ChatMessageAvatar from "../ChatMessageAvatar.vue";
+import ChatMessageContent from "../ChatMessageContent.vue";
+
+const colors = ["neutral", "light", "dark"] as const;
+const variants = ["solid", "outline", "soft", "subtle", "naked"] as const;
+const sides = ["start", "end"] as const;
+
+const initial = (color: string) => color.charAt(0).toUpperCase();
+</script>
+
+<template>
+	<div class="chat-message-section">
+		<div v-for="variant in variants" :key="variant">
+			<div class="chat-message-label">{{ variant }}</div>
+			<div class="chat-message-row">
+				<ChatMessage
+					v-for="side in sides"
+					:key="`${variant}-${side}`"
+					:variant="variant"
+					:side="side"
+				>
+					<ChatMessageAvatar :variant="variant">
+						{{ initial(side === "start" ? "AI" : "Me") }}
+					</ChatMessageAvatar>
+					<ChatMessageContent :variant="variant">
+						{{ variant }} bubble on {{ side }}.
+					</ChatMessageContent>
+				</ChatMessage>
+				<ChatMessage
+					v-for="color in colors"
+					:key="`${variant}-${color}`"
+					:color="color"
+					:variant="variant"
+				>
+					<ChatMessageAvatar :color="color" :variant="variant">
+						{{ initial(color) }}
+					</ChatMessageAvatar>
+					<ChatMessageContent :color="color" :variant="variant">
+						{{ color }} {{ variant }} bubble.
+					</ChatMessageContent>
+				</ChatMessage>
+			</div>
+		</div>
+	</div>
+</template>

--- a/apps/storybook/src/components/components/chat-message/preview/ChatMessageSizeGrid.vue
+++ b/apps/storybook/src/components/components/chat-message/preview/ChatMessageSizeGrid.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import ChatMessage from "../ChatMessage.vue";
+import ChatMessageAvatar from "../ChatMessageAvatar.vue";
+import ChatMessageContent from "../ChatMessageContent.vue";
+import ChatMessageActions from "../ChatMessageActions.vue";
+
+const sizes = ["sm", "md", "lg"] as const;
+const sizeTitles: Record<string, string> = {
+	sm: "Small",
+	md: "Medium",
+	lg: "Large",
+};
+</script>
+
+<template>
+	<div class="chat-message-section">
+		<div v-for="size in sizes" :key="size">
+			<div class="chat-message-label">{{ sizeTitles[size] }}</div>
+			<div class="chat-message-row">
+				<ChatMessage :size="size" side="start">
+					<ChatMessageAvatar :size="size">AI</ChatMessageAvatar>
+					<div class="chat-message-stack">
+						<ChatMessageContent :size="size">
+							This is a {{ sizeTitles[size].toLowerCase() }} assistant message.
+						</ChatMessageContent>
+						<ChatMessageActions :size="size">
+							<button class="chat-message-action-button" type="button">Copy</button>
+							<button class="chat-message-action-button" type="button">Regenerate</button>
+						</ChatMessageActions>
+					</div>
+				</ChatMessage>
+				<ChatMessage :size="size" side="end">
+					<ChatMessageAvatar :size="size">Me</ChatMessageAvatar>
+					<ChatMessageContent :size="size">
+						And this is a {{ sizeTitles[size].toLowerCase() }} user reply.
+					</ChatMessageContent>
+				</ChatMessage>
+			</div>
+		</div>
+	</div>
+</template>

--- a/apps/storybook/stories/components/chat-message.stories.ts
+++ b/apps/storybook/stories/components/chat-message.stories.ts
@@ -1,0 +1,151 @@
+import type { Meta, StoryObj } from "@storybook/vue3-vite";
+
+import ChatMessage from "@/components/components/chat-message/ChatMessage.vue";
+import ChatMessageAvatar from "@/components/components/chat-message/ChatMessageAvatar.vue";
+import ChatMessageContent from "@/components/components/chat-message/ChatMessageContent.vue";
+import ChatMessageActions from "@/components/components/chat-message/ChatMessageActions.vue";
+import ChatMessageGrid from "@/components/components/chat-message/preview/ChatMessageGrid.vue";
+import ChatMessageSizeGrid from "@/components/components/chat-message/preview/ChatMessageSizeGrid.vue";
+
+const colors = ["neutral", "light", "dark"] as const;
+const variants = ["solid", "outline", "soft", "subtle", "naked"] as const;
+const sizes = ["sm", "md", "lg"] as const;
+const sides = ["start", "end"] as const;
+
+const meta = {
+	title: "Theme/Recipes/ChatMessage",
+	component: ChatMessage,
+	tags: ["autodocs"],
+	parameters: {
+		layout: "padded",
+	},
+	argTypes: {
+		color: {
+			control: "select",
+			options: colors,
+			description: "The color variant of the message",
+		},
+		variant: {
+			control: "select",
+			options: variants,
+			description: "The visual style variant",
+		},
+		size: {
+			control: "select",
+			options: sizes,
+			description: "The size of the message",
+		},
+		side: {
+			control: "select",
+			options: sides,
+			description: "Logical side: start (assistant) or end (user)",
+		},
+	},
+	render: (args) => ({
+		components: {
+			ChatMessage,
+			ChatMessageAvatar,
+			ChatMessageContent,
+			ChatMessageActions,
+		},
+		setup() {
+			return { args };
+		},
+		template: `
+			<ChatMessage v-bind="args">
+				<ChatMessageAvatar v-bind="args">AI</ChatMessageAvatar>
+				<div class="chat-message-stack">
+					<ChatMessageContent v-bind="args">
+						Hello! I'm an assistant message rendered with the chat-message recipe.
+					</ChatMessageContent>
+					<ChatMessageActions v-bind="args">
+						<button class="chat-message-action-button" type="button">Copy</button>
+						<button class="chat-message-action-button" type="button">Regenerate</button>
+					</ChatMessageActions>
+				</div>
+			</ChatMessage>
+		`,
+	}),
+} satisfies Meta<typeof ChatMessage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {
+		color: "neutral",
+		variant: "subtle",
+		size: "md",
+		side: "start",
+	},
+};
+
+export const AllVariants: StoryObj = {
+	render: () => ({
+		components: { ChatMessageGrid },
+		template: "<ChatMessageGrid />",
+	}),
+};
+
+export const AllSizes: StoryObj = {
+	render: () => ({
+		components: { ChatMessageSizeGrid },
+		template: "<ChatMessageSizeGrid />",
+	}),
+};
+
+// Color stories
+export const Neutral: Story = {
+	args: { color: "neutral" },
+};
+
+export const Light: Story = {
+	args: { color: "light" },
+};
+
+export const Dark: Story = {
+	args: { color: "dark" },
+};
+
+// Variant stories
+export const Solid: Story = {
+	args: { variant: "solid" },
+};
+
+export const Outline: Story = {
+	args: { variant: "outline" },
+};
+
+export const Soft: Story = {
+	args: { variant: "soft" },
+};
+
+export const Subtle: Story = {
+	args: { variant: "subtle" },
+};
+
+export const Naked: Story = {
+	args: { variant: "naked" },
+};
+
+// Size stories
+export const Small: Story = {
+	args: { size: "sm" },
+};
+
+export const Medium: Story = {
+	args: { size: "md" },
+};
+
+export const Large: Story = {
+	args: { size: "lg" },
+};
+
+// Side stories
+export const SideStart: Story = {
+	args: { side: "start" },
+};
+
+export const SideEnd: Story = {
+	args: { side: "end" },
+};

--- a/apps/storybook/stories/components/chat-message.styleframe.ts
+++ b/apps/storybook/stories/components/chat-message.styleframe.ts
@@ -1,0 +1,74 @@
+import {
+	useChatMessageRecipe,
+	useChatMessageAvatarRecipe,
+	useChatMessageContentRecipe,
+	useChatMessageActionsRecipe,
+} from "@styleframe/theme";
+import { styleframe } from "virtual:styleframe";
+
+const s = styleframe();
+const { selector } = s;
+
+// Initialize chat-message recipes
+export const chatMessage = useChatMessageRecipe(s);
+export const chatMessageAvatar = useChatMessageAvatarRecipe(s);
+export const chatMessageContent = useChatMessageContentRecipe(s);
+export const chatMessageActions = useChatMessageActionsRecipe(s);
+
+// Container styles for story layout
+selector(".chat-message-grid", {
+	display: "flex",
+	flexDirection: "column",
+	gap: "@spacing.md",
+	padding: "@spacing.md",
+});
+
+selector(".chat-message-section", {
+	display: "flex",
+	flexDirection: "column",
+	gap: "@spacing.lg",
+	padding: "@spacing.md",
+});
+
+selector(".chat-message-row", {
+	display: "flex",
+	flexDirection: "column",
+	gap: "@spacing.sm",
+});
+
+selector(".chat-message-label", {
+	fontSize: "@font-size.sm",
+	fontWeight: "@font-weight.semibold",
+	color: "@color.text-weak",
+});
+
+// Vertical stack for content + actions inside a ChatMessage
+selector(".chat-message-stack", {
+	display: "flex",
+	flexDirection: "column",
+	minWidth: "0",
+});
+
+// Minimal pill styling for action buttons in stories
+selector(".chat-message-action-button", {
+	display: "inline-flex",
+	alignItems: "center",
+	gap: "@spacing.xs",
+	padding: "@0.25 @0.5",
+	fontSize: "@font-size.xs",
+	color: "@color.text-weak",
+	background: "transparent",
+	border: "none",
+	borderRadius: "@border-radius.sm",
+	cursor: "pointer",
+	"&:hover": {
+		background: "@color.gray-100",
+		color: "@color.text",
+	},
+	"&:dark:hover": {
+		background: "@color.gray-800",
+		color: "@color.white",
+	},
+});
+
+export default s;

--- a/theme/src/recipes/chat-message/index.ts
+++ b/theme/src/recipes/chat-message/index.ts
@@ -1,0 +1,4 @@
+export * from "./useChatMessageRecipe";
+export * from "./useChatMessageAvatarRecipe";
+export * from "./useChatMessageContentRecipe";
+export * from "./useChatMessageActionsRecipe";

--- a/theme/src/recipes/chat-message/useChatMessageActionsRecipe.test.ts
+++ b/theme/src/recipes/chat-message/useChatMessageActionsRecipe.test.ts
@@ -4,7 +4,13 @@ import { useChatMessageActionsRecipe } from "./index";
 
 function createInstance() {
 	const s = styleframe();
-	for (const name of ["display", "flexDirection", "gap", "marginTop"]) {
+	for (const name of [
+		"display",
+		"flexDirection",
+		"justifyContent",
+		"gap",
+		"marginTop",
+	]) {
 		s.utility(name, ({ value }) => ({ [name]: value }));
 	}
 	useDarkModifier(s);
@@ -77,6 +83,7 @@ describe("useChatMessageActionsRecipe", () => {
 			color: "neutral",
 			variant: "subtle",
 			size: "md",
+			side: "start",
 		});
 	});
 

--- a/theme/src/recipes/chat-message/useChatMessageActionsRecipe.test.ts
+++ b/theme/src/recipes/chat-message/useChatMessageActionsRecipe.test.ts
@@ -1,0 +1,93 @@
+import { styleframe } from "@styleframe/core";
+import { useDarkModifier } from "../../modifiers/useMediaPreferenceModifiers";
+import { useChatMessageActionsRecipe } from "./index";
+
+function createInstance() {
+	const s = styleframe();
+	for (const name of ["display", "flexDirection", "gap", "marginTop"]) {
+		s.utility(name, ({ value }) => ({ [name]: value }));
+	}
+	useDarkModifier(s);
+	return s;
+}
+
+describe("useChatMessageActionsRecipe", () => {
+	it("should create a recipe with correct metadata", () => {
+		const s = createInstance();
+		const recipe = useChatMessageActionsRecipe(s);
+
+		expect(recipe.type).toBe("recipe");
+		expect(recipe.name).toBe("chat-message-actions");
+	});
+
+	it("should have correct base styles", () => {
+		const s = createInstance();
+		const recipe = useChatMessageActionsRecipe(s);
+
+		expect(recipe.base).toEqual({
+			display: "flex",
+			flexDirection: "row",
+			gap: "@0.25",
+			marginTop: "@0.25",
+		});
+	});
+
+	describe("variants", () => {
+		it("should have all color variants", () => {
+			const s = createInstance();
+			const recipe = useChatMessageActionsRecipe(s);
+
+			expect(Object.keys(recipe.variants!.color)).toEqual([
+				"light",
+				"dark",
+				"neutral",
+			]);
+		});
+
+		it("should have all style variants", () => {
+			const s = createInstance();
+			const recipe = useChatMessageActionsRecipe(s);
+
+			expect(Object.keys(recipe.variants!.variant)).toEqual([
+				"solid",
+				"outline",
+				"soft",
+				"subtle",
+				"naked",
+			]);
+		});
+
+		it("should have size variants with correct gap and margin", () => {
+			const s = createInstance();
+			const recipe = useChatMessageActionsRecipe(s);
+
+			expect(recipe.variants!.size).toEqual({
+				sm: { gap: "@0.125", marginTop: "@0.125" },
+				md: { gap: "@0.25", marginTop: "@0.25" },
+				lg: { gap: "@0.375", marginTop: "@0.375" },
+			});
+		});
+	});
+
+	it("should have correct default variants", () => {
+		const s = createInstance();
+		const recipe = useChatMessageActionsRecipe(s);
+
+		expect(recipe.defaultVariants).toEqual({
+			color: "neutral",
+			variant: "subtle",
+			size: "md",
+		});
+	});
+
+	describe("filter", () => {
+		it("should filter size variants", () => {
+			const s = createInstance();
+			const recipe = useChatMessageActionsRecipe(s, {
+				filter: { size: ["md"] },
+			});
+
+			expect(Object.keys(recipe.variants!.size)).toEqual(["md"]);
+		});
+	});
+});

--- a/theme/src/recipes/chat-message/useChatMessageActionsRecipe.ts
+++ b/theme/src/recipes/chat-message/useChatMessageActionsRecipe.ts
@@ -1,0 +1,42 @@
+import { createUseRecipe } from "../../utils/createUseRecipe";
+
+/**
+ * Chat message actions row recipe — flex layout for action buttons displayed
+ * below the bubble. Hover-reveal is a markup concern (e.g., opacity toggled
+ * on the parent message group), not a recipe variant.
+ */
+export const useChatMessageActionsRecipe = createUseRecipe(
+	"chat-message-actions",
+	{
+		base: {
+			display: "flex",
+			flexDirection: "row",
+			gap: "@0.25",
+			marginTop: "@0.25",
+		},
+		variants: {
+			color: {
+				light: {},
+				dark: {},
+				neutral: {},
+			},
+			variant: {
+				solid: {},
+				outline: {},
+				soft: {},
+				subtle: {},
+				naked: {},
+			},
+			size: {
+				sm: { gap: "@0.125", marginTop: "@0.125" },
+				md: { gap: "@0.25", marginTop: "@0.25" },
+				lg: { gap: "@0.375", marginTop: "@0.375" },
+			},
+		},
+		defaultVariants: {
+			color: "neutral",
+			variant: "subtle",
+			size: "md",
+		},
+	},
+);

--- a/theme/src/recipes/chat-message/useChatMessageActionsRecipe.ts
+++ b/theme/src/recipes/chat-message/useChatMessageActionsRecipe.ts
@@ -20,6 +20,10 @@ export const useChatMessageActionsRecipe = createUseRecipe(
 				dark: {},
 				neutral: {},
 			},
+			side: {
+				start: {},
+				end: { justifyContent: "flex-end" },
+			},
 			variant: {
 				solid: {},
 				outline: {},
@@ -37,6 +41,7 @@ export const useChatMessageActionsRecipe = createUseRecipe(
 			color: "neutral",
 			variant: "subtle",
 			size: "md",
+			side: "start",
 		},
 	},
 );

--- a/theme/src/recipes/chat-message/useChatMessageAvatarRecipe.test.ts
+++ b/theme/src/recipes/chat-message/useChatMessageAvatarRecipe.test.ts
@@ -1,0 +1,112 @@
+import { styleframe } from "@styleframe/core";
+import { useDarkModifier } from "../../modifiers/useMediaPreferenceModifiers";
+import { useChatMessageAvatarRecipe } from "./index";
+
+function createInstance() {
+	const s = styleframe();
+	for (const name of [
+		"display",
+		"alignItems",
+		"justifyContent",
+		"flexShrink",
+		"overflow",
+		"borderRadius",
+		"background",
+		"color",
+		"width",
+		"height",
+	]) {
+		s.utility(name, ({ value }) => ({ [name]: value }));
+	}
+	useDarkModifier(s);
+	return s;
+}
+
+describe("useChatMessageAvatarRecipe", () => {
+	it("should create a recipe with correct metadata", () => {
+		const s = createInstance();
+		const recipe = useChatMessageAvatarRecipe(s);
+
+		expect(recipe.type).toBe("recipe");
+		expect(recipe.name).toBe("chat-message-avatar");
+	});
+
+	it("should have correct base styles", () => {
+		const s = createInstance();
+		const recipe = useChatMessageAvatarRecipe(s);
+
+		expect(recipe.base).toEqual({
+			display: "flex",
+			alignItems: "center",
+			justifyContent: "center",
+			flexShrink: "0",
+			overflow: "hidden",
+			borderRadius: "@border-radius.full",
+			background: "@color.gray-200",
+			color: "@color.gray-700",
+			"&:dark": {
+				background: "@color.gray-800",
+				color: "@color.gray-300",
+			},
+		});
+	});
+
+	describe("variants", () => {
+		it("should have all color variants", () => {
+			const s = createInstance();
+			const recipe = useChatMessageAvatarRecipe(s);
+
+			expect(Object.keys(recipe.variants!.color)).toEqual([
+				"light",
+				"dark",
+				"neutral",
+			]);
+		});
+
+		it("should have all style variants", () => {
+			const s = createInstance();
+			const recipe = useChatMessageAvatarRecipe(s);
+
+			expect(Object.keys(recipe.variants!.variant)).toEqual([
+				"solid",
+				"outline",
+				"soft",
+				"subtle",
+				"naked",
+			]);
+		});
+
+		it("should have size variants with correct dimensions", () => {
+			const s = createInstance();
+			const recipe = useChatMessageAvatarRecipe(s);
+
+			expect(recipe.variants!.size).toEqual({
+				sm: { width: "@1.5", height: "@1.5" },
+				md: { width: "@2", height: "@2" },
+				lg: { width: "@2.5", height: "@2.5" },
+			});
+		});
+	});
+
+	it("should have correct default variants", () => {
+		const s = createInstance();
+		const recipe = useChatMessageAvatarRecipe(s);
+
+		expect(recipe.defaultVariants).toEqual({
+			color: "neutral",
+			variant: "subtle",
+			size: "md",
+		});
+	});
+
+	describe("filter", () => {
+		it("should filter size variants", () => {
+			const s = createInstance();
+			const recipe = useChatMessageAvatarRecipe(s, {
+				filter: { size: ["md"] },
+			});
+
+			expect(Object.keys(recipe.variants!.size)).toEqual(["md"]);
+		});
+	});
+});

--- a/theme/src/recipes/chat-message/useChatMessageAvatarRecipe.ts
+++ b/theme/src/recipes/chat-message/useChatMessageAvatarRecipe.ts
@@ -1,0 +1,50 @@
+import { createUseRecipe } from "../../utils/createUseRecipe";
+
+/**
+ * Chat message avatar recipe — leading slot for an avatar or icon.
+ * Independent of the media recipe: consumers drop a raw <img> or icon
+ * inside an element styled by this recipe and get correct sizing/shape.
+ */
+export const useChatMessageAvatarRecipe = createUseRecipe(
+	"chat-message-avatar",
+	{
+		base: {
+			display: "flex",
+			alignItems: "center",
+			justifyContent: "center",
+			flexShrink: "0",
+			overflow: "hidden",
+			borderRadius: "@border-radius.full",
+			background: "@color.gray-200",
+			color: "@color.gray-700",
+			"&:dark": {
+				background: "@color.gray-800",
+				color: "@color.gray-300",
+			},
+		},
+		variants: {
+			color: {
+				light: {},
+				dark: {},
+				neutral: {},
+			},
+			variant: {
+				solid: {},
+				outline: {},
+				soft: {},
+				subtle: {},
+				naked: {},
+			},
+			size: {
+				sm: { width: "@1.5", height: "@1.5" },
+				md: { width: "@2", height: "@2" },
+				lg: { width: "@2.5", height: "@2.5" },
+			},
+		},
+		defaultVariants: {
+			color: "neutral",
+			variant: "subtle",
+			size: "md",
+		},
+	},
+);

--- a/theme/src/recipes/chat-message/useChatMessageContentRecipe.test.ts
+++ b/theme/src/recipes/chat-message/useChatMessageContentRecipe.test.ts
@@ -1,0 +1,230 @@
+import { styleframe } from "@styleframe/core";
+import { useDarkModifier } from "../../modifiers/useMediaPreferenceModifiers";
+import { useChatMessageContentRecipe } from "./index";
+
+function createInstance() {
+	const s = styleframe();
+	for (const name of [
+		"borderWidth",
+		"borderStyle",
+		"borderColor",
+		"borderRadius",
+		"background",
+		"maxWidth",
+		"lineHeight",
+		"color",
+		"paddingTop",
+		"paddingBottom",
+		"paddingLeft",
+		"paddingRight",
+	]) {
+		s.utility(name, ({ value }) => ({ [name]: value }));
+	}
+	useDarkModifier(s);
+	return s;
+}
+
+describe("useChatMessageContentRecipe", () => {
+	it("should create a recipe with correct metadata", () => {
+		const s = createInstance();
+		const recipe = useChatMessageContentRecipe(s);
+
+		expect(recipe.type).toBe("recipe");
+		expect(recipe.name).toBe("chat-message-content");
+	});
+
+	it("should have correct base styles", () => {
+		const s = createInstance();
+		const recipe = useChatMessageContentRecipe(s);
+
+		expect(recipe.base).toEqual({
+			borderWidth: "@border-width.thin",
+			borderStyle: "@border-style.solid",
+			borderColor: "transparent",
+			borderRadius: "@border-radius.md",
+			background: "transparent",
+			maxWidth: "75%",
+			lineHeight: "@line-height.normal",
+		});
+	});
+
+	describe("variants", () => {
+		it("should have all color variants", () => {
+			const s = createInstance();
+			const recipe = useChatMessageContentRecipe(s);
+
+			expect(Object.keys(recipe.variants!.color)).toEqual([
+				"light",
+				"dark",
+				"neutral",
+			]);
+		});
+
+		it("should have all style variants including outline and naked", () => {
+			const s = createInstance();
+			const recipe = useChatMessageContentRecipe(s);
+
+			expect(Object.keys(recipe.variants!.variant)).toEqual([
+				"solid",
+				"outline",
+				"soft",
+				"subtle",
+				"naked",
+			]);
+		});
+
+		it("should have naked variant that strips chrome", () => {
+			const s = createInstance();
+			const recipe = useChatMessageContentRecipe(s);
+
+			expect(recipe.variants!.variant.naked).toEqual({
+				background: "transparent",
+				borderColor: "transparent",
+				paddingTop: "0",
+				paddingBottom: "0",
+				paddingLeft: "0",
+				paddingRight: "0",
+				borderRadius: "0",
+			});
+		});
+
+		it("should have size variants with correct padding and border-radius", () => {
+			const s = createInstance();
+			const recipe = useChatMessageContentRecipe(s);
+
+			expect(recipe.variants!.size).toEqual({
+				sm: {
+					paddingTop: "@0.5",
+					paddingBottom: "@0.5",
+					paddingLeft: "@0.75",
+					paddingRight: "@0.75",
+					borderRadius: "@border-radius.sm",
+				},
+				md: {
+					paddingTop: "@0.75",
+					paddingBottom: "@0.75",
+					paddingLeft: "@1",
+					paddingRight: "@1",
+					borderRadius: "@border-radius.md",
+				},
+				lg: {
+					paddingTop: "@1",
+					paddingBottom: "@1",
+					paddingLeft: "@1.25",
+					paddingRight: "@1.25",
+					borderRadius: "@border-radius.lg",
+				},
+			});
+		});
+	});
+
+	it("should have correct default variants", () => {
+		const s = createInstance();
+		const recipe = useChatMessageContentRecipe(s);
+
+		expect(recipe.defaultVariants).toEqual({
+			color: "neutral",
+			size: "md",
+			variant: "subtle",
+		});
+	});
+
+	describe("compound variants", () => {
+		it("should have 12 compound variants total", () => {
+			const s = createInstance();
+			const recipe = useChatMessageContentRecipe(s);
+
+			// 3 colors × 4 visual variants (solid/outline/soft/subtle) = 12
+			// (naked has no compound entries — it strips chrome regardless of color)
+			expect(recipe.compoundVariants).toHaveLength(12);
+		});
+
+		it("should have correct light × outline compound variant", () => {
+			const s = createInstance();
+			const recipe = useChatMessageContentRecipe(s);
+
+			const lightOutline = recipe.compoundVariants!.find(
+				(cv) => cv.match.color === "light" && cv.match.variant === "outline",
+			);
+
+			expect(lightOutline).toEqual({
+				match: { color: "light", variant: "outline" },
+				css: {
+					borderColor: "@color.gray-200",
+					color: "@color.gray-700",
+					"&:dark": {
+						borderColor: "@color.gray-200",
+						color: "@color.gray-700",
+					},
+				},
+			});
+		});
+
+		it("should have correct neutral × subtle compound variant with adaptive dark mode", () => {
+			const s = createInstance();
+			const recipe = useChatMessageContentRecipe(s);
+
+			const neutralSubtle = recipe.compoundVariants!.find(
+				(cv) => cv.match.color === "neutral" && cv.match.variant === "subtle",
+			);
+
+			expect(neutralSubtle).toEqual({
+				match: { color: "neutral", variant: "subtle" },
+				css: {
+					background: "@color.gray-100",
+					color: "@color.gray-700",
+					borderColor: "@color.gray-200",
+					"&:dark": {
+						background: "@color.gray-800",
+						color: "@color.gray-300",
+						borderColor: "@color.gray-700",
+					},
+				},
+			});
+		});
+
+		it("should have no compound variants for naked", () => {
+			const s = createInstance();
+			const recipe = useChatMessageContentRecipe(s);
+
+			const nakedEntries = recipe.compoundVariants!.filter(
+				(cv) => cv.match.variant === "naked",
+			);
+
+			expect(nakedEntries).toHaveLength(0);
+		});
+	});
+
+	describe("filter", () => {
+		it("should filter color variants", () => {
+			const s = createInstance();
+			const recipe = useChatMessageContentRecipe(s, {
+				filter: { color: ["neutral"] },
+			});
+
+			expect(Object.keys(recipe.variants!.color)).toEqual(["neutral"]);
+			expect(
+				recipe.compoundVariants!.every((cv) => cv.match.color === "neutral"),
+			).toBe(true);
+			expect(recipe.compoundVariants).toHaveLength(4);
+		});
+
+		it("should prune compound variants when filtering variant axis", () => {
+			const s = createInstance();
+			const recipe = useChatMessageContentRecipe(s, {
+				filter: { variant: ["solid", "outline"] },
+			});
+
+			expect(Object.keys(recipe.variants!.variant)).toEqual([
+				"solid",
+				"outline",
+			]);
+			expect(
+				recipe.compoundVariants!.every(
+					(cv) =>
+						cv.match.variant === "solid" || cv.match.variant === "outline",
+				),
+			).toBe(true);
+		});
+	});
+});

--- a/theme/src/recipes/chat-message/useChatMessageContentRecipe.test.ts
+++ b/theme/src/recipes/chat-message/useChatMessageContentRecipe.test.ts
@@ -10,7 +10,7 @@ function createInstance() {
 		"borderColor",
 		"borderRadius",
 		"background",
-		"maxWidth",
+		"alignSelf",
 		"lineHeight",
 		"color",
 		"paddingTop",
@@ -43,7 +43,6 @@ describe("useChatMessageContentRecipe", () => {
 			borderColor: "transparent",
 			borderRadius: "@border-radius.md",
 			background: "transparent",
-			maxWidth: "75%",
 			lineHeight: "@line-height.normal",
 		});
 	});
@@ -126,6 +125,7 @@ describe("useChatMessageContentRecipe", () => {
 			color: "neutral",
 			size: "md",
 			variant: "subtle",
+			side: "start",
 		});
 	});
 

--- a/theme/src/recipes/chat-message/useChatMessageContentRecipe.ts
+++ b/theme/src/recipes/chat-message/useChatMessageContentRecipe.ts
@@ -1,0 +1,223 @@
+import { createUseRecipe } from "../../utils/createUseRecipe";
+
+/**
+ * Chat message content recipe — the bubble itself. Owns the
+ * color × variant compound matrix (12 entries: 3 colors × 4 visual variants).
+ * The naked variant strips bubble chrome (transparent bg, no border, no
+ * padding) — used for assistant turns that should read as inline prose.
+ */
+export const useChatMessageContentRecipe = createUseRecipe(
+	"chat-message-content",
+	{
+		base: {
+			borderWidth: "@border-width.thin",
+			borderStyle: "@border-style.solid",
+			borderColor: "transparent",
+			borderRadius: "@border-radius.md",
+			background: "transparent",
+			maxWidth: "75%",
+			lineHeight: "@line-height.normal",
+		},
+		variants: {
+			color: {
+				light: {},
+				dark: {},
+				neutral: {},
+			},
+			size: {
+				sm: {
+					paddingTop: "@0.5",
+					paddingBottom: "@0.5",
+					paddingLeft: "@0.75",
+					paddingRight: "@0.75",
+					borderRadius: "@border-radius.sm",
+				},
+				md: {
+					paddingTop: "@0.75",
+					paddingBottom: "@0.75",
+					paddingLeft: "@1",
+					paddingRight: "@1",
+					borderRadius: "@border-radius.md",
+				},
+				lg: {
+					paddingTop: "@1",
+					paddingBottom: "@1",
+					paddingLeft: "@1.25",
+					paddingRight: "@1.25",
+					borderRadius: "@border-radius.lg",
+				},
+			},
+			variant: {
+				solid: {},
+				outline: {},
+				soft: {},
+				subtle: {},
+				naked: {
+					background: "transparent",
+					borderColor: "transparent",
+					paddingTop: "0",
+					paddingBottom: "0",
+					paddingLeft: "0",
+					paddingRight: "0",
+					borderRadius: "0",
+				},
+			},
+		},
+		compoundVariants: [
+			// Light (fixed across themes — light-toned bubble in both modes)
+			{
+				match: { color: "light" as const, variant: "solid" as const },
+				css: {
+					background: "@color.white",
+					color: "@color.text",
+					borderColor: "@color.gray-200",
+					"&:dark": {
+						background: "@color.white",
+						color: "@color.text-inverted",
+						borderColor: "@color.gray-200",
+					},
+				},
+			},
+			{
+				match: { color: "light" as const, variant: "outline" as const },
+				css: {
+					borderColor: "@color.gray-200",
+					color: "@color.gray-700",
+					"&:dark": {
+						borderColor: "@color.gray-200",
+						color: "@color.gray-700",
+					},
+				},
+			},
+			{
+				match: { color: "light" as const, variant: "soft" as const },
+				css: {
+					background: "@color.gray-100",
+					color: "@color.gray-700",
+					"&:dark": {
+						background: "@color.gray-100",
+						color: "@color.gray-700",
+					},
+				},
+			},
+			{
+				match: { color: "light" as const, variant: "subtle" as const },
+				css: {
+					background: "@color.gray-100",
+					color: "@color.gray-700",
+					borderColor: "@color.gray-200",
+					"&:dark": {
+						background: "@color.gray-100",
+						color: "@color.gray-700",
+						borderColor: "@color.gray-200",
+					},
+				},
+			},
+
+			// Dark (fixed across themes — dark-toned bubble in both modes)
+			{
+				match: { color: "dark" as const, variant: "solid" as const },
+				css: {
+					background: "@color.gray-900",
+					color: "@color.text-inverted",
+					borderColor: "@color.gray-700",
+					"&:dark": {
+						background: "@color.gray-900",
+						color: "@color.text",
+						borderColor: "@color.gray-700",
+					},
+				},
+			},
+			{
+				match: { color: "dark" as const, variant: "outline" as const },
+				css: {
+					borderColor: "@color.gray-700",
+					color: "@color.gray-300",
+					"&:dark": {
+						borderColor: "@color.gray-700",
+						color: "@color.gray-300",
+					},
+				},
+			},
+			{
+				match: { color: "dark" as const, variant: "soft" as const },
+				css: {
+					background: "@color.gray-800",
+					color: "@color.gray-300",
+					"&:dark": {
+						background: "@color.gray-800",
+						color: "@color.gray-300",
+					},
+				},
+			},
+			{
+				match: { color: "dark" as const, variant: "subtle" as const },
+				css: {
+					background: "@color.gray-800",
+					color: "@color.gray-300",
+					borderColor: "@color.gray-700",
+					"&:dark": {
+						background: "@color.gray-800",
+						color: "@color.gray-300",
+						borderColor: "@color.gray-700",
+					},
+				},
+			},
+
+			// Neutral (adaptive — light in light mode, dark in dark mode)
+			{
+				match: { color: "neutral" as const, variant: "solid" as const },
+				css: {
+					background: "@color.white",
+					color: "@color.text",
+					borderColor: "@color.gray-200",
+					"&:dark": {
+						background: "@color.gray-900",
+						color: "@color.white",
+						borderColor: "@color.gray-700",
+					},
+				},
+			},
+			{
+				match: { color: "neutral" as const, variant: "outline" as const },
+				css: {
+					borderColor: "@color.gray-200",
+					color: "@color.gray-700",
+					"&:dark": {
+						borderColor: "@color.gray-700",
+						color: "@color.gray-300",
+					},
+				},
+			},
+			{
+				match: { color: "neutral" as const, variant: "soft" as const },
+				css: {
+					background: "@color.gray-100",
+					color: "@color.gray-700",
+					"&:dark": {
+						background: "@color.gray-800",
+						color: "@color.gray-300",
+					},
+				},
+			},
+			{
+				match: { color: "neutral" as const, variant: "subtle" as const },
+				css: {
+					background: "@color.gray-100",
+					color: "@color.gray-700",
+					borderColor: "@color.gray-200",
+					"&:dark": {
+						background: "@color.gray-800",
+						color: "@color.gray-300",
+						borderColor: "@color.gray-700",
+					},
+				},
+			},
+		],
+		defaultVariants: {
+			color: "neutral",
+			size: "md",
+			variant: "subtle",
+		},
+	},
+);

--- a/theme/src/recipes/chat-message/useChatMessageContentRecipe.ts
+++ b/theme/src/recipes/chat-message/useChatMessageContentRecipe.ts
@@ -15,7 +15,6 @@ export const useChatMessageContentRecipe = createUseRecipe(
 			borderColor: "transparent",
 			borderRadius: "@border-radius.md",
 			background: "transparent",
-			maxWidth: "75%",
 			lineHeight: "@line-height.normal",
 		},
 		variants: {
@@ -23,6 +22,10 @@ export const useChatMessageContentRecipe = createUseRecipe(
 				light: {},
 				dark: {},
 				neutral: {},
+			},
+			side: {
+				start: {},
+				end: { alignSelf: "flex-end" },
 			},
 			size: {
 				sm: {
@@ -218,6 +221,7 @@ export const useChatMessageContentRecipe = createUseRecipe(
 			color: "neutral",
 			size: "md",
 			variant: "subtle",
+			side: "start",
 		},
 	},
 );

--- a/theme/src/recipes/chat-message/useChatMessageRecipe.test.ts
+++ b/theme/src/recipes/chat-message/useChatMessageRecipe.test.ts
@@ -1,0 +1,146 @@
+import { styleframe } from "@styleframe/core";
+import { useDarkModifier } from "../../modifiers/useMediaPreferenceModifiers";
+import { useChatMessageRecipe } from "./index";
+
+function createInstance() {
+	const s = styleframe();
+	for (const name of [
+		"display",
+		"flexDirection",
+		"alignItems",
+		"justifyContent",
+		"gap",
+		"width",
+	]) {
+		s.utility(name, ({ value }) => ({ [name]: value }));
+	}
+	useDarkModifier(s);
+	return s;
+}
+
+describe("useChatMessageRecipe", () => {
+	it("should create a recipe with correct metadata", () => {
+		const s = createInstance();
+		const recipe = useChatMessageRecipe(s);
+
+		expect(recipe.type).toBe("recipe");
+		expect(recipe.name).toBe("chat-message");
+	});
+
+	it("should have correct base styles", () => {
+		const s = createInstance();
+		const recipe = useChatMessageRecipe(s);
+
+		expect(recipe.base).toEqual({
+			display: "flex",
+			flexDirection: "row",
+			alignItems: "flex-start",
+			gap: "@0.75",
+			width: "100%",
+		});
+	});
+
+	describe("variants", () => {
+		it("should have all color variants", () => {
+			const s = createInstance();
+			const recipe = useChatMessageRecipe(s);
+
+			expect(Object.keys(recipe.variants!.color)).toEqual([
+				"light",
+				"dark",
+				"neutral",
+			]);
+		});
+
+		it("should have all style variants", () => {
+			const s = createInstance();
+			const recipe = useChatMessageRecipe(s);
+
+			expect(Object.keys(recipe.variants!.variant)).toEqual([
+				"solid",
+				"outline",
+				"soft",
+				"subtle",
+				"naked",
+			]);
+		});
+
+		it("should have size variants with correct gap", () => {
+			const s = createInstance();
+			const recipe = useChatMessageRecipe(s);
+
+			expect(recipe.variants!.size).toEqual({
+				sm: { gap: "@0.5" },
+				md: { gap: "@0.75" },
+				lg: { gap: "@1" },
+			});
+		});
+
+		it("should have side variants with logical alignment", () => {
+			const s = createInstance();
+			const recipe = useChatMessageRecipe(s);
+
+			expect(recipe.variants!.side).toEqual({
+				start: { justifyContent: "flex-start" },
+				end: {
+					justifyContent: "flex-end",
+					flexDirection: "row-reverse",
+				},
+			});
+		});
+	});
+
+	it("should have correct default variants", () => {
+		const s = createInstance();
+		const recipe = useChatMessageRecipe(s);
+
+		expect(recipe.defaultVariants).toEqual({
+			color: "neutral",
+			size: "md",
+			variant: "subtle",
+			side: "start",
+		});
+	});
+
+	describe("config overrides", () => {
+		it("should allow overriding base styles", () => {
+			const s = createInstance();
+			const recipe = useChatMessageRecipe(s, {
+				base: { display: "inline-flex" },
+			});
+
+			expect(recipe.base!.display).toBe("inline-flex");
+			expect(recipe.base!.flexDirection).toBe("row");
+		});
+	});
+
+	describe("filter", () => {
+		it("should filter color variants", () => {
+			const s = createInstance();
+			const recipe = useChatMessageRecipe(s, {
+				filter: { color: ["neutral"] },
+			});
+
+			expect(Object.keys(recipe.variants!.color)).toEqual(["neutral"]);
+		});
+
+		it("should filter side axis", () => {
+			const s = createInstance();
+			const recipe = useChatMessageRecipe(s, {
+				filter: { side: ["end"] },
+			});
+
+			expect(Object.keys(recipe.variants!.side)).toEqual(["end"]);
+		});
+
+		it("should adjust default variants when filtered out", () => {
+			const s = createInstance();
+			const recipe = useChatMessageRecipe(s, {
+				filter: { side: ["end"] },
+			});
+
+			expect(recipe.defaultVariants?.side).toBeUndefined();
+			expect(recipe.defaultVariants?.color).toBe("neutral");
+		});
+	});
+});

--- a/theme/src/recipes/chat-message/useChatMessageRecipe.test.ts
+++ b/theme/src/recipes/chat-message/useChatMessageRecipe.test.ts
@@ -83,7 +83,7 @@ describe("useChatMessageRecipe", () => {
 			expect(recipe.variants!.side).toEqual({
 				start: { justifyContent: "flex-start" },
 				end: {
-					justifyContent: "flex-end",
+					justifyContent: "flex-start",
 					flexDirection: "row-reverse",
 				},
 			});

--- a/theme/src/recipes/chat-message/useChatMessageRecipe.ts
+++ b/theme/src/recipes/chat-message/useChatMessageRecipe.ts
@@ -36,7 +36,7 @@ export const useChatMessageRecipe = createUseRecipe("chat-message", {
 				justifyContent: "flex-start",
 			},
 			end: {
-				justifyContent: "flex-end",
+				justifyContent: "flex-start",
 				flexDirection: "row-reverse",
 			},
 		},

--- a/theme/src/recipes/chat-message/useChatMessageRecipe.ts
+++ b/theme/src/recipes/chat-message/useChatMessageRecipe.ts
@@ -1,0 +1,50 @@
+import { createUseRecipe } from "../../utils/createUseRecipe";
+
+/**
+ * Chat message root recipe — a flex container wrapping an optional leading
+ * avatar/icon and a content bubble. Owns the side axis (start/end) for
+ * alignment, with logical sides that flip under dir="rtl".
+ */
+export const useChatMessageRecipe = createUseRecipe("chat-message", {
+	base: {
+		display: "flex",
+		flexDirection: "row",
+		alignItems: "flex-start",
+		gap: "@0.75",
+		width: "100%",
+	},
+	variants: {
+		color: {
+			light: {},
+			dark: {},
+			neutral: {},
+		},
+		size: {
+			sm: { gap: "@0.5" },
+			md: { gap: "@0.75" },
+			lg: { gap: "@1" },
+		},
+		variant: {
+			solid: {},
+			outline: {},
+			soft: {},
+			subtle: {},
+			naked: {},
+		},
+		side: {
+			start: {
+				justifyContent: "flex-start",
+			},
+			end: {
+				justifyContent: "flex-end",
+				flexDirection: "row-reverse",
+			},
+		},
+	},
+	defaultVariants: {
+		color: "neutral",
+		size: "md",
+		variant: "subtle",
+		side: "start",
+	},
+});

--- a/theme/src/recipes/index.ts
+++ b/theme/src/recipes/index.ts
@@ -4,6 +4,7 @@ export * from "./button";
 export * from "./button-group";
 export * from "./callout";
 export * from "./card";
+export * from "./chat-message";
 export * from "./chip";
 export * from "./dropdown";
 export * from "./hamburger-menu";


### PR DESCRIPTION
## Summary

Multi-part Styleframe recipe for AI chat-message bubbles, inspired by [Nuxt UI's ChatMessage](https://ui.nuxt.com/docs/components/chat-message). Four sub-recipes (`chat-message`, `chat-message-avatar`, `chat-message-content`, `chat-message-actions`) share a common axis set: container colors (`light`/`dark`/`neutral`), five visual variants (`solid`/`outline`/`soft`/`subtle`/`naked`), three sizes, plus a logical `side` axis (`start`/`end`) on the root for RTL-safe alignment. The avatar sub-recipe is independent of the `media` recipe — drop a raw `<img>` and get correct sizing/shape. Content owns the 12-entry color × variant compound matrix; the `naked` variant strips bubble chrome at the variant level so it has no compound rows.

Ships with 37 unit tests, a Storybook showcase (per-variant/per-size/per-side stories plus `ChatMessageGrid` and `ChatMessageSizeGrid` previews), and a docs page at `apps/docs/content/docs/04.components/02.composables/16.chat-message.md`. `pnpm typecheck`, `pnpm --filter @styleframe/theme test` (2594/2594), and `pnpm lint` (0 errors, 0 warnings from new files) all pass.

## Test plan

- [ ] `pnpm typecheck` clean
- [ ] `pnpm --filter @styleframe/theme test` clean (37 new tests)
- [ ] `pnpm lint` clean
- [ ] Manual: open `Theme/Recipes/ChatMessage` in Storybook and verify `AllVariants`, `AllSizes`, `SideEnd`, and `Naked` stories render correctly in both light and dark themes
- [ ] Manual: open the new docs page and confirm `::story-preview` embeds resolve and code samples are correct