### PR TITLE
feat(transpiler): export named Props types from virtual:styleframe

### DIFF
--- a/.changeset/virtual-props-types.md
+++ b/.changeset/virtual-props-types.md
@@ -1,0 +1,6 @@
+---
+"@styleframe/transpiler": minor
+"styleframe": minor
+---
+
+Export named Props types from `virtual:styleframe` for each recipe (e.g. `import { button, type ButtonProps } from 'virtual:styleframe'`).

--- a/apps/docs/content/docs/02.api/11.recipes/00.index.md
+++ b/apps/docs/content/docs/02.api/11.recipes/00.index.md
@@ -63,7 +63,7 @@ The `@styleframe/runtime` runtime package provides lightweight functions that po
 
 ```ts [recipes.ts (auto-generated)]
 import { createRecipe } from "@styleframe/runtime";
-import type { RecipeRuntime } from "@styleframe/runtime";
+import type { RecipeRuntime, RecipeVariantProps } from "@styleframe/runtime";
 
 const buttonRecipe = {
     base: {
@@ -83,15 +83,18 @@ const buttonRecipe = {
     }
 } as const satisfies RecipeRuntime;
 
+export type ButtonProps = RecipeVariantProps<typeof buttonRecipe>;
 export const button = createRecipe("button", buttonRecipe);
 ```
 
 ### 3. Use in Components
 
-The recipe function handles all the logic of combining base styles with your selected variants, so you just pass in the props you want.
+The recipe function handles all the logic of combining base styles with your selected variants, so you just pass in the props you want. Each recipe also exports a named Props type that you can use to type your component props.
 
 ```ts [src/components/Button.tsx]
-import { button } from "virtual:styleframe";
+import { button, type ButtonProps } from "virtual:styleframe";
+
+// ButtonProps = { color?: "primary" | "secondary" }
 
 // Use in your components
 button({ color: "primary" })

--- a/apps/docs/content/docs/02.api/11.recipes/01.runtime.md
+++ b/apps/docs/content/docs/02.api/11.recipes/01.runtime.md
@@ -13,12 +13,12 @@ Once defined, recipes are generated as functions that you can import and use in 
 
 ## Using Recipes in Components
 
-Import your recipe function and call it with variant props to generate class names:
+Import your recipe function and its Props type, then call it with variant props to generate class names:
 
 ```ts [src/components/Button.tsx]
-import { button } from "virtual:styleframe";
+import { button, type ButtonProps } from "virtual:styleframe";
 
-function Button({ color, size, children, ...props }) {
+function Button({ color, size, children, ...props }: ButtonProps & { children: React.ReactNode }) {
     // Generate class names based on variant props
     const className = button({ color, size });
     // Returns: "button _border-width:thin _border-style:[solid] _background:primary _color:white _padding:md"
@@ -39,7 +39,7 @@ When you define a recipe, Styleframe auto-generates a TypeScript file with a run
 
 ```ts [recipes.ts (auto-generated)]
 import { createRecipe } from "@styleframe/runtime";
-import type { RecipeRuntime } from "@styleframe/runtime";
+import type { RecipeRuntime, RecipeVariantProps } from "@styleframe/runtime";
 
 const buttonRecipe = {
     base: {
@@ -69,6 +69,7 @@ const buttonRecipe = {
     },
 } as const satisfies RecipeRuntime;
 
+export type ButtonProps = RecipeVariantProps<typeof buttonRecipe>;
 export const button = createRecipe("button", buttonRecipe);
 ```
 
@@ -122,6 +123,44 @@ button({ color: "primary", size: "lg" })
 button({ color: "invalid" })
 //              ^^^^^^^^^ Type '"invalid"' is not assignable to type '"primary" | "secondary"'
 ```
+
+### Props Types
+
+Each recipe exports a named Props type alongside its function, derived from its variant definitions. The type name follows the convention `PascalCase(exportName) + "Props"`:
+
+| Recipe Export | Props Type |
+|--------------|------------|
+| `button` | `ButtonProps` |
+| `cardHeader` | `CardHeaderProps` |
+| `badge` | `BadgeProps` |
+
+Import the Props type to use it in your component interfaces:
+
+```vue [src/components/Button.vue]
+<script setup lang="ts">
+import { button, type ButtonProps } from "virtual:styleframe";
+
+// ButtonProps = { color?: "primary" | "secondary"; size?: "sm" | "md" | "lg" }
+
+const props = defineProps<ButtonProps & { label?: string }>();
+</script>
+
+<template>
+    <button :class="button({ color: props.color, size: props.size })">
+        {{ props.label }}
+    </button>
+</template>
+```
+
+```tsx [src/components/Button.tsx]
+import { button, type ButtonProps } from "virtual:styleframe";
+
+function Button({ color, size, children }: ButtonProps & { children: React.ReactNode }) {
+    return <button className={button({ color, size })}>{children}</button>;
+}
+```
+
+This eliminates the need to manually duplicate variant types in your component props.
 
 ## Frequently Asked Questions
 

--- a/apps/docs/content/docs/02.api/11.recipes/02.output-format.md
+++ b/apps/docs/content/docs/02.api/11.recipes/02.output-format.md
@@ -261,10 +261,11 @@ This generates classes like:
 
 ## Generated Output
 
-When you run the Styleframe build, recipes generate two types of output:
+When you run the Styleframe build, recipes generate three types of output:
 
 1. **CSS Utility Classes**: Static CSS classes for all unique utility-value combinations
 2. **Runtime Recipe Functions**: TypeScript functions that combine classes based on variant props
+3. **Props Types**: Named TypeScript types for each recipe's variant props
 
 ### CSS Utility Classes
 
@@ -287,6 +288,24 @@ All unique utility-value combinations found in the recipe are generated as CSS c
 Styleframe automatically deduplicates utility classes across all recipes. If multiple recipes use `background: ref(colorPrimary)`, only one `._background:primary` class is generated.
 
 This keeps your CSS bundle size minimal regardless of how many recipes share the same utility values.
+
+### Props Types
+
+Each recipe also generates a named Props type that matches its variant definitions. The type is exported alongside the recipe function from `virtual:styleframe`:
+
+```ts [recipes.ts (auto-generated)]
+export type ButtonProps = RecipeVariantProps<typeof buttonRecipe>;
+// Resolves to: { color?: "primary" | "secondary"; size?: "sm" | "md" | "lg" }
+```
+
+The type declaration file (`.d.ts`) contains the fully expanded type:
+
+```ts [.styleframe/styleframe.d.ts (auto-generated)]
+declare module "virtual:styleframe" {
+    export type ButtonProps = { color?: "primary" | "secondary"; size?: "sm" | "md" | "lg" };
+    export const button: (props?: ButtonProps) => string;
+}
+```
 
 ## Frequently Asked Questions
 

--- a/apps/docs/content/docs/05.components/02.composables/01.badge.md
+++ b/apps/docs/content/docs/05.components/02.composables/01.badge.md
@@ -64,13 +64,9 @@ Import the `badge` runtime function from the virtual module and pass variant pro
 
 ```vue [src/components/Badge.vue]
 <script setup lang="ts">
-import { badge } from "virtual:styleframe";
+import { badge, type BadgeProps } from "virtual:styleframe";
 
-const { color = "neutral", variant = "solid", size = "sm" } = defineProps<{
-	color?: "primary" | "secondary" | "success" | "info" | "warning" | "error" | "light" | "dark" | "neutral";
-	variant?: "solid" | "outline" | "soft" | "subtle";
-	size?: "xs" | "sm" | "md" | "lg" | "xl";
-}>();
+const { color = "neutral", variant = "solid", size = "sm" } = defineProps<BadgeProps>();
 </script>
 
 <template>
@@ -83,21 +79,14 @@ const { color = "neutral", variant = "solid", size = "sm" } = defineProps<{
 #react
 
 ```ts [src/components/Badge.tsx]
-import { badge } from "virtual:styleframe";
-
-interface BadgeProps {
-	color?: "primary" | "secondary" | "success" | "info" | "warning" | "error" | "light" | "dark" | "neutral";
-	variant?: "solid" | "outline" | "soft" | "subtle";
-	size?: "xs" | "sm" | "md" | "lg" | "xl";
-	children?: React.ReactNode;
-}
+import { badge, type BadgeProps } from "virtual:styleframe";
 
 export function Badge({
 	color = "neutral",
 	variant = "solid",
 	size = "sm",
 	children,
-}: BadgeProps) {
+}: BadgeProps & { children?: React.ReactNode }) {
 	const classes = badge({ color, variant, size });
 
 	return <span className={classes}>{children}</span>;

--- a/apps/docs/content/docs/05.components/02.composables/02.button.md
+++ b/apps/docs/content/docs/05.components/02.composables/02.button.md
@@ -64,19 +64,14 @@ Import the `button` runtime function from the virtual module and pass variant pr
 
 ```vue [src/components/Button.vue]
 <script setup lang="ts">
-import { button } from "virtual:styleframe";
+import { button, type ButtonProps } from "virtual:styleframe";
 
 const {
 	color = "neutral",
 	variant = "solid",
 	size = "md",
 	disabled = false,
-} = defineProps<{
-	color?: "primary" | "secondary" | "success" | "info" | "warning" | "error" | "light" | "dark" | "neutral";
-	variant?: "solid" | "outline" | "soft" | "subtle" | "ghost" | "link";
-	size?: "xs" | "sm" | "md" | "lg" | "xl";
-	disabled?: boolean;
-}>();
+} = defineProps<ButtonProps>();
 </script>
 
 <template>
@@ -89,15 +84,7 @@ const {
 #react
 
 ```ts [src/components/Button.tsx]
-import { button } from "virtual:styleframe";
-
-interface ButtonProps {
-	color?: "primary" | "secondary" | "success" | "info" | "warning" | "error" | "light" | "dark" | "neutral";
-	variant?: "solid" | "outline" | "soft" | "subtle" | "ghost" | "link";
-	size?: "xs" | "sm" | "md" | "lg" | "xl";
-	disabled?: boolean;
-	children?: React.ReactNode;
-}
+import { button, type ButtonProps } from "virtual:styleframe";
 
 export function Button({
 	color = "neutral",
@@ -105,7 +92,7 @@ export function Button({
 	size = "md",
 	disabled = false,
 	children,
-}: ButtonProps) {
+}: ButtonProps & { children?: React.ReactNode }) {
 	const classes = button({ color, variant, size });
 
 	return (

--- a/apps/docs/content/docs/05.components/02.composables/03.button-group.md
+++ b/apps/docs/content/docs/05.components/02.composables/03.button-group.md
@@ -64,13 +64,10 @@ Import the `buttonGroup` runtime function from the virtual module and pass varia
 
 ```vue [src/components/ButtonGroup.vue]
 <script setup lang="ts">
-import { buttonGroup } from "virtual:styleframe";
+import { buttonGroup, type ButtonGroupProps } from "virtual:styleframe";
 
 const props = withDefaults(
-	defineProps<{
-		orientation?: "horizontal" | "vertical";
-		block?: boolean;
-	}>(),
+	defineProps<ButtonGroupProps>(),
 	{
 		orientation: "horizontal",
 		block: false,
@@ -91,19 +88,13 @@ const props = withDefaults(
 #react
 
 ```ts [src/components/ButtonGroup.tsx]
-import { buttonGroup } from "virtual:styleframe";
-
-interface ButtonGroupProps {
-	orientation?: "horizontal" | "vertical";
-	block?: boolean;
-	children?: React.ReactNode;
-}
+import { buttonGroup, type ButtonGroupProps } from "virtual:styleframe";
 
 export function ButtonGroup({
 	orientation = "horizontal",
 	block = false,
 	children,
-}: ButtonGroupProps) {
+}: ButtonGroupProps & { children?: React.ReactNode }) {
 	const classes = buttonGroup({ orientation, block: block ? "true" : "false" });
 
 	return (

--- a/apps/docs/content/docs/05.components/02.composables/04.callout.md
+++ b/apps/docs/content/docs/05.components/02.composables/04.callout.md
@@ -65,7 +65,7 @@ Import the `callout` runtime function from the virtual module and pass variant p
 
 ```vue [src/components/Callout.vue]
 <script setup lang="ts">
-import { callout } from "virtual:styleframe";
+import { callout, type CalloutProps } from "virtual:styleframe";
 
 const {
 	color = "neutral",
@@ -75,15 +75,7 @@ const {
 	title,
 	description,
 	dismissible = false,
-} = defineProps<{
-	color?: "primary" | "secondary" | "success" | "info" | "warning" | "error" | "light" | "dark" | "neutral";
-	variant?: "solid" | "outline" | "soft" | "subtle";
-	size?: "sm" | "md" | "lg";
-	orientation?: "horizontal" | "vertical";
-	title?: string;
-	description?: string;
-	dismissible?: boolean;
-}>();
+} = defineProps<CalloutProps & { title?: string; description?: string; dismissible?: boolean }>();
 
 const emit = defineEmits<{
 	dismiss: [];
@@ -108,13 +100,9 @@ const emit = defineEmits<{
 #react
 
 ```ts [src/components/Callout.tsx]
-import { callout } from "virtual:styleframe";
+import { callout, type CalloutProps } from "virtual:styleframe";
 
-interface CalloutProps {
-	color?: "primary" | "secondary" | "success" | "info" | "warning" | "error" | "light" | "dark" | "neutral";
-	variant?: "solid" | "outline" | "soft" | "subtle";
-	size?: "sm" | "md" | "lg";
-	orientation?: "horizontal" | "vertical";
+interface CalloutComponentProps extends CalloutProps {
 	title?: string;
 	description?: string;
 	icon?: React.ReactNode;
@@ -134,7 +122,7 @@ export function Callout({
 	dismissible = false,
 	onDismiss,
 	children,
-}: CalloutProps) {
+}: CalloutComponentProps) {
 	const classes = callout({ color, variant, size, orientation });
 
 	return (

--- a/apps/docs/content/docs/05.components/02.composables/05.card.md
+++ b/apps/docs/content/docs/05.components/02.composables/05.card.md
@@ -73,17 +73,13 @@ Import the `card`, `cardHeader`, `cardBody`, and `cardFooter` runtime functions 
 
 ```vue [src/components/Card.vue]
 <script setup lang="ts">
-import { card, cardHeader, cardBody, cardFooter } from "virtual:styleframe";
+import { card, cardHeader, cardBody, cardFooter, type CardProps } from "virtual:styleframe";
 
 const {
 	color = "neutral",
 	variant = "solid",
 	size = "md",
-} = defineProps<{
-	color?: "light" | "dark" | "neutral";
-	variant?: "solid" | "soft" | "subtle";
-	size?: "sm" | "md" | "lg";
-}>();
+} = defineProps<CardProps>();
 </script>
 
 <template>
@@ -104,17 +100,7 @@ const {
 #react
 
 ```ts [src/components/Card.tsx]
-import { card, cardHeader, cardBody, cardFooter } from "virtual:styleframe";
-
-interface CardProps {
-	color?: "light" | "dark" | "neutral";
-	variant?: "solid" | "soft" | "subtle";
-	size?: "sm" | "md" | "lg";
-	title?: string;
-	description?: string;
-	footer?: React.ReactNode;
-	children?: React.ReactNode;
-}
+import { card, cardHeader, cardBody, cardFooter, type CardProps } from "virtual:styleframe";
 
 export function Card({
 	color = "neutral",
@@ -124,7 +110,7 @@ export function Card({
 	description,
 	footer,
 	children,
-}: CardProps) {
+}: CardProps & { title?: string; description?: string; footer?: React.ReactNode; children?: React.ReactNode }) {
 	return (
 		<div className={card({ color, variant, size })}>
 			{title && (

--- a/apps/docs/content/docs/05.components/02.composables/06.nav.md
+++ b/apps/docs/content/docs/05.components/02.composables/06.nav.md
@@ -66,15 +66,12 @@ Import the `nav` and `navItem` runtime functions from the virtual module and pas
 
 ```vue [src/components/Nav.vue]
 <script setup lang="ts">
-import { nav } from "virtual:styleframe";
+import { nav, type NavProps } from "virtual:styleframe";
 
 const {
 	orientation = "horizontal",
 	size = "md",
-} = defineProps<{
-	orientation?: "horizontal" | "vertical";
-	size?: "sm" | "md" | "lg";
-}>();
+} = defineProps<NavProps>();
 </script>
 
 <template>
@@ -86,7 +83,7 @@ const {
 
 ```vue [src/components/NavItem.vue]
 <script setup lang="ts">
-import { navItem } from "virtual:styleframe";
+import { navItem, type NavItemProps } from "virtual:styleframe";
 
 const {
 	color = "neutral",
@@ -95,14 +92,7 @@ const {
 	active = false,
 	disabled = false,
 	href,
-} = defineProps<{
-	color?: "light" | "dark" | "neutral";
-	variant?: "ghost" | "link";
-	size?: "sm" | "md" | "lg";
-	active?: boolean;
-	disabled?: boolean;
-	href?: string;
-}>();
+} = defineProps<NavItemProps & { href?: string }>();
 </script>
 
 <template>
@@ -120,29 +110,13 @@ const {
 #react
 
 ```ts [src/components/Nav.tsx]
-import { nav, navItem } from "virtual:styleframe";
-
-interface NavItemProps {
-	color?: "light" | "dark" | "neutral";
-	variant?: "ghost" | "link";
-	size?: "sm" | "md" | "lg";
-	active?: boolean;
-	disabled?: boolean;
-	href?: string;
-	children?: React.ReactNode;
-}
-
-interface NavProps {
-	orientation?: "horizontal" | "vertical";
-	size?: "sm" | "md" | "lg";
-	children?: React.ReactNode;
-}
+import { nav, navItem, type NavProps, type NavItemProps } from "virtual:styleframe";
 
 export function Nav({
 	orientation = "horizontal",
 	size = "md",
 	children,
-}: NavProps) {
+}: NavProps & { children?: React.ReactNode }) {
 	return (
 		<nav className={nav({ orientation, size })}>
 			{children}
@@ -158,7 +132,7 @@ export function NavItem({
 	disabled = false,
 	href,
 	children,
-}: NavItemProps) {
+}: NavItemProps & { href?: string; children?: React.ReactNode }) {
 	return (
 		<a
 			href={href}

--- a/apps/docs/content/docs/05.components/02.composables/07.modal.md
+++ b/apps/docs/content/docs/05.components/02.composables/07.modal.md
@@ -75,17 +75,13 @@ Import the `modal`, `modalHeader`, `modalBody`, `modalFooter`, and `modalOverlay
 
 ```vue [src/components/Modal.vue]
 <script setup lang="ts">
-import { modal, modalHeader, modalBody, modalFooter, modalOverlay } from "virtual:styleframe";
+import { modal, modalHeader, modalBody, modalFooter, modalOverlay, type ModalProps } from "virtual:styleframe";
 
 const {
 	color = "neutral",
 	variant = "solid",
 	size = "md",
-} = defineProps<{
-	color?: "light" | "dark" | "neutral";
-	variant?: "solid" | "soft" | "subtle";
-	size?: "sm" | "md" | "lg";
-}>();
+} = defineProps<ModalProps>();
 
 const emit = defineEmits<{
 	close: [];
@@ -119,19 +115,7 @@ const emit = defineEmits<{
 #react
 
 ```ts [src/components/Modal.tsx]
-import { modal, modalHeader, modalBody, modalFooter, modalOverlay } from "virtual:styleframe";
-
-interface ModalProps {
-	color?: "light" | "dark" | "neutral";
-	variant?: "solid" | "soft" | "subtle";
-	size?: "sm" | "md" | "lg";
-	open?: boolean;
-	title?: string;
-	description?: string;
-	footer?: React.ReactNode;
-	children?: React.ReactNode;
-	onClose?: () => void;
-}
+import { modal, modalHeader, modalBody, modalFooter, modalOverlay, type ModalProps } from "virtual:styleframe";
 
 export function Modal({
 	color = "neutral",
@@ -143,7 +127,7 @@ export function Modal({
 	footer,
 	children,
 	onClose,
-}: ModalProps) {
+}: ModalProps & { open?: boolean; title?: string; description?: string; footer?: React.ReactNode; children?: React.ReactNode; onClose?: () => void }) {
 	if (!open) return null;
 
 	return (

--- a/apps/docs/content/docs/05.components/02.composables/08.skeleton.md
+++ b/apps/docs/content/docs/05.components/02.composables/08.skeleton.md
@@ -66,15 +66,12 @@ Import the `skeleton` runtime function from the virtual module and pass variant 
 
 ```vue [src/components/Skeleton.vue]
 <script setup lang="ts">
-import { skeleton } from "virtual:styleframe";
+import { skeleton, type SkeletonProps } from "virtual:styleframe";
 
 const {
 	size = "md",
 	rounded = false,
-} = defineProps<{
-	size?: "xs" | "sm" | "md" | "lg" | "xl";
-	rounded?: boolean;
-}>();
+} = defineProps<SkeletonProps>();
 </script>
 
 <template>
@@ -88,19 +85,13 @@ const {
 #react
 
 ```ts [src/components/Skeleton.tsx]
-import { skeleton } from "virtual:styleframe";
-
-interface SkeletonProps {
-	size?: "xs" | "sm" | "md" | "lg" | "xl";
-	rounded?: boolean;
-	className?: string;
-}
+import { skeleton, type SkeletonProps } from "virtual:styleframe";
 
 export function Skeleton({
 	size = "md",
 	rounded = false,
 	className,
-}: SkeletonProps) {
+}: SkeletonProps & { className?: string }) {
 	return (
 		<div
 			className={`${skeleton({ size, rounded: String(rounded) })} ${className ?? ""}`}

--- a/apps/docs/content/docs/05.components/02.composables/08.tooltip.md
+++ b/apps/docs/content/docs/05.components/02.composables/08.tooltip.md
@@ -70,15 +70,10 @@ Import the `tooltip` and `tooltipArrow` runtime functions from the virtual modul
 ```vue [src/components/Tooltip.vue]
 <script setup lang="ts">
 import { computed } from "vue";
-import { tooltip, tooltipArrow } from "virtual:styleframe";
+import { tooltip, tooltipArrow, type TooltipProps } from "virtual:styleframe";
 
 const props = withDefaults(
-	defineProps<{
-		color?: "light" | "dark" | "neutral";
-		variant?: "solid" | "soft" | "subtle";
-		size?: "sm" | "md" | "lg";
-		label?: string;
-	}>(),
+	defineProps<TooltipProps & { label?: string }>(),
 	{},
 );
 
@@ -111,12 +106,9 @@ const arrowClasses = computed(() =>
 #react
 
 ```ts [src/components/Tooltip.tsx]
-import { tooltip, tooltipArrow } from "virtual:styleframe";
+import { tooltip, tooltipArrow, type TooltipProps } from "virtual:styleframe";
 
-interface TooltipProps {
-	color?: "light" | "dark" | "neutral";
-	variant?: "solid" | "soft" | "subtle";
-	size?: "sm" | "md" | "lg";
+interface TooltipComponentProps extends TooltipProps {
 	label?: string;
 	children?: React.ReactNode;
 }
@@ -127,7 +119,7 @@ export function Tooltip({
 	size = "md",
 	label,
 	children,
-}: TooltipProps) {
+}: TooltipComponentProps) {
 	return (
 		<div className="tooltip-wrapper">
 			<span

--- a/apps/docs/content/docs/05.components/02.composables/10.progress.md
+++ b/apps/docs/content/docs/05.components/02.composables/10.progress.md
@@ -69,18 +69,10 @@ Import the `progress` and `progressBar` runtime functions from the virtual modul
 ```vue [src/components/Progress.vue]
 <script setup lang="ts">
 import { computed } from "vue";
-import { progress, progressBar } from "virtual:styleframe";
+import { progress, progressBar, type ProgressProps, type ProgressBarProps } from "virtual:styleframe";
 
 const props = withDefaults(
-	defineProps<{
-		color?: "primary" | "secondary" | "success" | "info" | "warning" | "error" | "light" | "dark" | "neutral";
-		trackColor?: "light" | "dark" | "neutral";
-		size?: "xs" | "sm" | "md" | "lg" | "xl";
-		orientation?: "horizontal" | "vertical";
-		inverted?: boolean;
-		animation?: "none" | "carousel" | "carousel-inverse" | "swing" | "elastic";
-		value?: number | null;
-	}>(),
+	defineProps<ProgressProps & ProgressBarProps & { trackColor?: "light" | "dark" | "neutral"; value?: number | null }>(),
 	{ color: "primary", trackColor: "neutral", value: 0, animation: "none" },
 );
 
@@ -124,15 +116,10 @@ const fillStyle = computed(() => {
 #react
 
 ```ts [src/components/Progress.tsx]
-import { progress, progressBar } from "virtual:styleframe";
+import { progress, progressBar, type ProgressProps, type ProgressBarProps } from "virtual:styleframe";
 
-interface ProgressProps {
-	color?: "primary" | "secondary" | "success" | "info" | "warning" | "error" | "light" | "dark" | "neutral";
+interface ProgressComponentProps extends ProgressProps, ProgressBarProps {
 	trackColor?: "light" | "dark" | "neutral";
-	size?: "xs" | "sm" | "md" | "lg" | "xl";
-	orientation?: "horizontal" | "vertical";
-	inverted?: boolean;
-	animation?: "none" | "carousel" | "carousel-inverse" | "swing" | "elastic";
 	value?: number | null;
 }
 
@@ -144,7 +131,7 @@ export function Progress({
 	inverted = false,
 	animation = "none",
 	value = 0,
-}: ProgressProps) {
+}: ProgressComponentProps) {
 	const isIndeterminate = value == null;
 	const clampedValue = isIndeterminate ? 50 : Math.min(100, Math.max(0, value));
 	const fillProp = orientation === "vertical" ? "height" : "width";

--- a/apps/docs/content/docs/05.components/02.composables/11.popover.md
+++ b/apps/docs/content/docs/05.components/02.composables/11.popover.md
@@ -76,16 +76,9 @@ Import the `popover`, `popoverHeader`, `popoverBody`, `popoverFooter`, and `popo
 ```vue [src/components/Popover.vue]
 <script setup lang="ts">
 import { computed } from "vue";
-import { popover, popoverHeader, popoverBody, popoverFooter, popoverArrow } from "virtual:styleframe";
+import { popover, popoverHeader, popoverBody, popoverFooter, popoverArrow, type PopoverProps } from "virtual:styleframe";
 
-const props = withDefaults(
-	defineProps<{
-		color?: "light" | "dark" | "neutral";
-		variant?: "solid" | "soft" | "subtle";
-		size?: "sm" | "md" | "lg";
-	}>(),
-	{},
-);
+const props = defineProps<PopoverProps>();
 
 const classes = computed(() => popover({ color: props.color, variant: props.variant, size: props.size }));
 const headerClasses = computed(() => popoverHeader({ color: props.color, variant: props.variant, size: props.size }));
@@ -115,16 +108,7 @@ const arrowClasses = computed(() => popoverArrow({ color: props.color, variant: 
 #react
 
 ```ts [src/components/Popover.tsx]
-import { popover, popoverHeader, popoverBody, popoverFooter, popoverArrow } from "virtual:styleframe";
-
-interface PopoverProps {
-	color?: "light" | "dark" | "neutral";
-	variant?: "solid" | "soft" | "subtle";
-	size?: "sm" | "md" | "lg";
-	title?: string;
-	children?: React.ReactNode;
-	footer?: React.ReactNode;
-}
+import { popover, popoverHeader, popoverBody, popoverFooter, popoverArrow, type PopoverProps } from "virtual:styleframe";
 
 export function Popover({
 	color = "neutral",
@@ -133,7 +117,7 @@ export function Popover({
 	title,
 	children,
 	footer,
-}: PopoverProps) {
+}: PopoverProps & { title?: string; children?: React.ReactNode; footer?: React.ReactNode }) {
 	return (
 		<div className="popover-wrapper">
 			<div className={popover({ color, variant, size })}>

--- a/apps/docs/content/docs/05.components/02.composables/12.chip.md
+++ b/apps/docs/content/docs/05.components/02.composables/12.chip.md
@@ -67,17 +67,10 @@ Import the `chip` and `chipIndicator` runtime functions from the virtual module 
 
 ```vue [src/components/Chip.vue]
 <script setup lang="ts">
-import { chip, chipIndicator } from "virtual:styleframe";
+import { chip, chipIndicator, type ChipProps, type ChipIndicatorProps } from "virtual:styleframe";
 
 const props = withDefaults(
-	defineProps<{
-		color?: "primary" | "secondary" | "success" | "info" | "warning" | "error" | "light" | "dark" | "neutral";
-		variant?: "solid" | "soft";
-		size?: "xs" | "sm" | "md" | "lg" | "xl";
-		position?: "top-right" | "top-left" | "bottom-right" | "bottom-left";
-		inset?: boolean;
-		text?: string;
-	}>(),
+	defineProps<ChipProps & ChipIndicatorProps & { text?: string }>(),
 	{ color: "primary", variant: "solid", size: "md", position: "top-right", inset: false },
 );
 </script>
@@ -103,17 +96,7 @@ const props = withDefaults(
 #react
 
 ```ts [src/components/Chip.tsx]
-import { chip, chipIndicator } from "virtual:styleframe";
-
-interface ChipProps {
-	color?: "primary" | "secondary" | "success" | "info" | "warning" | "error" | "light" | "dark" | "neutral";
-	variant?: "solid" | "soft";
-	size?: "xs" | "sm" | "md" | "lg" | "xl";
-	position?: "top-right" | "top-left" | "bottom-right" | "bottom-left";
-	inset?: boolean;
-	text?: string;
-	children?: React.ReactNode;
-}
+import { chip, chipIndicator, type ChipProps, type ChipIndicatorProps } from "virtual:styleframe";
 
 export function Chip({
 	color = "primary",
@@ -123,7 +106,7 @@ export function Chip({
 	inset = false,
 	text,
 	children,
-}: ChipProps) {
+}: ChipProps & ChipIndicatorProps & { text?: string; children?: React.ReactNode }) {
 	return (
 		<div className={chip()}>
 			{children}

--- a/apps/docs/content/docs/05.components/02.composables/13.spinner.md
+++ b/apps/docs/content/docs/05.components/02.composables/13.spinner.md
@@ -66,13 +66,9 @@ Import the `spinner` and `spinnerCircle` runtime functions from the virtual modu
 
 ```vue [src/components/Spinner.vue]
 <script setup lang="ts">
-import { spinner, spinnerCircle } from "virtual:styleframe";
+import { spinner, spinnerCircle, type SpinnerProps } from "virtual:styleframe";
 
-const { color = "primary", size = "md", label } = defineProps<{
-	color?: "primary" | "light" | "dark" | "neutral";
-	size?: "auto" | "sm" | "md" | "lg";
-	label?: string;
-}>();
+const { color = "primary", size = "md", label } = defineProps<SpinnerProps & { label?: string }>();
 </script>
 
 <template>
@@ -89,11 +85,9 @@ const { color = "primary", size = "md", label } = defineProps<{
 #react
 
 ```ts [src/components/Spinner.tsx]
-import { spinner, spinnerCircle } from "virtual:styleframe";
+import { spinner, spinnerCircle, type SpinnerProps } from "virtual:styleframe";
 
-interface SpinnerProps {
-	color?: "primary" | "light" | "dark" | "neutral";
-	size?: "auto" | "sm" | "md" | "lg";
+interface SpinnerComponentProps extends SpinnerProps {
 	label?: string;
 	children?: React.ReactNode;
 }
@@ -103,7 +97,7 @@ export function Spinner({
 	size = "md",
 	label,
 	children,
-}: SpinnerProps) {
+}: SpinnerComponentProps) {
 	const containerClasses = spinner({ color, size });
 	const circleClasses = spinnerCircle({ size });
 

--- a/apps/docs/content/docs/05.components/02.composables/14.dropdown.md
+++ b/apps/docs/content/docs/05.components/02.composables/14.dropdown.md
@@ -81,17 +81,14 @@ import {
     dropdownSeparator,
     dropdownLabel,
     dropdownArrow,
+    type DropdownProps,
 } from "virtual:styleframe";
 
 const {
     color = "neutral",
     variant = "solid",
     size = "md",
-} = defineProps<{
-    color?: "light" | "dark" | "neutral";
-    variant?: "solid" | "soft" | "subtle";
-    size?: "sm" | "md" | "lg";
-}>();
+} = defineProps<DropdownProps>();
 </script>
 
 <template>
@@ -122,12 +119,10 @@ import {
     dropdownSeparator,
     dropdownLabel,
     dropdownArrow,
+    type DropdownProps,
 } from "virtual:styleframe";
 
-interface DropdownProps {
-    color?: "light" | "dark" | "neutral";
-    variant?: "solid" | "soft" | "subtle";
-    size?: "sm" | "md" | "lg";
+interface DropdownComponentProps extends DropdownProps {
     children?: React.ReactNode;
 }
 
@@ -136,7 +131,7 @@ export function Dropdown({
     variant = "solid",
     size = "md",
     children,
-}: DropdownProps) {
+}: DropdownComponentProps) {
     return (
         <div role="menu" className={dropdown({ color, variant, size })}>
             {children}
@@ -144,7 +139,7 @@ export function Dropdown({
     );
 }
 
-interface DropdownItemProps extends DropdownProps {
+interface DropdownItemProps extends DropdownComponentProps {
     disabled?: boolean;
     onClick?: () => void;
 }

--- a/apps/docs/content/docs/05.components/02.composables/14.hamburger-menu.md
+++ b/apps/docs/content/docs/05.components/02.composables/14.hamburger-menu.md
@@ -66,26 +66,14 @@ Import the `hamburgerMenu` runtime function from the virtual module, manage `act
 ```vue [src/components/HamburgerMenu.vue]
 <script setup lang="ts">
 import { computed, ref } from "vue";
-import { hamburgerMenu } from "virtual:styleframe";
+import { hamburgerMenu, type HamburgerMenuProps } from "virtual:styleframe";
 
 const {
 	color = "neutral",
 	size = "md",
 	animation = "close",
 	label = "Toggle menu",
-} = defineProps<{
-	color?: "light" | "dark" | "neutral";
-	size?: "sm" | "md" | "lg";
-	animation?:
-		| "close"
-		| "arrow-up"
-		| "arrow-down"
-		| "arrow-left"
-		| "arrow-right"
-		| "minus"
-		| "plus";
-	label?: string;
-}>();
+} = defineProps<HamburgerMenuProps & { label?: string }>();
 
 const active = ref(false);
 const classes = computed(() =>
@@ -115,19 +103,9 @@ const classes = computed(() =>
 
 ```tsx [src/components/HamburgerMenu.tsx]
 import { useState } from "react";
-import { hamburgerMenu } from "virtual:styleframe";
+import { hamburgerMenu, type HamburgerMenuProps } from "virtual:styleframe";
 
-interface HamburgerMenuProps {
-	color?: "light" | "dark" | "neutral";
-	size?: "sm" | "md" | "lg";
-	animation?:
-		| "close"
-		| "arrow-up"
-		| "arrow-down"
-		| "arrow-left"
-		| "arrow-right"
-		| "minus"
-		| "plus";
+interface HamburgerMenuComponentProps extends HamburgerMenuProps {
 	label?: string;
 	onToggle?: (active: boolean) => void;
 }
@@ -138,7 +116,7 @@ export function HamburgerMenu({
 	animation = "close",
 	label = "Toggle menu",
 	onToggle,
-}: HamburgerMenuProps) {
+}: HamburgerMenuComponentProps) {
 	const [active, setActive] = useState(false);
 	const toggle = () => {
 		const next = !active;

--- a/apps/docs/content/docs/05.components/02.composables/15.breadcrumb.md
+++ b/apps/docs/content/docs/05.components/02.composables/15.breadcrumb.md
@@ -66,11 +66,9 @@ Import the `breadcrumb` and `breadcrumbItem` runtime functions from the virtual 
 
 ```vue [src/components/Breadcrumb.vue]
 <script setup lang="ts">
-import { breadcrumb } from "virtual:styleframe";
+import { breadcrumb, type BreadcrumbProps } from "virtual:styleframe";
 
-const { size = "md" } = defineProps<{
-	size?: "sm" | "md" | "lg";
-}>();
+const { size = "md" } = defineProps<BreadcrumbProps>();
 </script>
 
 <template>
@@ -83,7 +81,7 @@ const { size = "md" } = defineProps<{
 ```vue [src/components/BreadcrumbItem.vue]
 <script setup lang="ts">
 import { computed } from "vue";
-import { breadcrumbItem } from "virtual:styleframe";
+import { breadcrumbItem, type BreadcrumbItemProps } from "virtual:styleframe";
 
 const {
 	color = "neutral",
@@ -91,13 +89,7 @@ const {
 	active = false,
 	disabled = false,
 	href,
-} = defineProps<{
-	color?: "light" | "dark" | "neutral";
-	size?: "sm" | "md" | "lg";
-	active?: boolean;
-	disabled?: boolean;
-	href?: string;
-}>();
+} = defineProps<BreadcrumbItemProps & { href?: string }>();
 
 const tag = computed(() => (active ? "span" : "a"));
 </script>
@@ -119,23 +111,9 @@ const tag = computed(() => (active ? "span" : "a"));
 #react
 
 ```ts [src/components/Breadcrumb.tsx]
-import { breadcrumb, breadcrumbItem } from "virtual:styleframe";
+import { breadcrumb, breadcrumbItem, type BreadcrumbProps, type BreadcrumbItemProps } from "virtual:styleframe";
 
-interface BreadcrumbProps {
-	size?: "sm" | "md" | "lg";
-	children?: React.ReactNode;
-}
-
-interface BreadcrumbItemProps {
-	color?: "light" | "dark" | "neutral";
-	size?: "sm" | "md" | "lg";
-	active?: boolean;
-	disabled?: boolean;
-	href?: string;
-	children?: React.ReactNode;
-}
-
-export function Breadcrumb({ size = "md", children }: BreadcrumbProps) {
+export function Breadcrumb({ size = "md", children }: BreadcrumbProps & { children?: React.ReactNode }) {
 	return (
 		<nav aria-label="Breadcrumb" className={breadcrumb({ size })}>
 			{children}
@@ -150,7 +128,7 @@ export function BreadcrumbItem({
 	disabled = false,
 	href,
 	children,
-}: BreadcrumbItemProps) {
+}: BreadcrumbItemProps & { href?: string; children?: React.ReactNode }) {
 	const className = breadcrumbItem({
 		color,
 		size,

--- a/apps/docs/content/docs/05.components/02.composables/15.media.md
+++ b/apps/docs/content/docs/05.components/02.composables/15.media.md
@@ -73,17 +73,13 @@ Import the `media`, `mediaFigure`, `mediaBody`, and `mediaTitle` runtime functio
 
 ```vue [src/components/Media.vue]
 <script setup lang="ts">
-import { media, mediaFigure, mediaBody, mediaTitle } from "virtual:styleframe";
+import { media, mediaFigure, mediaBody, mediaTitle, type MediaProps } from "virtual:styleframe";
 
 const {
 	orientation = "horizontal",
 	align = "start",
 	size = "md",
-} = defineProps<{
-	orientation?: "horizontal" | "vertical";
-	align?: "start" | "center" | "end";
-	size?: "sm" | "md" | "lg";
-}>();
+} = defineProps<MediaProps>();
 </script>
 
 <template>
@@ -104,16 +100,7 @@ const {
 #react
 
 ```ts [src/components/Media.tsx]
-import { media, mediaFigure, mediaBody, mediaTitle } from "virtual:styleframe";
-
-interface MediaProps {
-	orientation?: "horizontal" | "vertical";
-	align?: "start" | "center" | "end";
-	size?: "sm" | "md" | "lg";
-	figure?: React.ReactNode;
-	title?: string;
-	children?: React.ReactNode;
-}
+import { media, mediaFigure, mediaBody, mediaTitle, type MediaProps } from "virtual:styleframe";
 
 export function Media({
 	orientation = "horizontal",
@@ -122,7 +109,7 @@ export function Media({
 	figure,
 	title,
 	children,
-}: MediaProps) {
+}: MediaProps & { figure?: React.ReactNode; title?: string; children?: React.ReactNode }) {
 	return (
 		<div className={media({ orientation, align, size })}>
 			{figure && (

--- a/apps/docs/content/docs/05.components/02.composables/15.page-hero.md
+++ b/apps/docs/content/docs/05.components/02.composables/15.page-hero.md
@@ -88,6 +88,7 @@ import {
     pageHeroTitle,
     pageHeroDescription,
     pageHeroActions,
+    type PageHeroProps,
 } from "virtual:styleframe";
 
 const {
@@ -97,14 +98,7 @@ const {
     alignment = "center",
     title,
     description,
-} = defineProps<{
-    color?: "light" | "dark" | "neutral";
-    size?: "sm" | "md" | "lg";
-    orientation?: "vertical" | "horizontal";
-    alignment?: "start" | "center";
-    title: string;
-    description?: string;
-}>();
+} = defineProps<PageHeroProps & { title: string; description?: string }>();
 </script>
 
 <template>
@@ -133,17 +127,8 @@ import {
     pageHeroTitle,
     pageHeroDescription,
     pageHeroActions,
+    type PageHeroProps,
 } from "virtual:styleframe";
-
-interface PageHeroProps {
-    color?: "light" | "dark" | "neutral";
-    size?: "sm" | "md" | "lg";
-    orientation?: "vertical" | "horizontal";
-    alignment?: "start" | "center";
-    title: string;
-    description?: string;
-    children?: React.ReactNode;
-}
 
 export function PageHero({
     color = "neutral",
@@ -153,7 +138,7 @@ export function PageHero({
     title,
     description,
     children,
-}: PageHeroProps) {
+}: PageHeroProps & { title: string; description?: string; children?: React.ReactNode }) {
     return (
         <section className={pageHero({ color, size, orientation, alignment })}>
             <div className={pageHeroBackdrop({ variant: "gradient" })} aria-hidden />

--- a/apps/docs/content/docs/05.components/02.composables/15.pagination.md
+++ b/apps/docs/content/docs/05.components/02.composables/15.pagination.md
@@ -71,15 +71,12 @@ Import the `pagination`, `paginationItem`, and `paginationEllipsis` runtime func
 
 ```vue [src/components/Pagination.vue]
 <script setup lang="ts">
-import { pagination } from "virtual:styleframe";
+import { pagination, type PaginationProps } from "virtual:styleframe";
 
 const {
     orientation = "horizontal",
     size = "md",
-} = defineProps<{
-    orientation?: "horizontal" | "vertical";
-    size?: "sm" | "md" | "lg";
-}>();
+} = defineProps<PaginationProps>();
 </script>
 
 <template>
@@ -95,7 +92,7 @@ const {
 
 ```vue [src/components/PaginationItem.vue]
 <script setup lang="ts">
-import { paginationItem } from "virtual:styleframe";
+import { paginationItem, type PaginationItemProps } from "virtual:styleframe";
 
 const {
     color = "neutral",
@@ -104,14 +101,7 @@ const {
     active = false,
     disabled = false,
     href,
-} = defineProps<{
-    color?: "light" | "dark" | "neutral";
-    variant?: "solid" | "outline" | "soft" | "subtle" | "ghost" | "link";
-    size?: "sm" | "md" | "lg";
-    active?: boolean;
-    disabled?: boolean;
-    href?: string;
-}>();
+} = defineProps<PaginationItemProps & { href?: string }>();
 </script>
 
 <template>
@@ -138,11 +128,9 @@ const {
 
 ```vue [src/components/PaginationEllipsis.vue]
 <script setup lang="ts">
-import { paginationEllipsis } from "virtual:styleframe";
+import { paginationEllipsis, type PaginationEllipsisProps } from "virtual:styleframe";
 
-const { size = "md" } = defineProps<{
-    size?: "sm" | "md" | "lg";
-}>();
+const { size = "md" } = defineProps<PaginationEllipsisProps>();
 </script>
 
 <template>
@@ -153,30 +141,13 @@ const { size = "md" } = defineProps<{
 #react
 
 ```ts [src/components/Pagination.tsx]
-import { pagination, paginationItem, paginationEllipsis } from "virtual:styleframe";
-
-interface PaginationProps {
-    orientation?: "horizontal" | "vertical";
-    size?: "sm" | "md" | "lg";
-    children?: React.ReactNode;
-}
-
-interface PaginationItemProps {
-    color?: "light" | "dark" | "neutral";
-    variant?: "solid" | "outline" | "soft" | "subtle" | "ghost" | "link";
-    size?: "sm" | "md" | "lg";
-    active?: boolean;
-    disabled?: boolean;
-    href?: string;
-    "aria-label"?: string;
-    children?: React.ReactNode;
-}
+import { pagination, paginationItem, paginationEllipsis, type PaginationProps, type PaginationItemProps, type PaginationEllipsisProps } from "virtual:styleframe";
 
 export function Pagination({
     orientation = "horizontal",
     size = "md",
     children,
-}: PaginationProps) {
+}: PaginationProps & { children?: React.ReactNode }) {
     return (
         <nav
             className={pagination({ orientation, size })}
@@ -197,7 +168,7 @@ export function PaginationItem({
     href,
     children,
     ...rest
-}: PaginationItemProps) {
+}: PaginationItemProps & { href?: string; "aria-label"?: string; children?: React.ReactNode }) {
     const classes = paginationItem({
         color,
         variant,
@@ -220,7 +191,7 @@ export function PaginationItem({
     );
 }
 
-export function PaginationEllipsis({ size = "md" }: { size?: "sm" | "md" | "lg" }) {
+export function PaginationEllipsis({ size = "md" }: PaginationEllipsisProps) {
     return (
         <span className={paginationEllipsis({ size })} aria-hidden="true">
             …

--- a/engine/transpiler/src/consume/dts/recipe.test.ts
+++ b/engine/transpiler/src/consume/dts/recipe.test.ts
@@ -38,7 +38,12 @@ describe("createRecipeConsumer (dts)", () => {
 
 		const result = consumeRecipe(instance, options);
 
-		expect(result).toContain('disabled?: "true" | "false" | boolean');
+		expect(result).toContain(
+			'export type ButtonProps = { disabled?: "true" | "false" | boolean }',
+		);
+		expect(result).toContain(
+			"export const button: (props?: ButtonProps) => string;",
+		);
 	});
 
 	it("should not include boolean when variant has only true key", () => {
@@ -58,6 +63,7 @@ describe("createRecipeConsumer (dts)", () => {
 
 		expect(result).toContain('rounded?: "true"');
 		expect(result).not.toContain("boolean");
+		expect(result).toContain("(props?: ButtonProps) => string;");
 	});
 
 	it("should not include boolean for normal string variants", () => {
@@ -77,7 +83,10 @@ describe("createRecipeConsumer (dts)", () => {
 
 		const result = consumeRecipe(instance, options);
 
-		expect(result).toContain('size?: "sm" | "md" | "lg"');
+		expect(result).toContain(
+			'export type ButtonProps = { size?: "sm" | "md" | "lg" }',
+		);
+		expect(result).toContain("(props?: ButtonProps) => string;");
 		expect(result).not.toContain("boolean");
 	});
 
@@ -104,5 +113,76 @@ describe("createRecipeConsumer (dts)", () => {
 
 		expect(result).toContain('disabled?: "true" | "false" | boolean');
 		expect(result).toContain('size?: "sm" | "md"');
+		expect(result).toContain("(props?: ButtonProps) => string;");
+	});
+
+	it("should generate PascalCase props type name from export name", () => {
+		utility("padding", ({ value }) => ({ padding: value }));
+
+		const instance = recipe({
+			name: "card-header",
+			base: {},
+			variants: {
+				size: {
+					sm: { padding: "1rem" },
+				},
+			},
+		});
+
+		const result = consumeRecipe(instance, options);
+
+		expect(result).toContain("export type CardHeaderProps =");
+		expect(result).toContain("(props?: CardHeaderProps) => string;");
+	});
+
+	it("should handle PascalCase export names", () => {
+		const instance = recipe({
+			name: "PrimaryButton",
+			base: {},
+			variants: {},
+		});
+
+		const result = consumeRecipe(instance, options);
+
+		expect(result).toContain("export type PrimaryButtonProps =");
+		expect(result).toContain("(props?: PrimaryButtonProps) => string;");
+	});
+
+	it("should generate props type from _exportName when set", () => {
+		utility("padding", ({ value }) => ({ padding: value }));
+
+		const instance = recipe({
+			name: "my-tab",
+			base: {},
+			variants: {
+				state: {
+					active: { padding: "1rem" },
+					inactive: { padding: "0.5rem" },
+				},
+			},
+		});
+		instance._exportName = "pgTab";
+
+		const result = consumeRecipe(instance, options);
+
+		expect(result).toContain("export type PgTabProps =");
+		expect(result).toContain(
+			"export const pgTab: (props?: PgTabProps) => string;",
+		);
+	});
+
+	it("should generate empty props type for recipes without variants", () => {
+		const instance = recipe({
+			name: "divider",
+			base: {},
+			variants: {},
+		});
+
+		const result = consumeRecipe(instance, options);
+
+		expect(result).toContain(
+			"export type DividerProps = Record<string, never>;",
+		);
+		expect(result).toContain("(props?: DividerProps) => string;");
 	});
 });

--- a/engine/transpiler/src/consume/dts/recipe.ts
+++ b/engine/transpiler/src/consume/dts/recipe.ts
@@ -57,7 +57,9 @@ export function createRecipeConsumer(_consume: ConsumeFunction) {
 		}
 
 		const variantPropsType = generateVariantPropsType(instance._runtime);
+		const propsTypeName = `${capitalizeFirst(exportName)}Props`;
 
-		return `    export const ${exportName}: (props?: ${variantPropsType}) => string;`;
+		return `    export type ${propsTypeName} = ${variantPropsType};
+    export const ${exportName}: (props?: ${propsTypeName}) => string;`;
 	};
 }

--- a/engine/transpiler/src/consume/ts/recipe.test.ts
+++ b/engine/transpiler/src/consume/ts/recipe.test.ts
@@ -46,6 +46,7 @@ describe("createRecipeConsumer", () => {
     "variants": {}
 } as const satisfies RecipeRuntime;
 
+export type ButtonProps = RecipeVariantProps<typeof buttonRecipe>;
 export const button = createRecipe("button", buttonRecipe);
 `);
 	});
@@ -97,6 +98,7 @@ export const button = createRecipe("button", buttonRecipe);
     }
 } as const satisfies RecipeRuntime;
 
+export type ButtonProps = RecipeVariantProps<typeof buttonRecipe>;
 export const button = createRecipe("button", buttonRecipe);
 `);
 	});
@@ -159,6 +161,7 @@ export const button = createRecipe("button", buttonRecipe);
     }
 } as const satisfies RecipeRuntime;
 
+export type ButtonProps = RecipeVariantProps<typeof buttonRecipe>;
 export const button = createRecipe("button", buttonRecipe);
 `);
 	});
@@ -191,6 +194,7 @@ export const button = createRecipe("button", buttonRecipe);
     "variants": {}
 } as const satisfies RecipeRuntime;
 
+export type CardProps = RecipeVariantProps<typeof cardRecipe>;
 export const card = createRecipe("card", cardRecipe);
 `);
 	});
@@ -255,6 +259,7 @@ export const card = createRecipe("card", cardRecipe);
     }
 } as const satisfies RecipeRuntime;
 
+export type ChipProps = RecipeVariantProps<typeof chipRecipe>;
 export const chip = createRecipe("chip", chipRecipe);
 `);
 	});
@@ -339,6 +344,7 @@ export const chip = createRecipe("chip", chipRecipe);
     ]
 } as const satisfies RecipeRuntime;
 
+export type BadgeProps = RecipeVariantProps<typeof badgeRecipe>;
 export const badge = createRecipe("badge", badgeRecipe);
 `);
 	});
@@ -434,6 +440,7 @@ export const badge = createRecipe("badge", badgeRecipe);
     ]
 } as const satisfies RecipeRuntime;
 
+export type InputProps = RecipeVariantProps<typeof inputRecipe>;
 export const input = createRecipe("input", inputRecipe);
 `);
 	});
@@ -452,6 +459,7 @@ export const input = createRecipe("input", inputRecipe);
     "variants": {}
 } as const satisfies RecipeRuntime;
 
+export type MinimalProps = RecipeVariantProps<typeof minimalRecipe>;
 export const minimal = createRecipe("minimal", minimalRecipe);
 `);
 	});
@@ -479,6 +487,7 @@ export const minimal = createRecipe("minimal", minimalRecipe);
     "variants": {}
 } as const satisfies RecipeRuntime;
 
+export type SimpleProps = RecipeVariantProps<typeof simpleRecipe>;
 export const simple = createRecipe("simple", simpleRecipe);
 `);
 	});
@@ -503,6 +512,7 @@ export const simple = createRecipe("simple", simpleRecipe);
     "variants": {}
 } as const satisfies RecipeRuntime;
 
+export type PrimaryButtonProps = RecipeVariantProps<typeof PrimaryButtonRecipe>;
 export const PrimaryButton = createRecipe("PrimaryButton", PrimaryButtonRecipe);
 `);
 	});
@@ -525,6 +535,7 @@ export const PrimaryButton = createRecipe("PrimaryButton", PrimaryButtonRecipe);
     "variants": {}
 } as const satisfies RecipeRuntime;
 
+export type PrimaryButtonProps = RecipeVariantProps<typeof primaryButtonRecipe>;
 export const primaryButton = createRecipe("primaryButton", primaryButtonRecipe);
 `);
 	});
@@ -547,6 +558,7 @@ export const primaryButton = createRecipe("primaryButton", primaryButtonRecipe);
     "variants": {}
 } as const satisfies RecipeRuntime;
 
+export type PrimaryButtonProps = RecipeVariantProps<typeof primaryButtonRecipe>;
 export const primaryButton = createRecipe("primary-button", primaryButtonRecipe);
 `);
 	});
@@ -648,6 +660,7 @@ export const primaryButton = createRecipe("primary-button", primaryButtonRecipe)
     }
 } as const satisfies RecipeRuntime;
 
+export type AlertProps = RecipeVariantProps<typeof alertRecipe>;
 export const alert = createRecipe("alert", alertRecipe);
 `);
 	});
@@ -666,6 +679,9 @@ export const alert = createRecipe("alert", alertRecipe);
 		const result = consumeRecipe(instance, options);
 
 		expect(result).toContain("const myComponentRecipe = {");
+		expect(result).toContain(
+			"export type MyComponentProps = RecipeVariantProps<typeof myComponentRecipe>;",
+		);
 		expect(result).toContain(
 			`export const myComponent = createRecipe("myComponent", myComponentRecipe);`,
 		);
@@ -766,6 +782,7 @@ export const alert = createRecipe("alert", alertRecipe);
     "variants": {}
 } as const satisfies RecipeRuntime;
 
+export type ButtonProps = RecipeVariantProps<typeof buttonRecipe>;
 export const button = createRecipe("button", buttonRecipe);
 `);
 	});
@@ -799,6 +816,7 @@ export const button = createRecipe("button", buttonRecipe);
     }
 } as const satisfies RecipeRuntime;
 
+export type ToggleProps = RecipeVariantProps<typeof toggleRecipe>;
 export const toggle = createRecipe("toggle", toggleRecipe);
 `);
 	});
@@ -836,6 +854,7 @@ export const toggle = createRecipe("toggle", toggleRecipe);
     }
 } as const satisfies RecipeRuntime;
 
+export type PlaceholderProps = RecipeVariantProps<typeof placeholderRecipe>;
 export const placeholder = createRecipe("placeholder", placeholderRecipe);
 `);
 	});
@@ -927,6 +946,7 @@ export const placeholder = createRecipe("placeholder", placeholderRecipe);
     ]
 } as const satisfies RecipeRuntime;
 
+export type MatrixProps = RecipeVariantProps<typeof matrixRecipe>;
 export const matrix = createRecipe("matrix", matrixRecipe);
 `);
 	});
@@ -991,6 +1011,9 @@ export const matrix = createRecipe("matrix", matrixRecipe);
 		const result = consumeRecipe(instance, options);
 
 		expect(result).toContain(
+			"export type ExportedProps = RecipeVariantProps<typeof exportedRecipe>;",
+		);
+		expect(result).toContain(
 			`export const exported = createRecipe("exported", exportedRecipe);`,
 		);
 	});
@@ -1017,6 +1040,7 @@ export const matrix = createRecipe("matrix", matrixRecipe);
 			result,
 		).toEqual(`const noRuntimeRecipe = {} as const satisfies RecipeRuntime;
 
+export type NoRuntimeProps = RecipeVariantProps<typeof noRuntimeRecipe>;
 export const noRuntime = createRecipe("noRuntime", noRuntimeRecipe);
 `);
 	});

--- a/engine/transpiler/src/consume/ts/recipe.ts
+++ b/engine/transpiler/src/consume/ts/recipe.ts
@@ -27,12 +27,15 @@ export function createRecipeConsumer(_consume: ConsumeFunction) {
 		const recipeConstant = `${exportConstant}Recipe`;
 		const runtime = instance._runtime ?? {};
 
+		const propsTypeName = `${capitalizeFirst(exportConstant)}Props`;
+
 		return `const ${recipeConstant} = ${JSON.stringify(
 			runtime,
 			null,
 			4,
 		)} as const satisfies RecipeRuntime;
 
+export type ${propsTypeName} = RecipeVariantProps<typeof ${recipeConstant}>;
 export const ${exportConstant} = createRecipe("${instance.name}", ${recipeConstant});
 `;
 	};

--- a/engine/transpiler/src/consume/ts/root.test.ts
+++ b/engine/transpiler/src/consume/ts/root.test.ts
@@ -64,7 +64,7 @@ describe("createRootConsumer", () => {
 		const result = consumeRoot(root, options);
 
 		expect(result).toEqual(`import { createRecipe } from '@styleframe/runtime';
-import type { RecipeRuntime } from '@styleframe/runtime';
+import type { RecipeRuntime, RecipeVariantProps } from '@styleframe/runtime';
 
 const buttonRecipe = {
     "base": {
@@ -86,6 +86,7 @@ const buttonRecipe = {
     }
 } as const satisfies RecipeRuntime;
 
+export type ButtonProps = RecipeVariantProps<typeof buttonRecipe>;
 export const button = createRecipe("button", buttonRecipe);
 `);
 	});
@@ -116,7 +117,7 @@ export const button = createRecipe("button", buttonRecipe);
 		const result = consumeRoot(root, options);
 
 		expect(result).toEqual(`import { createRecipe } from '@styleframe/runtime';
-import type { RecipeRuntime } from '@styleframe/runtime';
+import type { RecipeRuntime, RecipeVariantProps } from '@styleframe/runtime';
 
 const buttonRecipe = {
     "base": {
@@ -134,6 +135,7 @@ const buttonRecipe = {
     }
 } as const satisfies RecipeRuntime;
 
+export type ButtonProps = RecipeVariantProps<typeof buttonRecipe>;
 export const button = createRecipe("button", buttonRecipe);
 
 const cardRecipe = {
@@ -152,6 +154,7 @@ const cardRecipe = {
     }
 } as const satisfies RecipeRuntime;
 
+export type CardProps = RecipeVariantProps<typeof cardRecipe>;
 export const card = createRecipe("card", cardRecipe);
 `);
 	});
@@ -176,7 +179,7 @@ export const card = createRecipe("card", cardRecipe);
 		const result = consumeRoot(root, options);
 
 		expect(result).toEqual(`import { createRecipe } from '@styleframe/runtime';
-import type { RecipeRuntime } from '@styleframe/runtime';
+import type { RecipeRuntime, RecipeVariantProps } from '@styleframe/runtime';
 
 const chipRecipe = {
     "base": {
@@ -208,6 +211,7 @@ const chipRecipe = {
     }
 } as const satisfies RecipeRuntime;
 
+export type ChipProps = RecipeVariantProps<typeof chipRecipe>;
 export const chip = createRecipe("chip", chipRecipe);
 `);
 	});
@@ -237,7 +241,7 @@ export const chip = createRecipe("chip", chipRecipe);
 		const result = consumeRoot(root, options);
 
 		expect(result).toEqual(`import { createRecipe } from '@styleframe/runtime';
-import type { RecipeRuntime } from '@styleframe/runtime';
+import type { RecipeRuntime, RecipeVariantProps } from '@styleframe/runtime';
 
 const badgeRecipe = {
     "base": {
@@ -274,6 +278,7 @@ const badgeRecipe = {
     ]
 } as const satisfies RecipeRuntime;
 
+export type BadgeProps = RecipeVariantProps<typeof badgeRecipe>;
 export const badge = createRecipe("badge", badgeRecipe);
 `);
 	});
@@ -304,7 +309,7 @@ export const badge = createRecipe("badge", badgeRecipe);
 		const result = consumeRoot(root, options);
 
 		expect(result).toEqual(`import { createRecipe } from '@styleframe/runtime';
-import type { RecipeRuntime } from '@styleframe/runtime';
+import type { RecipeRuntime, RecipeVariantProps } from '@styleframe/runtime';
 
 const inputRecipe = {
     "base": {
@@ -345,6 +350,7 @@ const inputRecipe = {
     ]
 } as const satisfies RecipeRuntime;
 
+export type InputProps = RecipeVariantProps<typeof inputRecipe>;
 export const input = createRecipe("input", inputRecipe);
 `);
 	});
@@ -382,7 +388,7 @@ export const input = createRecipe("input", inputRecipe);
 		const result = consumeRoot(root, options);
 
 		expect(result).toEqual(`import { createRecipe } from '@styleframe/runtime';
-import type { RecipeRuntime } from '@styleframe/runtime';
+import type { RecipeRuntime, RecipeVariantProps } from '@styleframe/runtime';
 
 const alertRecipe = {
     "base": {
@@ -412,6 +418,7 @@ const alertRecipe = {
     }
 } as const satisfies RecipeRuntime;
 
+export type AlertProps = RecipeVariantProps<typeof alertRecipe>;
 export const alert = createRecipe("alert", alertRecipe);
 `);
 	});
@@ -431,7 +438,7 @@ export const alert = createRecipe("alert", alertRecipe);
 		const result = consumeRoot(root, options);
 
 		expect(result).toEqual(`import { createRecipe } from '@styleframe/runtime';
-import type { RecipeRuntime } from '@styleframe/runtime';
+import type { RecipeRuntime, RecipeVariantProps } from '@styleframe/runtime';
 
 const minimalRecipe = {
     "base": {},
@@ -447,6 +454,7 @@ const minimalRecipe = {
     }
 } as const satisfies RecipeRuntime;
 
+export type MinimalProps = RecipeVariantProps<typeof minimalRecipe>;
 export const minimal = createRecipe("minimal", minimalRecipe);
 `);
 	});
@@ -461,7 +469,7 @@ export const minimal = createRecipe("minimal", minimalRecipe);
 		const result = consumeRoot(root, options);
 
 		expect(result).toEqual(`import { createRecipe } from '@styleframe/runtime';
-import type { RecipeRuntime } from '@styleframe/runtime';
+import type { RecipeRuntime, RecipeVariantProps } from '@styleframe/runtime';
 
 const simpleRecipe = {
     "base": {
@@ -471,6 +479,7 @@ const simpleRecipe = {
     "variants": {}
 } as const satisfies RecipeRuntime;
 
+export type SimpleProps = RecipeVariantProps<typeof simpleRecipe>;
 export const simple = createRecipe("simple", simpleRecipe);
 `);
 	});
@@ -490,7 +499,11 @@ export const simple = createRecipe("simple", simpleRecipe);
 		const result = consumeRoot(root, options);
 
 		expect(result).toContain("RecipeRuntime");
+		expect(result).toContain("RecipeVariantProps");
 		expect(result).toContain("const myRecipeRecipe = {");
+		expect(result).toContain(
+			"export type MyRecipeProps = RecipeVariantProps<typeof myRecipeRecipe>;",
+		);
 		expect(result).toContain(
 			`export const myRecipe = createRecipe("myRecipe", myRecipeRecipe);`,
 		);
@@ -516,7 +529,7 @@ export const simple = createRecipe("simple", simpleRecipe);
 		const result = consumeRoot(root, options);
 
 		expect(result).toEqual(`import { createRecipe } from '@styleframe/runtime';
-import type { RecipeRuntime } from '@styleframe/runtime';
+import type { RecipeRuntime, RecipeVariantProps } from '@styleframe/runtime';
 
 const PascalCaseRecipe = {
     "base": {},
@@ -528,6 +541,7 @@ const PascalCaseRecipe = {
     }
 } as const satisfies RecipeRuntime;
 
+export type PascalCaseProps = RecipeVariantProps<typeof PascalCaseRecipe>;
 export const PascalCase = createRecipe("PascalCase", PascalCaseRecipe);
 
 const camelCaseRecipe = {
@@ -540,6 +554,7 @@ const camelCaseRecipe = {
     }
 } as const satisfies RecipeRuntime;
 
+export type CamelCaseProps = RecipeVariantProps<typeof camelCaseRecipe>;
 export const camelCase = createRecipe("camelCase", camelCaseRecipe);
 
 const kebabCaseRecipe = {
@@ -552,6 +567,7 @@ const kebabCaseRecipe = {
     }
 } as const satisfies RecipeRuntime;
 
+export type KebabCaseProps = RecipeVariantProps<typeof kebabCaseRecipe>;
 export const kebabCase = createRecipe("kebab-case", kebabCaseRecipe);
 `);
 	});
@@ -563,7 +579,7 @@ export const kebabCase = createRecipe("kebab-case", kebabCaseRecipe);
 		const result = consumeRoot(root, options);
 
 		expect(result).toEqual(`import { createRecipe } from '@styleframe/runtime';
-import type { RecipeRuntime } from '@styleframe/runtime';
+import type { RecipeRuntime, RecipeVariantProps } from '@styleframe/runtime';
 
 const firstRecipe = {
     "base": {
@@ -572,6 +588,7 @@ const firstRecipe = {
     "variants": {}
 } as const satisfies RecipeRuntime;
 
+export type FirstProps = RecipeVariantProps<typeof firstRecipe>;
 export const first = createRecipe("first", firstRecipe);
 
 const secondRecipe = {
@@ -581,6 +598,7 @@ const secondRecipe = {
     "variants": {}
 } as const satisfies RecipeRuntime;
 
+export type SecondProps = RecipeVariantProps<typeof secondRecipe>;
 export const second = createRecipe("second", secondRecipe);
 `);
 	});
@@ -593,7 +611,7 @@ export const second = createRecipe("second", secondRecipe);
 		const result = consumeRoot(root, customOptions);
 
 		expect(result).toEqual(`import { createRecipe } from '@styleframe/runtime';
-import type { RecipeRuntime } from '@styleframe/runtime';
+import type { RecipeRuntime, RecipeVariantProps } from '@styleframe/runtime';
 
 const customizedRecipe = {
     "base": {
@@ -602,6 +620,7 @@ const customizedRecipe = {
     "variants": {}
 } as const satisfies RecipeRuntime;
 
+export type CustomizedProps = RecipeVariantProps<typeof customizedRecipe>;
 export const customized = createRecipe("customized", customizedRecipe);
 `);
 	});
@@ -616,7 +635,7 @@ export const customized = createRecipe("customized", customizedRecipe);
 		const result = consumeRoot(root, options);
 
 		expect(result).toEqual(`import { createRecipe } from '@styleframe/runtime';
-import type { RecipeRuntime } from '@styleframe/runtime';
+import type { RecipeRuntime, RecipeVariantProps } from '@styleframe/runtime';
 
 const structuredRecipe = {
     "base": {},
@@ -628,6 +647,7 @@ const structuredRecipe = {
     }
 } as const satisfies RecipeRuntime;
 
+export type StructuredProps = RecipeVariantProps<typeof structuredRecipe>;
 export const structured = createRecipe("structured", structuredRecipe);
 `);
 	});

--- a/engine/transpiler/src/consume/ts/root.ts
+++ b/engine/transpiler/src/consume/ts/root.ts
@@ -33,7 +33,7 @@ export function createRootConsumer(consume: ConsumeFunction) {
 		// Add imports and generate recipe exports
 		if (hasRecipes) {
 			parts.push(`import { createRecipe } from '@styleframe/runtime';
-import type { RecipeRuntime } from '@styleframe/runtime';
+import type { RecipeRuntime, RecipeVariantProps } from '@styleframe/runtime';
 `);
 			parts.push(consume(instance.recipes, options));
 		}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9713,8 +9713,8 @@ packages:
   vue-component-type-helpers@3.2.5:
     resolution: {integrity: sha512-tkvNr+bU8+xD/onAThIe7CHFvOJ/BO6XCOrxMzeytJq40nTfpGDJuVjyCM8ccGZKfAbGk2YfuZyDMXM56qheZQ==}
 
-  vue-component-type-helpers@3.2.8:
-    resolution: {integrity: sha512-9689efAXhN/EV86plgkL/XFiJSXhGtWPG6JDboZ+QnjlUWUUQrQ0ILKQtw4iQsuwIwu5k6Aw+JnehDe7161e7A==}
+  vue-component-type-helpers@3.2.9:
+    resolution: {integrity: sha512-S3BiWYaLSzHxTpln665ELSrMR9UYmrIDUmhik7nVZxmJjTKL2/a+ew1hvGxksKelivm0ujjWfG1fYOiU/2e8rA==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -13682,7 +13682,7 @@ snapshots:
       storybook: 10.2.13(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       type-fest: 2.19.0
       vue: 3.5.26(typescript@5.8.3)
-      vue-component-type-helpers: 3.2.8
+      vue-component-type-helpers: 3.2.9
 
   '@styleframe/license@2.0.2': {}
 
@@ -21275,7 +21275,7 @@ snapshots:
 
   vue-component-type-helpers@3.2.5: {}
 
-  vue-component-type-helpers@3.2.8: {}
+  vue-component-type-helpers@3.2.9: {}
 
   vue-demi@0.14.10(vue@3.5.26(typescript@5.8.3)):
     dependencies:


### PR DESCRIPTION
## Summary

- Each recipe now emits a companion named Props type (e.g. `ButtonProps`, `CardHeaderProps`) alongside its function export in both the TS and DTS transpiler consumers
- Consumers can import types directly: `import { button, type ButtonProps } from 'virtual:styleframe'` instead of manually duplicating variant signatures
- DTS consumer generates the expanded inline type; TS consumer uses `RecipeVariantProps<typeof xRecipe>` to avoid duplication
- Naming convention: `PascalCase(exportName) + "Props"`

## Test plan

- [x] All 832 transpiler tests pass (`pnpm --filter @styleframe/transpiler test`)
- [x] Typecheck passes (`pnpm --filter @styleframe/transpiler typecheck`)
- [x] Lint passes (oxlint on changed files)
- [ ] Verify generated `.styleframe/styleframe.d.ts` in playground/storybook shows Props types