### PR TITLE
docs: add persistent framework switcher to docs sidebar

### DIFF
--- a/.changeset/docs-framework-switcher.md
+++ b/.changeset/docs-framework-switcher.md
@@ -1,0 +1,5 @@
+---
+"@styleframe/docs": patch
+---
+
+Add a persistent framework switcher to the docs sidebar (Vue, React, Vanilla / Other) backed by `useFramework()` with localStorage persistence. Replace inline `tabs-item` blocks with a shared `<FrameworkSwitcher>` content component across both getting-started guides and all 20 composable recipe docs, and add a vanilla TS + HTML `#other` slot to every composable doc showing the recipe's framework-agnostic class-string output.

--- a/apps/docs/app/components/content/FrameworkSwitcher.vue
+++ b/apps/docs/app/components/content/FrameworkSwitcher.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+const { framework, frameworks } = useFramework();
+const slots = useSlots();
+
+const current = computed(
+	() =>
+		frameworks.find((f) => f.value === framework.value) ?? frameworks[0],
+);
+
+const fallback = computed(() => {
+	if (slots[framework.value]) return null;
+	return frameworks.find((f) => slots[f.value]) ?? null;
+});
+</script>
+
+<template>
+	<div class="framework-switcher">
+		<p v-if="fallback" class="text-sm text-muted mb-2">
+			Not available for {{ current.label }} — showing {{ fallback.label }}.
+		</p>
+		<slot v-if="!fallback" :name="framework" />
+		<slot v-else :name="fallback.value" />
+	</div>
+</template>

--- a/apps/docs/app/components/content/FrameworkSwitcher.vue
+++ b/apps/docs/app/components/content/FrameworkSwitcher.vue
@@ -3,8 +3,7 @@ const { framework, frameworks } = useFramework();
 const slots = useSlots();
 
 const current = computed(
-	() =>
-		frameworks.find((f) => f.value === framework.value) ?? frameworks[0],
+	() => frameworks.find((f) => f.value === framework.value) ?? frameworks[0],
 );
 
 const fallback = computed(() => {

--- a/apps/docs/app/components/docs/DocsAsideLeftTop.vue
+++ b/apps/docs/app/components/docs/DocsAsideLeftTop.vue
@@ -1,3 +1,16 @@
 <template>
-	<div />
+	<div>
+		<span class="group relative w-full pr-2.5 py-1.5 flex items-center gap-1.5 text-sm text-muted cursor-default hover:text-highlighted transition-colors font-normal">
+			<span class="truncate">
+				Framework
+			</span>
+		</span>
+
+		<DocsFrameworkSelect class="mb-2" />
+
+		<!-- <USeparator
+			type="dashed"
+			class="my-6"
+		/> -->
+	</div>
 </template>

--- a/apps/docs/app/components/docs/DocsFrameworkSelect.vue
+++ b/apps/docs/app/components/docs/DocsFrameworkSelect.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+const { framework, frameworks } = useFramework();
+
+const current = computed(
+	() =>
+		frameworks.find((option) => option.value === framework.value) ??
+		frameworks[0],
+);
+</script>
+
+<template>
+	<USelect
+		v-model="framework"
+		:items="[...frameworks]"
+		variant="ghost"
+		color="neutral"
+		:icon="current.icon"
+		class="w-full"
+	/>
+</template>

--- a/apps/docs/app/composables/useFramework.ts
+++ b/apps/docs/app/composables/useFramework.ts
@@ -1,0 +1,32 @@
+import { useLocalStorage } from "@vueuse/core";
+
+export type Framework = "vue" | "react" | "other";
+
+export interface FrameworkOption {
+	value: Framework;
+	label: string;
+	icon: string;
+}
+
+export const FRAMEWORKS: readonly FrameworkOption[] = [
+	{ value: "react", label: "React", icon: "i-mdi-react" },
+	{
+		value: "other",
+		label: "Vanilla",
+		icon: "i-mdi-language-typescript",
+	},
+	{ value: "vue", label: "Vue", icon: "i-mdi-vuejs" },
+] as const;
+
+const STORAGE_KEY = "styleframe-docs:framework";
+
+export const useFramework = () => {
+	const framework = useLocalStorage<Framework>(STORAGE_KEY, "react", {
+		initOnMounted: true,
+	});
+
+	return {
+		framework,
+		frameworks: FRAMEWORKS,
+	};
+};

--- a/apps/docs/content/docs/01.getting-started/03.guides/01.create-design-system-in-under-15-minutes.md
+++ b/apps/docs/content/docs/01.getting-started/03.guides/01.create-design-system-in-under-15-minutes.md
@@ -273,8 +273,9 @@ export default s;
 
 Import the `button` runtime function from the auto-generated `virtual:styleframe` module and pass variant props to compute class names. The function is fully typed, so invalid colors, variants, or sizes are caught at compile time.
 
-:::tabs
-::::tabs-item{icon="i-devicon-vuejs" label="Vue"}
+::framework-switcher
+
+#vue
 
 ```vue [src/components/Button.vue]
 <script setup lang="ts">
@@ -300,8 +301,7 @@ const {
 </template>
 ```
 
-::::
-::::tabs-item{icon="i-devicon-react" label="React"}
+#react
 
 ```tsx [src/components/Button.tsx]
 import { button } from 'virtual:styleframe';
@@ -329,8 +329,7 @@ export function Button({
 }
 ```
 
-::::
-:::
+::
 
 #### See it in action
 
@@ -396,8 +395,9 @@ export default s;
 
 Drop a `Button` inside the footer to combine recipes. Layout is handled with utility classes from `useUtilitiesPreset`. No extra CSS file required.
 
-:::tabs
-::::tabs-item{icon="i-devicon-vuejs" label="Vue"}
+::framework-switcher
+
+#vue
 
 ```vue [src/components/ProfileCard.vue]
 <script setup lang="ts">
@@ -421,8 +421,7 @@ import Button from './Button.vue';
 </template>
 ```
 
-::::
-::::tabs-item{icon="i-devicon-react" label="React"}
+#react
 
 ```tsx [src/components/ProfileCard.tsx]
 import { card, cardHeader, cardBody, cardFooter } from 'virtual:styleframe';
@@ -446,8 +445,7 @@ export function ProfileCard() {
 }
 ```
 
-::::
-:::
+::
 
 #### See it in action
 

--- a/apps/docs/content/docs/01.getting-started/03.guides/02.theme-switcher.md
+++ b/apps/docs/content/docs/01.getting-started/03.guides/02.theme-switcher.md
@@ -82,67 +82,11 @@ When you change the `data-theme` attribute, all CSS variables are updated automa
 
 ## Implementation
 
-To switch themes dynamically, update the `data-theme` attribute on the `<html>` element using JavaScript. Below are framework-specific implementations that include localStorage persistence and type safety.
+To switch themes dynamically, update the `data-theme` attribute on the `<html>` element using JavaScript. Use the framework selector in the sidebar to switch between the Vue, React, and plain TypeScript implementations &mdash; each includes localStorage persistence and type safety.
 
-::tabs
-:::tabs-item{icon="i-devicon-react" label="React"}
+::framework-switcher
 
-```ts
-import { useState, useEffect, useCallback } from 'react';
-
-type Theme = 'light' | 'dark';
-
-export const useTheme = () => {
-    const [theme, setThemeState] = useState<Theme>('light');
-
-    const setTheme = useCallback((newTheme: Theme) => {
-        setThemeState(newTheme);
-
-        if (typeof window !== 'undefined') {
-            document.documentElement.setAttribute('data-theme', newTheme);
-            localStorage.setItem('theme', newTheme);
-        }
-    }, []);
-
-    const toggleTheme = useCallback(() => {
-        setTheme(theme === 'dark' ? 'light' : 'dark');
-    }, [theme, setTheme]);
-
-    useEffect(() => {
-        if (typeof window !== 'undefined') {
-            const saved = localStorage.getItem('theme') as Theme;
-            if (saved && (saved === 'light' || saved === 'dark')) {
-                setTheme(saved);
-            }
-        }
-    }, [setTheme]);
-
-    return {
-        theme, 
-        setTheme,
-        toggleTheme
-    } as const; 
-};
-```
-
-**Usage:**
-
-```ts
-import { useTheme } from './hooks/useTheme';
-
-function ThemeSwitcher() {
-    const { theme, toggleTheme } = useTheme();
-    
-    return (
-        <button onClick={toggleTheme}>
-            {theme === 'dark' ? '☀️ Light' : '🌙 Dark'}
-        </button>
-    );
-}
-```
-
-:::
-:::tabs-item{icon="i-devicon-vuejs" label="Vue"}
+#vue
 
 ```ts
 import { ref, onMounted, readonly } from 'vue';
@@ -198,8 +142,63 @@ const { theme, toggleTheme } = useTheme();
 </template>
 ```
 
-:::
-:::tabs-item{icon="i-devicon-typescript" label="TypeScript"}
+#react
+
+```ts
+import { useState, useEffect, useCallback } from 'react';
+
+type Theme = 'light' | 'dark';
+
+export const useTheme = () => {
+    const [theme, setThemeState] = useState<Theme>('light');
+
+    const setTheme = useCallback((newTheme: Theme) => {
+        setThemeState(newTheme);
+
+        if (typeof window !== 'undefined') {
+            document.documentElement.setAttribute('data-theme', newTheme);
+            localStorage.setItem('theme', newTheme);
+        }
+    }, []);
+
+    const toggleTheme = useCallback(() => {
+        setTheme(theme === 'dark' ? 'light' : 'dark');
+    }, [theme, setTheme]);
+
+    useEffect(() => {
+        if (typeof window !== 'undefined') {
+            const saved = localStorage.getItem('theme') as Theme;
+            if (saved && (saved === 'light' || saved === 'dark')) {
+                setTheme(saved);
+            }
+        }
+    }, [setTheme]);
+
+    return {
+        theme, 
+        setTheme,
+        toggleTheme
+    } as const; 
+};
+```
+
+**Usage:**
+
+```ts
+import { useTheme } from './hooks/useTheme';
+
+function ThemeSwitcher() {
+    const { theme, toggleTheme } = useTheme();
+    
+    return (
+        <button onClick={toggleTheme}>
+            {theme === 'dark' ? '☀️ Light' : '🌙 Dark'}
+        </button>
+    );
+}
+```
+
+#other
 
 ```ts
 type Theme = 'light' | 'dark';
@@ -250,7 +249,6 @@ button?.addEventListener('click', () => {
 });
 ```
 
-:::
 ::
 
 ::tip

--- a/apps/docs/content/docs/05.components/02.composables/01.badge.md
+++ b/apps/docs/content/docs/05.components/02.composables/01.badge.md
@@ -58,8 +58,29 @@ export default s;
 
 Import the `badge` runtime function from the virtual module and pass variant props to compute class names:
 
-:::tabs
-::::tabs-item{icon="i-devicon-react" label="React"}
+::framework-switcher
+
+#vue
+
+```vue [src/components/Badge.vue]
+<script setup lang="ts">
+import { badge } from "virtual:styleframe";
+
+const { color = "neutral", variant = "solid", size = "sm" } = defineProps<{
+	color?: "primary" | "secondary" | "success" | "info" | "warning" | "error" | "light" | "dark" | "neutral";
+	variant?: "solid" | "outline" | "soft" | "subtle";
+	size?: "xs" | "sm" | "md" | "lg" | "xl";
+}>();
+</script>
+
+<template>
+	<span :class="badge({ color, variant, size })">
+		<slot />
+	</span>
+</template>
+```
+
+#react
 
 ```ts [src/components/Badge.tsx]
 import { badge } from "virtual:styleframe";
@@ -83,29 +104,22 @@ export function Badge({
 }
 ```
 
-::::
-::::tabs-item{icon="i-devicon-vuejs" label="Vue"}
+#other
 
-```vue [src/components/Badge.vue]
-<script setup lang="ts">
+The `badge()` runtime returns a class string. Apply it however your framework binds classes:
+
+```ts [src/components/badge.ts]
 import { badge } from "virtual:styleframe";
 
-const { color = "neutral", variant = "solid", size = "sm" } = defineProps<{
-	color?: "primary" | "secondary" | "success" | "info" | "warning" | "error" | "light" | "dark" | "neutral";
-	variant?: "solid" | "outline" | "soft" | "subtle";
-	size?: "xs" | "sm" | "md" | "lg" | "xl";
-}>();
-</script>
-
-<template>
-	<span :class="badge({ color, variant, size })">
-		<slot />
-	</span>
-</template>
+const classes = badge({ color: "neutral", variant: "solid", size: "sm" });
+// → "badge _background:neutral _color:white _padding:xs ..."
 ```
 
-::::
-:::
+```html [src/components/badge.html]
+<span class="badge _background:neutral _color:white _padding:xs ...">Status</span>
+```
+
+::
 
 #### See it in action
 

--- a/apps/docs/content/docs/05.components/02.composables/02.button.md
+++ b/apps/docs/content/docs/05.components/02.composables/02.button.md
@@ -58,8 +58,35 @@ export default s;
 
 Import the `button` runtime function from the virtual module and pass variant props to compute class names:
 
-:::tabs
-::::tabs-item{icon="i-devicon-react" label="React"}
+::framework-switcher
+
+#vue
+
+```vue [src/components/Button.vue]
+<script setup lang="ts">
+import { button } from "virtual:styleframe";
+
+const {
+	color = "neutral",
+	variant = "solid",
+	size = "md",
+	disabled = false,
+} = defineProps<{
+	color?: "primary" | "secondary" | "success" | "info" | "warning" | "error" | "light" | "dark" | "neutral";
+	variant?: "solid" | "outline" | "soft" | "subtle" | "ghost" | "link";
+	size?: "xs" | "sm" | "md" | "lg" | "xl";
+	disabled?: boolean;
+}>();
+</script>
+
+<template>
+	<button :class="button({ color, variant, size })" :disabled="disabled">
+		<slot />
+	</button>
+</template>
+```
+
+#react
 
 ```ts [src/components/Button.tsx]
 import { button } from "virtual:styleframe";
@@ -89,35 +116,22 @@ export function Button({
 }
 ```
 
-::::
-::::tabs-item{icon="i-devicon-vuejs" label="Vue"}
+#other
 
-```vue [src/components/Button.vue]
-<script setup lang="ts">
+The `button()` runtime returns a class string. Apply it however your framework binds classes:
+
+```ts [src/components/button.ts]
 import { button } from "virtual:styleframe";
 
-const {
-	color = "neutral",
-	variant = "solid",
-	size = "md",
-	disabled = false,
-} = defineProps<{
-	color?: "primary" | "secondary" | "success" | "info" | "warning" | "error" | "light" | "dark" | "neutral";
-	variant?: "solid" | "outline" | "soft" | "subtle" | "ghost" | "link";
-	size?: "xs" | "sm" | "md" | "lg" | "xl";
-	disabled?: boolean;
-}>();
-</script>
-
-<template>
-	<button :class="button({ color, variant, size })" :disabled="disabled">
-		<slot />
-	</button>
-</template>
+const classes = button({ color: "neutral", variant: "solid", size: "md" });
+// → "button _border-width:thin _cursor:pointer _background:neutral ..."
 ```
 
-::::
-:::
+```html [src/components/button.html]
+<button class="button _border-width:thin _cursor:pointer _background:neutral ...">Click me</button>
+```
+
+::
 
 #### See it in action
 

--- a/apps/docs/content/docs/05.components/02.composables/03.button-group.md
+++ b/apps/docs/content/docs/05.components/02.composables/03.button-group.md
@@ -58,35 +58,9 @@ export default s;
 
 Import the `buttonGroup` runtime function from the virtual module and pass variant props to compute class names:
 
-:::tabs
-::::tabs-item{icon="i-devicon-react" label="React"}
+::framework-switcher
 
-```ts [src/components/ButtonGroup.tsx]
-import { buttonGroup } from "virtual:styleframe";
-
-interface ButtonGroupProps {
-	orientation?: "horizontal" | "vertical";
-	block?: boolean;
-	children?: React.ReactNode;
-}
-
-export function ButtonGroup({
-	orientation = "horizontal",
-	block = false,
-	children,
-}: ButtonGroupProps) {
-	const classes = buttonGroup({ orientation, block: block ? "true" : "false" });
-
-	return (
-		<div className={classes} role="group">
-			{children}
-		</div>
-	);
-}
-```
-
-::::
-::::tabs-item{icon="i-devicon-vuejs" label="Vue"}
+#vue
 
 ```vue [src/components/ButtonGroup.vue]
 <script setup lang="ts">
@@ -114,8 +88,51 @@ const props = withDefaults(
 </template>
 ```
 
-::::
-:::
+#react
+
+```ts [src/components/ButtonGroup.tsx]
+import { buttonGroup } from "virtual:styleframe";
+
+interface ButtonGroupProps {
+	orientation?: "horizontal" | "vertical";
+	block?: boolean;
+	children?: React.ReactNode;
+}
+
+export function ButtonGroup({
+	orientation = "horizontal",
+	block = false,
+	children,
+}: ButtonGroupProps) {
+	const classes = buttonGroup({ orientation, block: block ? "true" : "false" });
+
+	return (
+		<div className={classes} role="group">
+			{children}
+		</div>
+	);
+}
+```
+
+#other
+
+The `buttonGroup()` runtime returns a class string. Apply it however your framework binds classes:
+
+```ts [src/components/button-group.ts]
+import { buttonGroup } from "virtual:styleframe";
+
+const classes = buttonGroup({ orientation: "horizontal", block: "false" });
+// → "button-group _display:inline-flex _flex-direction:row ..."
+```
+
+```html [src/components/button-group.html]
+<div class="button-group _display:inline-flex _flex-direction:row ..." role="group">
+	<button class="button ...">One</button>
+	<button class="button ...">Two</button>
+</div>
+```
+
+::
 
 #### See it in action
 

--- a/apps/docs/content/docs/05.components/02.composables/04.callout.md
+++ b/apps/docs/content/docs/05.components/02.composables/04.callout.md
@@ -59,8 +59,53 @@ export default s;
 
 Import the `callout` runtime function from the virtual module and pass variant props to compute class names:
 
-:::tabs
-::::tabs-item{icon="i-devicon-react" label="React"}
+::framework-switcher
+
+#vue
+
+```vue [src/components/Callout.vue]
+<script setup lang="ts">
+import { callout } from "virtual:styleframe";
+
+const {
+	color = "neutral",
+	variant = "subtle",
+	size = "md",
+	orientation = "horizontal",
+	title,
+	description,
+	dismissible = false,
+} = defineProps<{
+	color?: "primary" | "secondary" | "success" | "info" | "warning" | "error" | "light" | "dark" | "neutral";
+	variant?: "solid" | "outline" | "soft" | "subtle";
+	size?: "sm" | "md" | "lg";
+	orientation?: "horizontal" | "vertical";
+	title?: string;
+	description?: string;
+	dismissible?: boolean;
+}>();
+
+const emit = defineEmits<{
+	dismiss: [];
+}>();
+</script>
+
+<template>
+	<div :class="callout({ color, variant, size, orientation })" role="alert">
+		<slot name="icon" />
+		<div>
+			<strong v-if="title">{{ title }}</strong>
+			<p v-if="description">{{ description }}</p>
+			<slot />
+		</div>
+		<button v-if="dismissible" aria-label="Dismiss" @click="emit('dismiss')">
+			&times;
+		</button>
+	</div>
+</template>
+```
+
+#react
 
 ```ts [src/components/Callout.tsx]
 import { callout } from "virtual:styleframe";
@@ -110,53 +155,29 @@ export function Callout({
 }
 ```
 
-::::
-::::tabs-item{icon="i-devicon-vuejs" label="Vue"}
+#other
 
-```vue [src/components/Callout.vue]
-<script setup lang="ts">
+The `callout()` runtime returns a class string. Apply it however your framework binds classes:
+
+```ts [src/components/callout.ts]
 import { callout } from "virtual:styleframe";
 
-const {
-	color = "neutral",
-	variant = "subtle",
-	size = "md",
-	orientation = "horizontal",
-	title,
-	description,
-	dismissible = false,
-} = defineProps<{
-	color?: "primary" | "secondary" | "success" | "info" | "warning" | "error" | "light" | "dark" | "neutral";
-	variant?: "solid" | "outline" | "soft" | "subtle";
-	size?: "sm" | "md" | "lg";
-	orientation?: "horizontal" | "vertical";
-	title?: string;
-	description?: string;
-	dismissible?: boolean;
-}>();
-
-const emit = defineEmits<{
-	dismiss: [];
-}>();
-</script>
-
-<template>
-	<div :class="callout({ color, variant, size, orientation })" role="alert">
-		<slot name="icon" />
-		<div>
-			<strong v-if="title">{{ title }}</strong>
-			<p v-if="description">{{ description }}</p>
-			<slot />
-		</div>
-		<button v-if="dismissible" aria-label="Dismiss" @click="emit('dismiss')">
-			&times;
-		</button>
-	</div>
-</template>
+const classes = callout({
+	color: "neutral",
+	variant: "subtle",
+	size: "md",
+	orientation: "horizontal",
+});
+// → "callout _display:flex _padding:md _border-width:thin ..."
 ```
 
-::::
-:::
+```html [src/components/callout.html]
+<div class="callout _display:flex _padding:md _border-width:thin ..." role="alert">
+	<strong>Heads up:</strong> Inline notice.
+</div>
+```
+
+::
 
 #### See it in action
 

--- a/apps/docs/content/docs/05.components/02.composables/05.card.md
+++ b/apps/docs/content/docs/05.components/02.composables/05.card.md
@@ -67,8 +67,41 @@ export default s;
 
 Import the `card`, `cardHeader`, `cardBody`, and `cardFooter` runtime functions from the virtual module and pass variant props to compute class names:
 
-:::tabs
-::::tabs-item{icon="i-devicon-react" label="React"}
+::framework-switcher
+
+#vue
+
+```vue [src/components/Card.vue]
+<script setup lang="ts">
+import { card, cardHeader, cardBody, cardFooter } from "virtual:styleframe";
+
+const {
+	color = "neutral",
+	variant = "solid",
+	size = "md",
+} = defineProps<{
+	color?: "light" | "dark" | "neutral";
+	variant?: "solid" | "soft" | "subtle";
+	size?: "sm" | "md" | "lg";
+}>();
+</script>
+
+<template>
+	<div :class="card({ color, variant, size })">
+		<div :class="cardHeader({ color, variant, size })">
+			<slot name="header" />
+		</div>
+		<div :class="cardBody({ size })">
+			<slot />
+		</div>
+		<div :class="cardFooter({ color, variant, size })">
+			<slot name="footer" />
+		</div>
+	</div>
+</template>
+```
+
+#react
 
 ```ts [src/components/Card.tsx]
 import { card, cardHeader, cardBody, cardFooter } from "virtual:styleframe";
@@ -113,41 +146,34 @@ export function Card({
 }
 ```
 
-::::
-::::tabs-item{icon="i-devicon-vuejs" label="Vue"}
+#other
 
-```vue [src/components/Card.vue]
-<script setup lang="ts">
+The `card()`, `cardHeader()`, `cardBody()`, and `cardFooter()` runtimes each return a class string. Apply them however your framework binds classes:
+
+```ts [src/components/card.ts]
 import { card, cardHeader, cardBody, cardFooter } from "virtual:styleframe";
 
-const {
-	color = "neutral",
-	variant = "solid",
-	size = "md",
-} = defineProps<{
-	color?: "light" | "dark" | "neutral";
-	variant?: "solid" | "soft" | "subtle";
-	size?: "sm" | "md" | "lg";
-}>();
-</script>
+const variants = { color: "neutral", variant: "solid", size: "md" } as const;
 
-<template>
-	<div :class="card({ color, variant, size })">
-		<div :class="cardHeader({ color, variant, size })">
-			<slot name="header" />
-		</div>
-		<div :class="cardBody({ size })">
-			<slot />
-		</div>
-		<div :class="cardFooter({ color, variant, size })">
-			<slot name="footer" />
-		</div>
-	</div>
-</template>
+const containerClasses = card(variants);
+// → "card _background:neutral _border-radius:md ..."
+const headerClasses = cardHeader(variants);
+// → "card-header _padding:md _border-bottom-width:thin ..."
+const bodyClasses = cardBody({ size: "md" });
+// → "card-body _padding:md ..."
+const footerClasses = cardFooter(variants);
+// → "card-footer _padding:md _border-top-width:thin ..."
 ```
 
-::::
-:::
+```html [src/components/card.html]
+<div class="card _background:neutral _border-radius:md ...">
+	<div class="card-header _padding:md _border-bottom-width:thin ...">Header</div>
+	<div class="card-body _padding:md ...">Body content</div>
+	<div class="card-footer _padding:md _border-top-width:thin ...">Footer</div>
+</div>
+```
+
+::
 
 #### See it in action
 

--- a/apps/docs/content/docs/05.components/02.composables/06.nav.md
+++ b/apps/docs/content/docs/05.components/02.composables/06.nav.md
@@ -60,8 +60,64 @@ export default s;
 
 Import the `nav` and `navItem` runtime functions from the virtual module and pass variant props to compute class names:
 
-:::tabs
-::::tabs-item{icon="i-devicon-react" label="React"}
+::framework-switcher
+
+#vue
+
+```vue [src/components/Nav.vue]
+<script setup lang="ts">
+import { nav } from "virtual:styleframe";
+
+const {
+	orientation = "horizontal",
+	size = "md",
+} = defineProps<{
+	orientation?: "horizontal" | "vertical";
+	size?: "sm" | "md" | "lg";
+}>();
+</script>
+
+<template>
+	<nav :class="nav({ orientation, size })">
+		<slot />
+	</nav>
+</template>
+```
+
+```vue [src/components/NavItem.vue]
+<script setup lang="ts">
+import { navItem } from "virtual:styleframe";
+
+const {
+	color = "neutral",
+	variant = "ghost",
+	size = "md",
+	active = false,
+	disabled = false,
+	href,
+} = defineProps<{
+	color?: "light" | "dark" | "neutral";
+	variant?: "ghost" | "link";
+	size?: "sm" | "md" | "lg";
+	active?: boolean;
+	disabled?: boolean;
+	href?: string;
+}>();
+</script>
+
+<template>
+	<a
+		:href="href"
+		:class="navItem({ color, variant, size, active: active ? 'true' : 'false', disabled: disabled ? 'true' : 'false' })"
+		:aria-disabled="disabled || undefined"
+		:tabindex="disabled ? -1 : undefined"
+	>
+		<slot />
+	</a>
+</template>
+```
+
+#react
 
 ```ts [src/components/Nav.tsx]
 import { nav, navItem } from "virtual:styleframe";
@@ -122,64 +178,33 @@ export function NavItem({
 }
 ```
 
-::::
-::::tabs-item{icon="i-devicon-vuejs" label="Vue"}
+#other
 
-```vue [src/components/Nav.vue]
-<script setup lang="ts">
-import { nav } from "virtual:styleframe";
+The `nav()` and `navItem()` runtimes each return a class string. Apply them however your framework binds classes:
 
-const {
-	orientation = "horizontal",
-	size = "md",
-} = defineProps<{
-	orientation?: "horizontal" | "vertical";
-	size?: "sm" | "md" | "lg";
-}>();
-</script>
+```ts [src/components/nav.ts]
+import { nav, navItem } from "virtual:styleframe";
 
-<template>
-	<nav :class="nav({ orientation, size })">
-		<slot />
-	</nav>
-</template>
+const navClasses = nav({ orientation: "horizontal", size: "md" });
+// → "nav _display:flex _flex-direction:row ..."
+const itemClasses = navItem({
+	color: "neutral",
+	variant: "ghost",
+	size: "md",
+	active: "false",
+	disabled: "false",
+});
+// → "nav-item _padding:sm _color:text ..."
 ```
 
-```vue [src/components/NavItem.vue]
-<script setup lang="ts">
-import { navItem } from "virtual:styleframe";
-
-const {
-	color = "neutral",
-	variant = "ghost",
-	size = "md",
-	active = false,
-	disabled = false,
-	href,
-} = defineProps<{
-	color?: "light" | "dark" | "neutral";
-	variant?: "ghost" | "link";
-	size?: "sm" | "md" | "lg";
-	active?: boolean;
-	disabled?: boolean;
-	href?: string;
-}>();
-</script>
-
-<template>
-	<a
-		:href="href"
-		:class="navItem({ color, variant, size, active: active ? 'true' : 'false', disabled: disabled ? 'true' : 'false' })"
-		:aria-disabled="disabled || undefined"
-		:tabindex="disabled ? -1 : undefined"
-	>
-		<slot />
-	</a>
-</template>
+```html [src/components/nav.html]
+<nav class="nav _display:flex _flex-direction:row ..." aria-label="Main navigation">
+	<a href="/" class="nav-item _padding:sm ...">Home</a>
+	<a href="/about" class="nav-item _padding:sm ..." aria-current="page">About</a>
+</nav>
 ```
 
-::::
-:::
+::
 
 #### See it in action
 

--- a/apps/docs/content/docs/05.components/02.composables/07.modal.md
+++ b/apps/docs/content/docs/05.components/02.composables/07.modal.md
@@ -69,8 +69,54 @@ export default s;
 
 Import the `modal`, `modalHeader`, `modalBody`, `modalFooter`, and `modalOverlay` runtime functions from the virtual module and pass variant props to compute class names:
 
-:::tabs
-::::tabs-item{icon="i-devicon-react" label="React"}
+::framework-switcher
+
+#vue
+
+```vue [src/components/Modal.vue]
+<script setup lang="ts">
+import { modal, modalHeader, modalBody, modalFooter, modalOverlay } from "virtual:styleframe";
+
+const {
+	color = "neutral",
+	variant = "solid",
+	size = "md",
+} = defineProps<{
+	color?: "light" | "dark" | "neutral";
+	variant?: "solid" | "soft" | "subtle";
+	size?: "sm" | "md" | "lg";
+}>();
+
+const emit = defineEmits<{
+	close: [];
+}>();
+</script>
+
+<template>
+	<div
+		:class="modalOverlay()"
+		@click.self="emit('close')"
+	>
+		<div
+			:class="modal({ color, variant, size })"
+			role="dialog"
+			aria-modal="true"
+		>
+			<div :class="modalHeader({ color, variant, size })">
+				<slot name="header" />
+			</div>
+			<div :class="modalBody({ size })">
+				<slot />
+			</div>
+			<div :class="modalFooter({ color, variant, size })">
+				<slot name="footer" />
+			</div>
+		</div>
+	</div>
+</template>
+```
+
+#react
 
 ```ts [src/components/Modal.tsx]
 import { modal, modalHeader, modalBody, modalFooter, modalOverlay } from "virtual:styleframe";
@@ -130,54 +176,49 @@ export function Modal({
 }
 ```
 
-::::
-::::tabs-item{icon="i-devicon-vuejs" label="Vue"}
+#other
 
-```vue [src/components/Modal.vue]
-<script setup lang="ts">
-import { modal, modalHeader, modalBody, modalFooter, modalOverlay } from "virtual:styleframe";
+The `modal()`, `modalHeader()`, `modalBody()`, `modalFooter()`, and `modalOverlay()` runtimes each return a class string. Apply them however your framework binds classes:
 
-const {
-	color = "neutral",
-	variant = "solid",
-	size = "md",
-} = defineProps<{
-	color?: "light" | "dark" | "neutral";
-	variant?: "solid" | "soft" | "subtle";
-	size?: "sm" | "md" | "lg";
-}>();
+```ts [src/components/modal.ts]
+import {
+	modal,
+	modalHeader,
+	modalBody,
+	modalFooter,
+	modalOverlay,
+} from "virtual:styleframe";
 
-const emit = defineEmits<{
-	close: [];
-}>();
-</script>
+const variants = { color: "neutral", variant: "solid", size: "md" } as const;
 
-<template>
-	<div
-		:class="modalOverlay()"
-		@click.self="emit('close')"
-	>
-		<div
-			:class="modal({ color, variant, size })"
-			role="dialog"
-			aria-modal="true"
-		>
-			<div :class="modalHeader({ color, variant, size })">
-				<slot name="header" />
-			</div>
-			<div :class="modalBody({ size })">
-				<slot />
-			</div>
-			<div :class="modalFooter({ color, variant, size })">
-				<slot name="footer" />
-			</div>
-		</div>
-	</div>
-</template>
+const overlayClasses = modalOverlay();
+// → "modal-overlay _position:fixed _inset:0 ..."
+const containerClasses = modal(variants);
+// → "modal _background:neutral _border-radius:md ..."
+const headerClasses = modalHeader(variants);
+// → "modal-header _padding:md _border-bottom-width:thin ..."
+const bodyClasses = modalBody({ size: "md" });
+// → "modal-body _padding:md ..."
+const footerClasses = modalFooter(variants);
+// → "modal-footer _padding:md _justify-content:flex-end ..."
 ```
 
-::::
-:::
+```html [src/components/modal.html]
+<div class="modal-overlay _position:fixed _inset:0 ...">
+	<div class="modal _background:neutral _border-radius:md ..." role="dialog" aria-modal="true" aria-labelledby="modal-title">
+		<div class="modal-header _padding:md _border-bottom-width:thin ...">
+			<h2 id="modal-title">Confirm action</h2>
+		</div>
+		<div class="modal-body _padding:md ...">Are you sure?</div>
+		<div class="modal-footer _padding:md _justify-content:flex-end ...">
+			<button class="button ...">Cancel</button>
+			<button class="button ...">Confirm</button>
+		</div>
+	</div>
+</div>
+```
+
+::
 
 #### See it in action
 

--- a/apps/docs/content/docs/05.components/02.composables/08.skeleton.md
+++ b/apps/docs/content/docs/05.components/02.composables/08.skeleton.md
@@ -60,8 +60,32 @@ export default s;
 
 Import the `skeleton` runtime function from the virtual module and pass variant props to compute class names:
 
-:::tabs
-::::tabs-item{icon="i-devicon-react" label="React"}
+::framework-switcher
+
+#vue
+
+```vue [src/components/Skeleton.vue]
+<script setup lang="ts">
+import { skeleton } from "virtual:styleframe";
+
+const {
+	size = "md",
+	rounded = false,
+} = defineProps<{
+	size?: "xs" | "sm" | "md" | "lg" | "xl";
+	rounded?: boolean;
+}>();
+</script>
+
+<template>
+	<div
+		:class="skeleton({ size, rounded: String(rounded) })"
+		aria-hidden="true"
+	/>
+</template>
+```
+
+#react
 
 ```ts [src/components/Skeleton.tsx]
 import { skeleton } from "virtual:styleframe";
@@ -86,32 +110,22 @@ export function Skeleton({
 }
 ```
 
-::::
-::::tabs-item{icon="i-devicon-vuejs" label="Vue"}
+#other
 
-```vue [src/components/Skeleton.vue]
-<script setup lang="ts">
+The `skeleton()` runtime returns a class string. Apply it however your framework binds classes:
+
+```ts [src/components/skeleton.ts]
 import { skeleton } from "virtual:styleframe";
 
-const {
-	size = "md",
-	rounded = false,
-} = defineProps<{
-	size?: "xs" | "sm" | "md" | "lg" | "xl";
-	rounded?: boolean;
-}>();
-</script>
-
-<template>
-	<div
-		:class="skeleton({ size, rounded: String(rounded) })"
-		aria-hidden="true"
-	/>
-</template>
+const classes = skeleton({ size: "md", rounded: "false" });
+// → "skeleton _background:gray-200 _border-radius:md _animation:pulse ..."
 ```
 
-::::
-:::
+```html [src/components/skeleton.html]
+<div class="skeleton _background:gray-200 _border-radius:md _animation:pulse ..." aria-hidden="true"></div>
+```
+
+::
 
 #### See it in action
 

--- a/apps/docs/content/docs/05.components/02.composables/08.tooltip.md
+++ b/apps/docs/content/docs/05.components/02.composables/08.tooltip.md
@@ -63,43 +63,9 @@ export default s;
 
 Import the `tooltip` and `tooltipArrow` runtime functions from the virtual module and pass variant props to compute class names:
 
-:::tabs
-::::tabs-item{icon="i-devicon-react" label="React"}
+::framework-switcher
 
-```ts [src/components/Tooltip.tsx]
-import { tooltip, tooltipArrow } from "virtual:styleframe";
-
-interface TooltipProps {
-	color?: "light" | "dark" | "neutral";
-	variant?: "solid" | "soft" | "subtle";
-	size?: "sm" | "md" | "lg";
-	label?: string;
-	children?: React.ReactNode;
-}
-
-export function Tooltip({
-	color = "dark",
-	variant = "solid",
-	size = "md",
-	label,
-	children,
-}: TooltipProps) {
-	return (
-		<div className="tooltip-wrapper">
-			<span
-				className={tooltip({ color, variant, size })}
-				role="tooltip"
-			>
-				{children ?? label}
-			</span>
-			<span className={`${tooltipArrow({ color, variant })} tooltip-arrow-position`} />
-		</div>
-	);
-}
-```
-
-::::
-::::tabs-item{icon="i-devicon-vuejs" label="Vue"}
+#vue
 
 ```vue [src/components/Tooltip.vue]
 <script setup lang="ts">
@@ -142,8 +108,63 @@ const arrowClasses = computed(() =>
 </template>
 ```
 
-::::
-:::
+#react
+
+```ts [src/components/Tooltip.tsx]
+import { tooltip, tooltipArrow } from "virtual:styleframe";
+
+interface TooltipProps {
+	color?: "light" | "dark" | "neutral";
+	variant?: "solid" | "soft" | "subtle";
+	size?: "sm" | "md" | "lg";
+	label?: string;
+	children?: React.ReactNode;
+}
+
+export function Tooltip({
+	color = "dark",
+	variant = "solid",
+	size = "md",
+	label,
+	children,
+}: TooltipProps) {
+	return (
+		<div className="tooltip-wrapper">
+			<span
+				className={tooltip({ color, variant, size })}
+				role="tooltip"
+			>
+				{children ?? label}
+			</span>
+			<span className={`${tooltipArrow({ color, variant })} tooltip-arrow-position`} />
+		</div>
+	);
+}
+```
+
+#other
+
+The `tooltip()` and `tooltipArrow()` runtimes each return a class string. Apply them however your framework binds classes:
+
+```ts [src/components/tooltip.ts]
+import { tooltip, tooltipArrow } from "virtual:styleframe";
+
+const contentClasses = tooltip({ color: "dark", variant: "solid", size: "md" });
+// → "tooltip _background:dark _color:white _padding:sm ..."
+const arrowClasses = tooltipArrow({ color: "dark", variant: "solid" });
+// → "tooltip-arrow _border-color:dark ..."
+```
+
+```html [src/components/tooltip.html]
+<div class="tooltip-wrapper">
+	<span class="tooltip _background:dark _color:white ..." role="tooltip" id="tooltip-1">
+		Helpful description
+	</span>
+	<span class="tooltip-arrow tooltip-arrow-position"></span>
+</div>
+```
+
+::
 
 #### See it in action
 

--- a/apps/docs/content/docs/05.components/02.composables/09.placeholder.md
+++ b/apps/docs/content/docs/05.components/02.composables/09.placeholder.md
@@ -59,8 +59,25 @@ export default s;
 
 Import the `placeholder` runtime function from the virtual module and call it with no arguments to compute the class name:
 
-:::tabs
-::::tabs-item{icon="i-devicon-react" label="React"}
+::framework-switcher
+
+#vue
+
+```vue [src/components/Placeholder.vue]
+<script setup lang="ts">
+import { placeholder } from "virtual:styleframe";
+
+const classes = placeholder();
+</script>
+
+<template>
+	<div :class="classes">
+		<slot />
+	</div>
+</template>
+```
+
+#react
 
 ```ts [src/components/Placeholder.tsx]
 import { placeholder } from "virtual:styleframe";
@@ -79,25 +96,22 @@ export function Placeholder({ children, className }: PlaceholderProps) {
 }
 ```
 
-::::
-::::tabs-item{icon="i-devicon-vuejs" label="Vue"}
+#other
 
-```vue [src/components/Placeholder.vue]
-<script setup lang="ts">
+The `placeholder()` runtime returns a class string. Apply it however your framework binds classes:
+
+```ts [src/components/placeholder.ts]
 import { placeholder } from "virtual:styleframe";
 
 const classes = placeholder();
-</script>
-
-<template>
-	<div :class="classes">
-		<slot />
-	</div>
-</template>
+// → "placeholder _display:flex _border-style:dashed ..."
 ```
 
-::::
-:::
+```html [src/components/placeholder.html]
+<div class="placeholder _display:flex _border-style:dashed ...">Hero image</div>
+```
+
+::
 
 #### See it in action
 

--- a/apps/docs/content/docs/05.components/02.composables/10.progress.md
+++ b/apps/docs/content/docs/05.components/02.composables/10.progress.md
@@ -62,61 +62,9 @@ export default s;
 
 Import the `progress` and `progressBar` runtime functions from the virtual module and pass variant props to compute class names:
 
-:::tabs
-::::tabs-item{icon="i-devicon-react" label="React"}
+::framework-switcher
 
-```ts [src/components/Progress.tsx]
-import { progress, progressBar } from "virtual:styleframe";
-
-interface ProgressProps {
-	color?: "primary" | "secondary" | "success" | "info" | "warning" | "error" | "light" | "dark" | "neutral";
-	trackColor?: "light" | "dark" | "neutral";
-	size?: "xs" | "sm" | "md" | "lg" | "xl";
-	orientation?: "horizontal" | "vertical";
-	inverted?: boolean;
-	animation?: "none" | "carousel" | "carousel-inverse" | "swing" | "elastic";
-	value?: number | null;
-}
-
-export function Progress({
-	color = "primary",
-	trackColor = "neutral",
-	size = "md",
-	orientation = "horizontal",
-	inverted = false,
-	animation = "none",
-	value = 0,
-}: ProgressProps) {
-	const isIndeterminate = value == null;
-	const clampedValue = isIndeterminate ? 50 : Math.min(100, Math.max(0, value));
-	const fillProp = orientation === "vertical" ? "height" : "width";
-
-	return (
-		<div
-			className={progress({ color: trackColor, size, orientation })}
-			role="progressbar"
-			aria-valuenow={value ?? undefined}
-			aria-valuemin={0}
-			aria-valuemax={100}
-			aria-orientation={orientation}
-		>
-			<div
-				className={progressBar({
-					color,
-					size,
-					orientation,
-					inverted: String(inverted),
-					animation: isIndeterminate && animation !== "none" ? animation : "none",
-				})}
-				style={{ [fillProp]: `${clampedValue}%` }}
-			/>
-		</div>
-	);
-}
-```
-
-::::
-::::tabs-item{icon="i-devicon-vuejs" label="Vue"}
+#vue
 
 ```vue [src/components/Progress.vue]
 <script setup lang="ts">
@@ -173,8 +121,94 @@ const fillStyle = computed(() => {
 </template>
 ```
 
-::::
-:::
+#react
+
+```ts [src/components/Progress.tsx]
+import { progress, progressBar } from "virtual:styleframe";
+
+interface ProgressProps {
+	color?: "primary" | "secondary" | "success" | "info" | "warning" | "error" | "light" | "dark" | "neutral";
+	trackColor?: "light" | "dark" | "neutral";
+	size?: "xs" | "sm" | "md" | "lg" | "xl";
+	orientation?: "horizontal" | "vertical";
+	inverted?: boolean;
+	animation?: "none" | "carousel" | "carousel-inverse" | "swing" | "elastic";
+	value?: number | null;
+}
+
+export function Progress({
+	color = "primary",
+	trackColor = "neutral",
+	size = "md",
+	orientation = "horizontal",
+	inverted = false,
+	animation = "none",
+	value = 0,
+}: ProgressProps) {
+	const isIndeterminate = value == null;
+	const clampedValue = isIndeterminate ? 50 : Math.min(100, Math.max(0, value));
+	const fillProp = orientation === "vertical" ? "height" : "width";
+
+	return (
+		<div
+			className={progress({ color: trackColor, size, orientation })}
+			role="progressbar"
+			aria-valuenow={value ?? undefined}
+			aria-valuemin={0}
+			aria-valuemax={100}
+			aria-orientation={orientation}
+		>
+			<div
+				className={progressBar({
+					color,
+					size,
+					orientation,
+					inverted: String(inverted),
+					animation: isIndeterminate && animation !== "none" ? animation : "none",
+				})}
+				style={{ [fillProp]: `${clampedValue}%` }}
+			/>
+		</div>
+	);
+}
+```
+
+#other
+
+The `progress()` and `progressBar()` runtimes each return a class string. Apply them however your framework binds classes:
+
+```ts [src/components/progress.ts]
+import { progress, progressBar } from "virtual:styleframe";
+
+const trackClasses = progress({
+	color: "neutral",
+	size: "md",
+	orientation: "horizontal",
+});
+// → "progress _background:gray-200 _border-radius:md _overflow:hidden ..."
+const barClasses = progressBar({
+	color: "primary",
+	size: "md",
+	orientation: "horizontal",
+	inverted: "false",
+	animation: "none",
+});
+// → "progress-bar _background:primary _height:full ..."
+```
+
+```html [src/components/progress.html]
+<div
+	class="progress _background:gray-200 _border-radius:md ..."
+	role="progressbar"
+	aria-valuenow="65"
+	aria-valuemin="0"
+	aria-valuemax="100"
+>
+	<div class="progress-bar _background:primary ..." style="width: 65%"></div>
+</div>
+```
+
+::
 
 #### See it in action
 

--- a/apps/docs/content/docs/05.components/02.composables/11.popover.md
+++ b/apps/docs/content/docs/05.components/02.composables/11.popover.md
@@ -69,8 +69,50 @@ export default s;
 
 Import the `popover`, `popoverHeader`, `popoverBody`, `popoverFooter`, and `popoverArrow` runtime functions from the virtual module and pass variant props to compute class names:
 
-:::tabs
-::::tabs-item{icon="i-devicon-react" label="React"}
+::framework-switcher
+
+#vue
+
+```vue [src/components/Popover.vue]
+<script setup lang="ts">
+import { computed } from "vue";
+import { popover, popoverHeader, popoverBody, popoverFooter, popoverArrow } from "virtual:styleframe";
+
+const props = withDefaults(
+	defineProps<{
+		color?: "light" | "dark" | "neutral";
+		variant?: "solid" | "soft" | "subtle";
+		size?: "sm" | "md" | "lg";
+	}>(),
+	{},
+);
+
+const classes = computed(() => popover({ color: props.color, variant: props.variant, size: props.size }));
+const headerClasses = computed(() => popoverHeader({ color: props.color, variant: props.variant, size: props.size }));
+const bodyClasses = computed(() => popoverBody({ size: props.size }));
+const footerClasses = computed(() => popoverFooter({ color: props.color, variant: props.variant, size: props.size }));
+const arrowClasses = computed(() => popoverArrow({ color: props.color, variant: props.variant }));
+</script>
+
+<template>
+	<div class="popover-wrapper">
+		<div :class="classes">
+			<div :class="headerClasses">
+				<slot name="header" />
+			</div>
+			<div :class="bodyClasses">
+				<slot />
+			</div>
+			<div :class="footerClasses">
+				<slot name="footer" />
+			</div>
+		</div>
+		<span :class="arrowClasses" />
+	</div>
+</template>
+```
+
+#react
 
 ```ts [src/components/Popover.tsx]
 import { popover, popoverHeader, popoverBody, popoverFooter, popoverArrow } from "virtual:styleframe";
@@ -115,50 +157,45 @@ export function Popover({
 }
 ```
 
-::::
-::::tabs-item{icon="i-devicon-vuejs" label="Vue"}
+#other
 
-```vue [src/components/Popover.vue]
-<script setup lang="ts">
-import { computed } from "vue";
-import { popover, popoverHeader, popoverBody, popoverFooter, popoverArrow } from "virtual:styleframe";
+The popover runtimes each return a class string. Apply them however your framework binds classes:
 
-const props = withDefaults(
-	defineProps<{
-		color?: "light" | "dark" | "neutral";
-		variant?: "solid" | "soft" | "subtle";
-		size?: "sm" | "md" | "lg";
-	}>(),
-	{},
-);
+```ts [src/components/popover.ts]
+import {
+	popover,
+	popoverHeader,
+	popoverBody,
+	popoverFooter,
+	popoverArrow,
+} from "virtual:styleframe";
 
-const classes = computed(() => popover({ color: props.color, variant: props.variant, size: props.size }));
-const headerClasses = computed(() => popoverHeader({ color: props.color, variant: props.variant, size: props.size }));
-const bodyClasses = computed(() => popoverBody({ size: props.size }));
-const footerClasses = computed(() => popoverFooter({ color: props.color, variant: props.variant, size: props.size }));
-const arrowClasses = computed(() => popoverArrow({ color: props.color, variant: props.variant }));
-</script>
+const variants = { color: "neutral", variant: "solid", size: "md" } as const;
 
-<template>
-	<div class="popover-wrapper">
-		<div :class="classes">
-			<div :class="headerClasses">
-				<slot name="header" />
-			</div>
-			<div :class="bodyClasses">
-				<slot />
-			</div>
-			<div :class="footerClasses">
-				<slot name="footer" />
-			</div>
-		</div>
-		<span :class="arrowClasses" />
-	</div>
-</template>
+const containerClasses = popover(variants);
+// → "popover _background:neutral _border-radius:md _box-shadow:md ..."
+const headerClasses = popoverHeader(variants);
+// → "popover-header _padding:md _border-bottom-width:thin ..."
+const bodyClasses = popoverBody({ size: "md" });
+// → "popover-body _padding:md ..."
+const footerClasses = popoverFooter(variants);
+// → "popover-footer _padding:md _border-top-width:thin ..."
+const arrowClasses = popoverArrow({ color: "neutral", variant: "solid" });
+// → "popover-arrow _border-color:neutral ..."
 ```
 
-::::
-:::
+```html [src/components/popover.html]
+<div class="popover-wrapper">
+	<div class="popover _background:neutral _border-radius:md ..." role="dialog" aria-labelledby="popover-title">
+		<div class="popover-header _padding:md ..."><h3 id="popover-title">Title</h3></div>
+		<div class="popover-body _padding:md ...">Body content</div>
+		<div class="popover-footer _padding:md ...">Footer</div>
+	</div>
+	<span class="popover-arrow ..."></span>
+</div>
+```
+
+::
 
 #### See it in action
 

--- a/apps/docs/content/docs/05.components/02.composables/12.chip.md
+++ b/apps/docs/content/docs/05.components/02.composables/12.chip.md
@@ -61,8 +61,46 @@ export default s;
 
 Import the `chip` and `chipIndicator` runtime functions from the virtual module and pass variant props to compute class names:
 
-:::tabs
-::::tabs-item{icon="i-devicon-react" label="React"}
+::framework-switcher
+
+#vue
+
+```vue [src/components/Chip.vue]
+<script setup lang="ts">
+import { chip, chipIndicator } from "virtual:styleframe";
+
+const props = withDefaults(
+	defineProps<{
+		color?: "primary" | "secondary" | "success" | "info" | "warning" | "error" | "light" | "dark" | "neutral";
+		variant?: "solid" | "soft";
+		size?: "xs" | "sm" | "md" | "lg" | "xl";
+		position?: "top-right" | "top-left" | "bottom-right" | "bottom-left";
+		inset?: boolean;
+		text?: string;
+	}>(),
+	{ color: "primary", variant: "solid", size: "md", position: "top-right", inset: false },
+);
+</script>
+
+<template>
+	<div :class="chip()">
+		<slot />
+		<span
+			:class="chipIndicator({
+				color,
+				variant,
+				size,
+				position,
+				inset: inset ? 'true' : 'false',
+			})"
+		>
+			{{ text }}
+		</span>
+	</div>
+</template>
+```
+
+#react
 
 ```ts [src/components/Chip.tsx]
 import { chip, chipIndicator } from "virtual:styleframe";
@@ -105,46 +143,33 @@ export function Chip({
 }
 ```
 
-::::
-::::tabs-item{icon="i-devicon-vuejs" label="Vue"}
+#other
 
-```vue [src/components/Chip.vue]
-<script setup lang="ts">
+The `chip()` and `chipIndicator()` runtimes each return a class string. Apply them however your framework binds classes:
+
+```ts [src/components/chip.ts]
 import { chip, chipIndicator } from "virtual:styleframe";
 
-const props = withDefaults(
-	defineProps<{
-		color?: "primary" | "secondary" | "success" | "info" | "warning" | "error" | "light" | "dark" | "neutral";
-		variant?: "solid" | "soft";
-		size?: "xs" | "sm" | "md" | "lg" | "xl";
-		position?: "top-right" | "top-left" | "bottom-right" | "bottom-left";
-		inset?: boolean;
-		text?: string;
-	}>(),
-	{ color: "primary", variant: "solid", size: "md", position: "top-right", inset: false },
-);
-</script>
-
-<template>
-	<div :class="chip()">
-		<slot />
-		<span
-			:class="chipIndicator({
-				color,
-				variant,
-				size,
-				position,
-				inset: inset ? 'true' : 'false',
-			})"
-		>
-			{{ text }}
-		</span>
-	</div>
-</template>
+const wrapperClasses = chip();
+// → "chip _position:relative _display:inline-flex"
+const indicatorClasses = chipIndicator({
+	color: "primary",
+	variant: "solid",
+	size: "md",
+	position: "top-right",
+	inset: "false",
+});
+// → "chip-indicator _background:primary _color:white _position:absolute ..."
 ```
 
-::::
-:::
+```html [src/components/chip.html]
+<div class="chip _position:relative _display:inline-flex">
+	<button>Notifications</button>
+	<span class="chip-indicator _background:primary _color:white ..." aria-hidden="true">5</span>
+</div>
+```
+
+::
 
 #### See it in action
 

--- a/apps/docs/content/docs/05.components/02.composables/13.spinner.md
+++ b/apps/docs/content/docs/05.components/02.composables/13.spinner.md
@@ -60,8 +60,33 @@ export default s;
 
 Import the `spinner` and `spinnerCircle` runtime functions from the virtual module and pass variant props to compute class names:
 
-:::tabs
-::::tabs-item{icon="i-devicon-react" label="React"}
+::framework-switcher
+
+#vue
+
+```vue [src/components/Spinner.vue]
+<script setup lang="ts">
+import { spinner, spinnerCircle } from "virtual:styleframe";
+
+const { color = "primary", size = "md", label } = defineProps<{
+	color?: "primary" | "light" | "dark" | "neutral";
+	size?: "auto" | "sm" | "md" | "lg";
+	label?: string;
+}>();
+</script>
+
+<template>
+	<div :class="spinner({ color, size })" role="status">
+		<svg :class="spinnerCircle({ size })" viewBox="0 0 50 50">
+			<circle cx="25" cy="25" r="20" />
+		</svg>
+		<span v-if="label">{{ label }}</span>
+		<slot />
+	</div>
+</template>
+```
+
+#react
 
 ```ts [src/components/Spinner.tsx]
 import { spinner, spinnerCircle } from "virtual:styleframe";
@@ -94,33 +119,29 @@ export function Spinner({
 }
 ```
 
-::::
-::::tabs-item{icon="i-devicon-vuejs" label="Vue"}
+#other
 
-```vue [src/components/Spinner.vue]
-<script setup lang="ts">
+The `spinner()` and `spinnerCircle()` runtimes each return a class string. Apply them however your framework binds classes:
+
+```ts [src/components/spinner.ts]
 import { spinner, spinnerCircle } from "virtual:styleframe";
 
-const { color = "primary", size = "md", label } = defineProps<{
-	color?: "primary" | "light" | "dark" | "neutral";
-	size?: "auto" | "sm" | "md" | "lg";
-	label?: string;
-}>();
-</script>
-
-<template>
-	<div :class="spinner({ color, size })" role="status">
-		<svg :class="spinnerCircle({ size })" viewBox="0 0 50 50">
-			<circle cx="25" cy="25" r="20" />
-		</svg>
-		<span v-if="label">{{ label }}</span>
-		<slot />
-	</div>
-</template>
+const containerClasses = spinner({ color: "primary", size: "md" });
+// → "spinner _color:primary _display:inline-flex ..."
+const circleClasses = spinnerCircle({ size: "md" });
+// → "spinner-circle _width:3 _height:3 _animation:rotate ..."
 ```
 
-::::
-:::
+```html [src/components/spinner.html]
+<div class="spinner _color:primary _display:inline-flex ..." role="status">
+	<svg class="spinner-circle _animation:rotate ..." viewBox="0 0 50 50">
+		<circle cx="25" cy="25" r="20"></circle>
+	</svg>
+	<span>Loading…</span>
+</div>
+```
+
+::
 
 #### See it in action
 

--- a/apps/docs/content/docs/05.components/02.composables/14.dropdown.md
+++ b/apps/docs/content/docs/05.components/02.composables/14.dropdown.md
@@ -69,8 +69,51 @@ export default s;
 
 Import the `dropdown`, `dropdownItem`, `dropdownSeparator`, `dropdownLabel`, and `dropdownArrow` runtime functions from the virtual module and pass variant props to compute class names:
 
-:::tabs
-::::tabs-item{icon="i-devicon-react" label="React"}
+::framework-switcher
+
+#vue
+
+```vue [src/components/Dropdown.vue]
+<script setup lang="ts">
+import {
+    dropdown,
+    dropdownItem,
+    dropdownSeparator,
+    dropdownLabel,
+    dropdownArrow,
+} from "virtual:styleframe";
+
+const {
+    color = "neutral",
+    variant = "solid",
+    size = "md",
+} = defineProps<{
+    color?: "light" | "dark" | "neutral";
+    variant?: "solid" | "soft" | "subtle";
+    size?: "sm" | "md" | "lg";
+}>();
+</script>
+
+<template>
+    <div role="menu" :class="dropdown({ color, variant, size })">
+        <div role="presentation" :class="dropdownLabel({ color, size })">
+            Account
+        </div>
+        <button type="button" role="menuitem" :class="dropdownItem({ color, variant, size })">
+            Profile
+        </button>
+        <button type="button" role="menuitem" :class="dropdownItem({ color, variant, size })">
+            Settings
+        </button>
+        <hr role="separator" :class="dropdownSeparator({ color })" />
+        <button type="button" role="menuitem" :class="dropdownItem({ color, variant, size })">
+            Sign out
+        </button>
+    </div>
+</template>
+```
+
+#react
 
 ```ts [src/components/Dropdown.tsx]
 import {
@@ -151,11 +194,11 @@ export function DropdownArrow({
 }
 ```
 
-::::
-::::tabs-item{icon="i-devicon-vuejs" label="Vue"}
+#other
 
-```vue [src/components/Dropdown.vue]
-<script setup lang="ts">
+The dropdown runtimes each return a class string. Apply them however your framework binds classes:
+
+```ts [src/components/dropdown.ts]
 import {
     dropdown,
     dropdownItem,
@@ -164,38 +207,34 @@ import {
     dropdownArrow,
 } from "virtual:styleframe";
 
-const {
-    color = "neutral",
-    variant = "solid",
-    size = "md",
-} = defineProps<{
-    color?: "light" | "dark" | "neutral";
-    variant?: "solid" | "soft" | "subtle";
-    size?: "sm" | "md" | "lg";
-}>();
-</script>
+const variants = { color: "neutral", variant: "solid", size: "md" } as const;
 
-<template>
-    <div role="menu" :class="dropdown({ color, variant, size })">
-        <div role="presentation" :class="dropdownLabel({ color, size })">
-            Account
-        </div>
-        <button type="button" role="menuitem" :class="dropdownItem({ color, variant, size })">
-            Profile
-        </button>
-        <button type="button" role="menuitem" :class="dropdownItem({ color, variant, size })">
-            Settings
-        </button>
-        <hr role="separator" :class="dropdownSeparator({ color })" />
-        <button type="button" role="menuitem" :class="dropdownItem({ color, variant, size })">
-            Sign out
-        </button>
-    </div>
-</template>
+const panelClasses = dropdown(variants);
+// → "dropdown _background:neutral _border-radius:md _box-shadow:md ..."
+const itemClasses = dropdownItem(variants);
+// → "dropdown-item _padding:sm _color:text ..."
+const separatorClasses = dropdownSeparator({ color: "neutral" });
+// → "dropdown-separator _border-top-width:thin ..."
+const labelClasses = dropdownLabel({ color: "neutral", size: "md" });
+// → "dropdown-label _color:muted _text-transform:uppercase ..."
+const arrowClasses = dropdownArrow({ color: "neutral", variant: "solid" });
+// → "dropdown-arrow _border-color:neutral ..."
 ```
 
-::::
-:::
+```html [src/components/dropdown.html]
+<div class="dropdown-wrapper">
+    <div role="menu" class="dropdown _background:neutral _border-radius:md ...">
+        <div role="presentation" class="dropdown-label _color:muted ...">Account</div>
+        <button type="button" role="menuitem" class="dropdown-item _padding:sm ...">Profile</button>
+        <button type="button" role="menuitem" class="dropdown-item _padding:sm ...">Settings</button>
+        <hr role="separator" class="dropdown-separator _border-top-width:thin ..." />
+        <button type="button" role="menuitem" class="dropdown-item _padding:sm ...">Sign out</button>
+    </div>
+    <span class="dropdown-arrow ..."></span>
+</div>
+```
+
+::
 
 #### See it in action
 

--- a/apps/docs/content/docs/05.components/02.composables/14.hamburger-menu.md
+++ b/apps/docs/content/docs/05.components/02.composables/14.hamburger-menu.md
@@ -59,8 +59,59 @@ export default s;
 
 Import the `hamburgerMenu` runtime function from the virtual module, manage `active` state locally, and render a `<button>` with a single `.hamburger-menu-inner` child &mdash; the pseudo-elements render the top and bottom bars automatically:
 
-:::tabs
-::::tabs-item{icon="i-devicon-react" label="React"}
+::framework-switcher
+
+#vue
+
+```vue [src/components/HamburgerMenu.vue]
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { hamburgerMenu } from "virtual:styleframe";
+
+const {
+	color = "neutral",
+	size = "md",
+	animation = "close",
+	label = "Toggle menu",
+} = defineProps<{
+	color?: "light" | "dark" | "neutral";
+	size?: "sm" | "md" | "lg";
+	animation?:
+		| "close"
+		| "arrow-up"
+		| "arrow-down"
+		| "arrow-left"
+		| "arrow-right"
+		| "minus"
+		| "plus";
+	label?: string;
+}>();
+
+const active = ref(false);
+const classes = computed(() =>
+	hamburgerMenu({
+		color,
+		size,
+		animation,
+		active: active.value ? "true" : "false",
+	}),
+);
+</script>
+
+<template>
+	<button
+		type="button"
+		:class="classes"
+		:aria-expanded="active"
+		:aria-label="label"
+		@click="active = !active"
+	>
+		<span class="hamburger-menu-inner" />
+	</button>
+</template>
+```
+
+#react
 
 ```tsx [src/components/HamburgerMenu.tsx]
 import { useState } from "react";
@@ -113,59 +164,34 @@ export function HamburgerMenu({
 }
 ```
 
-::::
-::::tabs-item{icon="i-devicon-vuejs" label="Vue"}
+#other
 
-```vue [src/components/HamburgerMenu.vue]
-<script setup lang="ts">
-import { computed, ref } from "vue";
+The `hamburgerMenu()` runtime returns a class string. Apply it however your framework binds classes:
+
+```ts [src/components/hamburger-menu.ts]
 import { hamburgerMenu } from "virtual:styleframe";
 
-const {
-	color = "neutral",
-	size = "md",
-	animation = "close",
-	label = "Toggle menu",
-} = defineProps<{
-	color?: "light" | "dark" | "neutral";
-	size?: "sm" | "md" | "lg";
-	animation?:
-		| "close"
-		| "arrow-up"
-		| "arrow-down"
-		| "arrow-left"
-		| "arrow-right"
-		| "minus"
-		| "plus";
-	label?: string;
-}>();
-
-const active = ref(false);
-const classes = computed(() =>
-	hamburgerMenu({
-		color,
-		size,
-		animation,
-		active: active.value ? "true" : "false",
-	}),
-);
-</script>
-
-<template>
-	<button
-		type="button"
-		:class="classes"
-		:aria-expanded="active"
-		:aria-label="label"
-		@click="active = !active"
-	>
-		<span class="hamburger-menu-inner" />
-	</button>
-</template>
+const classes = hamburgerMenu({
+	color: "neutral",
+	size: "md",
+	animation: "close",
+	active: "false",
+});
+// → "hamburger-menu _color:neutral _padding:sm ..."
 ```
 
-::::
-:::
+```html [src/components/hamburger-menu.html]
+<button
+	type="button"
+	class="hamburger-menu _color:neutral _padding:sm ..."
+	aria-expanded="false"
+	aria-label="Toggle menu"
+>
+	<span class="hamburger-menu-inner"></span>
+</button>
+```
+
+::
 
 #### See it in action
 

--- a/apps/docs/content/docs/05.components/02.composables/15.breadcrumb.md
+++ b/apps/docs/content/docs/05.components/02.composables/15.breadcrumb.md
@@ -60,8 +60,63 @@ export default s;
 
 Import the `breadcrumb` and `breadcrumbItem` runtime functions from the virtual module and pass variant props to compute class names:
 
-:::tabs
-::::tabs-item{icon="i-devicon-react" label="React"}
+::framework-switcher
+
+#vue
+
+```vue [src/components/Breadcrumb.vue]
+<script setup lang="ts">
+import { breadcrumb } from "virtual:styleframe";
+
+const { size = "md" } = defineProps<{
+	size?: "sm" | "md" | "lg";
+}>();
+</script>
+
+<template>
+	<nav aria-label="Breadcrumb" :class="breadcrumb({ size })">
+		<slot />
+	</nav>
+</template>
+```
+
+```vue [src/components/BreadcrumbItem.vue]
+<script setup lang="ts">
+import { computed } from "vue";
+import { breadcrumbItem } from "virtual:styleframe";
+
+const {
+	color = "neutral",
+	size = "md",
+	active = false,
+	disabled = false,
+	href,
+} = defineProps<{
+	color?: "light" | "dark" | "neutral";
+	size?: "sm" | "md" | "lg";
+	active?: boolean;
+	disabled?: boolean;
+	href?: string;
+}>();
+
+const tag = computed(() => (active ? "span" : "a"));
+</script>
+
+<template>
+	<component
+		:is="tag"
+		:class="breadcrumbItem({ color, size, active: active ? 'true' : 'false', disabled: disabled ? 'true' : 'false' })"
+		:href="!active ? href : undefined"
+		:aria-current="active ? 'page' : undefined"
+		:aria-disabled="disabled || undefined"
+		:tabindex="disabled ? -1 : undefined"
+	>
+		<slot />
+	</component>
+</template>
+```
+
+#react
 
 ```ts [src/components/Breadcrumb.tsx]
 import { breadcrumb, breadcrumbItem } from "virtual:styleframe";
@@ -124,63 +179,40 @@ export function BreadcrumbItem({
 }
 ```
 
-::::
-::::tabs-item{icon="i-devicon-vuejs" label="Vue"}
+#other
 
-```vue [src/components/Breadcrumb.vue]
-<script setup lang="ts">
-import { breadcrumb } from "virtual:styleframe";
+The `breadcrumb()` and `breadcrumbItem()` runtimes each return a class string. Apply them however your framework binds classes:
 
-const { size = "md" } = defineProps<{
-	size?: "sm" | "md" | "lg";
-}>();
-</script>
+```ts [src/components/breadcrumb.ts]
+import { breadcrumb, breadcrumbItem } from "virtual:styleframe";
 
-<template>
-	<nav aria-label="Breadcrumb" :class="breadcrumb({ size })">
-		<slot />
-	</nav>
-</template>
+const containerClasses = breadcrumb({ size: "md" });
+// → "breadcrumb _display:flex _gap:sm _font-size:sm ..."
+const linkClasses = breadcrumbItem({
+	color: "neutral",
+	size: "md",
+	active: "false",
+	disabled: "false",
+});
+// → "breadcrumb-item _padding:sm _color:text ..."
+const currentClasses = breadcrumbItem({
+	color: "neutral",
+	size: "md",
+	active: "true",
+	disabled: "false",
+});
+// → "breadcrumb-item _padding:sm _font-weight:semibold ..."
 ```
 
-```vue [src/components/BreadcrumbItem.vue]
-<script setup lang="ts">
-import { computed } from "vue";
-import { breadcrumbItem } from "virtual:styleframe";
-
-const {
-	color = "neutral",
-	size = "md",
-	active = false,
-	disabled = false,
-	href,
-} = defineProps<{
-	color?: "light" | "dark" | "neutral";
-	size?: "sm" | "md" | "lg";
-	active?: boolean;
-	disabled?: boolean;
-	href?: string;
-}>();
-
-const tag = computed(() => (active ? "span" : "a"));
-</script>
-
-<template>
-	<component
-		:is="tag"
-		:class="breadcrumbItem({ color, size, active: active ? 'true' : 'false', disabled: disabled ? 'true' : 'false' })"
-		:href="!active ? href : undefined"
-		:aria-current="active ? 'page' : undefined"
-		:aria-disabled="disabled || undefined"
-		:tabindex="disabled ? -1 : undefined"
-	>
-		<slot />
-	</component>
-</template>
+```html [src/components/breadcrumb.html]
+<nav aria-label="Breadcrumb" class="breadcrumb _display:flex _gap:sm ...">
+	<a class="breadcrumb-item _padding:sm ..." href="/">Home</a>
+	<a class="breadcrumb-item _padding:sm ..." href="/library">Library</a>
+	<span class="breadcrumb-item _font-weight:semibold ..." aria-current="page">Current page</span>
+</nav>
 ```
 
-::::
-:::
+::
 
 #### See it in action
 

--- a/apps/docs/content/docs/05.components/02.composables/15.media.md
+++ b/apps/docs/content/docs/05.components/02.composables/15.media.md
@@ -67,8 +67,41 @@ export default s;
 
 Import the `media`, `mediaFigure`, `mediaBody`, and `mediaTitle` runtime functions from the virtual module and pass variant props to compute class names:
 
-:::tabs
-::::tabs-item{icon="i-devicon-react" label="React"}
+::framework-switcher
+
+#vue
+
+```vue [src/components/Media.vue]
+<script setup lang="ts">
+import { media, mediaFigure, mediaBody, mediaTitle } from "virtual:styleframe";
+
+const {
+	orientation = "horizontal",
+	align = "start",
+	size = "md",
+} = defineProps<{
+	orientation?: "horizontal" | "vertical";
+	align?: "start" | "center" | "end";
+	size?: "sm" | "md" | "lg";
+}>();
+</script>
+
+<template>
+	<div :class="media({ orientation, align, size })">
+		<div :class="mediaFigure({ size })">
+			<slot name="figure" />
+		</div>
+		<div :class="mediaBody({ size })">
+			<h3 :class="mediaTitle({ size })">
+				<slot name="title" />
+			</h3>
+			<slot />
+		</div>
+	</div>
+</template>
+```
+
+#react
 
 ```ts [src/components/Media.tsx]
 import { media, mediaFigure, mediaBody, mediaTitle } from "virtual:styleframe";
@@ -104,41 +137,40 @@ export function Media({
 }
 ```
 
-::::
-::::tabs-item{icon="i-devicon-vuejs" label="Vue"}
+#other
 
-```vue [src/components/Media.vue]
-<script setup lang="ts">
+The `media()`, `mediaFigure()`, `mediaBody()`, and `mediaTitle()` runtimes each return a class string. Apply them however your framework binds classes:
+
+```ts [src/components/media.ts]
 import { media, mediaFigure, mediaBody, mediaTitle } from "virtual:styleframe";
 
-const {
-	orientation = "horizontal",
-	align = "start",
-	size = "md",
-} = defineProps<{
-	orientation?: "horizontal" | "vertical";
-	align?: "start" | "center" | "end";
-	size?: "sm" | "md" | "lg";
-}>();
-</script>
-
-<template>
-	<div :class="media({ orientation, align, size })">
-		<div :class="mediaFigure({ size })">
-			<slot name="figure" />
-		</div>
-		<div :class="mediaBody({ size })">
-			<h3 :class="mediaTitle({ size })">
-				<slot name="title" />
-			</h3>
-			<slot />
-		</div>
-	</div>
-</template>
+const containerClasses = media({
+	orientation: "horizontal",
+	align: "start",
+	size: "md",
+});
+// → "media _display:flex _flex-direction:row _gap:md ..."
+const figureClasses = mediaFigure({ size: "md" });
+// → "media-figure _flex-shrink:0 _border-radius:md ..."
+const bodyClasses = mediaBody({ size: "md" });
+// → "media-body _flex-grow:1 _min-width:0 ..."
+const titleClasses = mediaTitle({ size: "md" });
+// → "media-title _font-weight:semibold _font-size:md ..."
 ```
 
-::::
-:::
+```html [src/components/media.html]
+<div class="media _display:flex _gap:md ...">
+	<div class="media-figure _flex-shrink:0 _border-radius:md ...">
+		<img src="/avatar.png" alt="Alex Grozav" />
+	</div>
+	<div class="media-body _flex-grow:1 _min-width:0 ...">
+		<h3 class="media-title _font-weight:semibold ...">Alex Grozav</h3>
+		<p>Body content goes here.</p>
+	</div>
+</div>
+```
+
+::
 
 #### See it in action
 

--- a/apps/docs/content/docs/05.components/02.composables/15.page-hero.md
+++ b/apps/docs/content/docs/05.components/02.composables/15.page-hero.md
@@ -75,8 +75,55 @@ export default s;
 
 Import the runtime functions from the virtual module and pass variant props to compute class names. Render the backdrop as the first child so DOM order keeps content above the absolute-positioned overlay:
 
-:::tabs
-::::tabs-item{icon="i-devicon-react" label="React"}
+::framework-switcher
+
+#vue
+
+```vue [src/components/PageHero.vue]
+<script setup lang="ts">
+import {
+    pageHero,
+    pageHeroBackdrop,
+    pageHeroHeadline,
+    pageHeroTitle,
+    pageHeroDescription,
+    pageHeroActions,
+} from "virtual:styleframe";
+
+const {
+    color = "neutral",
+    size = "md",
+    orientation = "vertical",
+    alignment = "center",
+    title,
+    description,
+} = defineProps<{
+    color?: "light" | "dark" | "neutral";
+    size?: "sm" | "md" | "lg";
+    orientation?: "vertical" | "horizontal";
+    alignment?: "start" | "center";
+    title: string;
+    description?: string;
+}>();
+</script>
+
+<template>
+    <section :class="pageHero({ color, size, orientation, alignment })">
+        <div :class="pageHeroBackdrop({ variant: 'gradient' })" aria-hidden />
+        <div :class="pageHeroHeadline({ size, alignment })">
+            <h1 :class="pageHeroTitle({ size })">{{ title }}</h1>
+            <p v-if="description" :class="pageHeroDescription({ size })">
+                {{ description }}
+            </p>
+        </div>
+        <div :class="pageHeroActions({ size, alignment })">
+            <slot />
+        </div>
+    </section>
+</template>
+```
+
+#react
 
 ```tsx [src/components/PageHero.tsx]
 import {
@@ -124,11 +171,11 @@ export function PageHero({
 }
 ```
 
-::::
-::::tabs-item{icon="i-devicon-vuejs" label="Vue"}
+#other
 
-```vue [src/components/PageHero.vue]
-<script setup lang="ts">
+The page-hero runtimes each return a class string. Apply them however your framework binds classes:
+
+```ts [src/components/page-hero.ts]
 import {
     pageHero,
     pageHeroBackdrop,
@@ -138,41 +185,40 @@ import {
     pageHeroActions,
 } from "virtual:styleframe";
 
-const {
-    color = "neutral",
-    size = "md",
-    orientation = "vertical",
-    alignment = "center",
-    title,
-    description,
-} = defineProps<{
-    color?: "light" | "dark" | "neutral";
-    size?: "sm" | "md" | "lg";
-    orientation?: "vertical" | "horizontal";
-    alignment?: "start" | "center";
-    title: string;
-    description?: string;
-}>();
-</script>
-
-<template>
-    <section :class="pageHero({ color, size, orientation, alignment })">
-        <div :class="pageHeroBackdrop({ variant: 'gradient' })" aria-hidden />
-        <div :class="pageHeroHeadline({ size, alignment })">
-            <h1 :class="pageHeroTitle({ size })">{{ title }}</h1>
-            <p v-if="description" :class="pageHeroDescription({ size })">
-                {{ description }}
-            </p>
-        </div>
-        <div :class="pageHeroActions({ size, alignment })">
-            <slot />
-        </div>
-    </section>
-</template>
+const sectionClasses = pageHero({
+    color: "neutral",
+    size: "md",
+    orientation: "vertical",
+    alignment: "center",
+});
+// → "page-hero _position:relative _padding-y:lg ..."
+const backdropClasses = pageHeroBackdrop({ variant: "gradient" });
+// → "page-hero-backdrop _position:absolute _inset:0 ..."
+const headlineClasses = pageHeroHeadline({ size: "md", alignment: "center" });
+// → "page-hero-headline _display:flex _flex-direction:column ..."
+const titleClasses = pageHeroTitle({ size: "md" });
+// → "page-hero-title _font-size:3xl _font-weight:bold ..."
+const descriptionClasses = pageHeroDescription({ size: "md" });
+// → "page-hero-description _max-width:60ch _font-size:md ..."
+const actionsClasses = pageHeroActions({ size: "md", alignment: "center" });
+// → "page-hero-actions _display:flex _gap:md ..."
 ```
 
-::::
-:::
+```html [src/components/page-hero.html]
+<section class="page-hero _position:relative _padding-y:lg ...">
+    <div class="page-hero-backdrop _position:absolute _inset:0 ..." aria-hidden></div>
+    <div class="page-hero-headline _display:flex _flex-direction:column ...">
+        <h1 class="page-hero-title _font-size:3xl ...">Welcome to Styleframe</h1>
+        <p class="page-hero-description _max-width:60ch ...">Type-safe CSS-in-TypeScript for design systems.</p>
+    </div>
+    <div class="page-hero-actions _display:flex _gap:md ...">
+        <a href="/docs" class="button ...">Get started</a>
+        <a href="/docs/api" class="button ...">Read the docs</a>
+    </div>
+</section>
+```
+
+::
 
 #### See it in action
 

--- a/apps/docs/content/docs/05.components/02.composables/15.pagination.md
+++ b/apps/docs/content/docs/05.components/02.composables/15.pagination.md
@@ -65,88 +65,9 @@ export default s;
 
 Import the `pagination`, `paginationItem`, and `paginationEllipsis` runtime functions from the virtual module and pass variant props to compute class names:
 
-:::tabs
-::::tabs-item{icon="i-devicon-react" label="React"}
+::framework-switcher
 
-```ts [src/components/Pagination.tsx]
-import { pagination, paginationItem, paginationEllipsis } from "virtual:styleframe";
-
-interface PaginationProps {
-    orientation?: "horizontal" | "vertical";
-    size?: "sm" | "md" | "lg";
-    children?: React.ReactNode;
-}
-
-interface PaginationItemProps {
-    color?: "light" | "dark" | "neutral";
-    variant?: "solid" | "outline" | "soft" | "subtle" | "ghost" | "link";
-    size?: "sm" | "md" | "lg";
-    active?: boolean;
-    disabled?: boolean;
-    href?: string;
-    "aria-label"?: string;
-    children?: React.ReactNode;
-}
-
-export function Pagination({
-    orientation = "horizontal",
-    size = "md",
-    children,
-}: PaginationProps) {
-    return (
-        <nav
-            className={pagination({ orientation, size })}
-            role="navigation"
-            aria-label="Pagination"
-        >
-            {children}
-        </nav>
-    );
-}
-
-export function PaginationItem({
-    color = "neutral",
-    variant = "ghost",
-    size = "md",
-    active = false,
-    disabled = false,
-    href,
-    children,
-    ...rest
-}: PaginationItemProps) {
-    const classes = paginationItem({
-        color,
-        variant,
-        size,
-        active: active ? "true" : "false",
-        disabled: disabled ? "true" : "false",
-    });
-    const Tag = href ? "a" : "button";
-    return (
-        <Tag
-            className={classes}
-            href={href && !disabled ? href : undefined}
-            disabled={!href && disabled ? true : undefined}
-            aria-current={active ? "page" : undefined}
-            aria-disabled={disabled || undefined}
-            {...rest}
-        >
-            {children}
-        </Tag>
-    );
-}
-
-export function PaginationEllipsis({ size = "md" }: { size?: "sm" | "md" | "lg" }) {
-    return (
-        <span className={paginationEllipsis({ size })} aria-hidden="true">
-            …
-        </span>
-    );
-}
-```
-
-::::
-::::tabs-item{icon="i-devicon-vuejs" label="Vue"}
+#vue
 
 ```vue [src/components/Pagination.vue]
 <script setup lang="ts">
@@ -229,8 +150,125 @@ const { size = "md" } = defineProps<{
 </template>
 ```
 
-::::
-:::
+#react
+
+```ts [src/components/Pagination.tsx]
+import { pagination, paginationItem, paginationEllipsis } from "virtual:styleframe";
+
+interface PaginationProps {
+    orientation?: "horizontal" | "vertical";
+    size?: "sm" | "md" | "lg";
+    children?: React.ReactNode;
+}
+
+interface PaginationItemProps {
+    color?: "light" | "dark" | "neutral";
+    variant?: "solid" | "outline" | "soft" | "subtle" | "ghost" | "link";
+    size?: "sm" | "md" | "lg";
+    active?: boolean;
+    disabled?: boolean;
+    href?: string;
+    "aria-label"?: string;
+    children?: React.ReactNode;
+}
+
+export function Pagination({
+    orientation = "horizontal",
+    size = "md",
+    children,
+}: PaginationProps) {
+    return (
+        <nav
+            className={pagination({ orientation, size })}
+            role="navigation"
+            aria-label="Pagination"
+        >
+            {children}
+        </nav>
+    );
+}
+
+export function PaginationItem({
+    color = "neutral",
+    variant = "ghost",
+    size = "md",
+    active = false,
+    disabled = false,
+    href,
+    children,
+    ...rest
+}: PaginationItemProps) {
+    const classes = paginationItem({
+        color,
+        variant,
+        size,
+        active: active ? "true" : "false",
+        disabled: disabled ? "true" : "false",
+    });
+    const Tag = href ? "a" : "button";
+    return (
+        <Tag
+            className={classes}
+            href={href && !disabled ? href : undefined}
+            disabled={!href && disabled ? true : undefined}
+            aria-current={active ? "page" : undefined}
+            aria-disabled={disabled || undefined}
+            {...rest}
+        >
+            {children}
+        </Tag>
+    );
+}
+
+export function PaginationEllipsis({ size = "md" }: { size?: "sm" | "md" | "lg" }) {
+    return (
+        <span className={paginationEllipsis({ size })} aria-hidden="true">
+            …
+        </span>
+    );
+}
+```
+
+#other
+
+The `pagination()`, `paginationItem()`, and `paginationEllipsis()` runtimes each return a class string. Apply them however your framework binds classes:
+
+```ts [src/components/pagination.ts]
+import { pagination, paginationItem, paginationEllipsis } from "virtual:styleframe";
+
+const navClasses = pagination({ orientation: "horizontal", size: "md" });
+// → "pagination _display:flex _flex-direction:row _gap:sm ..."
+const itemClasses = paginationItem({
+    color: "neutral",
+    variant: "ghost",
+    size: "md",
+    active: "false",
+    disabled: "false",
+});
+// → "pagination-item _padding:sm _color:text ..."
+const activeItemClasses = paginationItem({
+    color: "neutral",
+    variant: "ghost",
+    size: "md",
+    active: "true",
+    disabled: "false",
+});
+// → "pagination-item _padding:sm _font-weight:semibold ..."
+const ellipsisClasses = paginationEllipsis({ size: "md" });
+// → "pagination-ellipsis _color:muted _padding:sm ..."
+```
+
+```html [src/components/pagination.html]
+<nav class="pagination _display:flex _gap:sm ..." aria-label="Pagination">
+    <a href="?page=1" class="pagination-item _padding:sm ...">1</a>
+    <a href="?page=2" class="pagination-item _font-weight:semibold ..." aria-current="page">2</a>
+    <a href="?page=3" class="pagination-item _padding:sm ...">3</a>
+    <span class="pagination-ellipsis _color:muted ..." aria-hidden="true">…</span>
+    <a href="?page=9" class="pagination-item _padding:sm ...">9</a>
+</nav>
+```
+
+::
 
 #### See it in action
 


### PR DESCRIPTION
## Summary
- Adds a sidebar-controlled framework selector (Vue / React / Vanilla / Other) backed by `useFramework()` with localStorage persistence, plus a `<FrameworkSwitcher>` content component that renders the active slot.
- Replaces inline `tabs-item` blocks with `framework-switcher` blocks across both getting-started guides and all 20 composable recipe docs.
- Adds a vanilla TS + HTML `#other` slot to every composable doc, showing the recipe's framework-agnostic class-string output (with `// → "..."` previews).

## Test plan
- [ ] Run \`pnpm dev:docs\` and verify the sidebar shows a "Framework" label with the Vue / React / Vanilla / Other dropdown.
- [ ] Toggle each framework and confirm the selection persists across reloads.
- [ ] Click through the 2 getting-started guides and all 20 composable recipe docs and confirm each framework's slot renders without the "Not available for X" fallback banner.