### PR TITLE
chore(plugin): update importree from v1 to v2

### DIFF
--- a/.changeset/update-importree-v2.md
+++ b/.changeset/update-importree-v2.md
@@ -1,0 +1,6 @@
+---
+"styleframe": patch
+"@styleframe/plugin": patch
+---
+
+Update importree from v1 to v2. Adapt dependency graph merging to the new `ImportEdge[]` type in `graph` and `reverseGraph`.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1165,8 +1165,8 @@ importers:
         specifier: '*'
         version: 0.25.10
       importree:
-        specifier: ^1.0.1
-        version: 1.0.1
+        specifier: ^2.0.0
+        version: 2.0.0
       jiti:
         specifier: 'catalog:'
         version: 2.6.1
@@ -6650,8 +6650,8 @@ packages:
     resolution: {integrity: sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==}
     engines: {node: '>=8'}
 
-  importree@1.0.1:
-    resolution: {integrity: sha512-Ou/uhOL8MZagHNAWKsPyn2K+g39w0hxKELo/dAeZIgZC7/K2I5uJIzRma9y1zW0StxybIUgrhvlhDf5QKhXlUA==}
+  importree@2.0.0:
+    resolution: {integrity: sha512-2HCZB/T7UicttgiwnF0XsnjugjXqOm1C3gWUQJ0GyEc1JRmqbuiGqFdWl5GnSKmcFzBen5qzSbXz4LJC52Cavw==}
     engines: {node: '>=18'}
 
   impound@1.0.0:
@@ -16905,7 +16905,7 @@ snapshots:
 
   import-lazy@4.0.0: {}
 
-  importree@1.0.1: {}
+  importree@2.0.0: {}
 
   impound@1.0.0:
     dependencies:

--- a/tooling/plugin/package.json
+++ b/tooling/plugin/package.json
@@ -93,7 +93,7 @@
 		"@styleframe/scanner": "workspace:^3.1.2",
 		"@styleframe/transpiler": "workspace:^3.3.0",
 		"consola": "^3.4.2",
-		"importree": "^1.0.1",
+		"importree": "^2.0.0",
 		"tinyglobby": "catalog:",
 		"jiti": "catalog:",
 		"unplugin": "^2.3.4"

--- a/tooling/plugin/src/plugin/dependency-graph.ts
+++ b/tooling/plugin/src/plugin/dependency-graph.ts
@@ -1,4 +1,9 @@
-import { importree, getAffectedFiles, type ImportTree } from "importree";
+import {
+	importree,
+	getAffectedFiles,
+	type ImportTree,
+	type ImportEdge,
+} from "importree";
 
 export interface DependencyGraph {
 	trackedFiles: Set<string>;
@@ -49,28 +54,28 @@ export async function buildDependencyGraph(
 
 function mergeImportTrees(trees: ImportTree[]): ImportTree {
 	const files = new Set<string>();
-	const graph: Record<string, string[]> = {};
-	const reverseGraph: Record<string, string[]> = {};
+	const graph: Record<string, ImportEdge[]> = {};
+	const reverseGraph: Record<string, ImportEdge[]> = {};
 	const externals = new Set<string>();
 
 	for (const tree of trees) {
 		for (const file of tree.files) {
 			files.add(file);
 		}
-		for (const [key, deps] of Object.entries(tree.graph)) {
+		for (const [key, edges] of Object.entries(tree.graph)) {
 			const existing = graph[key] ?? [];
-			for (const dep of deps) {
-				if (!existing.includes(dep)) {
-					existing.push(dep);
+			for (const edge of edges) {
+				if (!existing.some((e) => e.path === edge.path)) {
+					existing.push(edge);
 				}
 			}
 			graph[key] = existing;
 		}
-		for (const [key, dependents] of Object.entries(tree.reverseGraph)) {
+		for (const [key, edges] of Object.entries(tree.reverseGraph)) {
 			const existing = reverseGraph[key] ?? [];
-			for (const dep of dependents) {
-				if (!existing.includes(dep)) {
-					existing.push(dep);
+			for (const edge of edges) {
+				if (!existing.some((e) => e.path === edge.path)) {
+					existing.push(edge);
 				}
 			}
 			reverseGraph[key] = existing;


### PR DESCRIPTION
The v2 breaking change replaces `string[]` with `ImportEdge[]` in `ImportTree.graph` and `reverseGraph`. Updated `mergeImportTrees` to deduplicate edges by `edge.path` instead of plain string comparison.