### PR TITLE
docs: add Input recipe docs page and standardize doc-recipe conventions

### DIFF
--- a/.claude/skills/document-recipe/SKILL.md
+++ b/.claude/skills/document-recipe/SKILL.md
@@ -45,7 +45,9 @@ Read the 2–3 most similar reference pages in full. Extract the conventions:
 - **Frontmatter:** `title` + `description`. No H1 in the body — the title renders from frontmatter.
 - **Section order:** Overview → Why use the X recipe? → Usage (`::steps{level="4"}`) → Colors → Variants → Sizes → Anatomy (multi-part only) → Accessibility → Customization → API Reference → Best Practices → FAQ (`::accordion`).
 - **Heading style:** sentence case, verb-first where it makes sense ("Why use the Badge recipe?", "Overriding defaults").
-- **Usage block:** `::steps{level="4"}` with three sub-steps: "Register the recipe" (`:::code-tree` with component `.styleframe.ts` + root `styleframe.config.ts`), "Build the component" (`:::tabs` with React + Vue tabs), "See it in action" (`::story-preview`).
+- **Usage block:** `::steps{level="4"}` with three sub-steps: "Register the recipe" (`:::code-tree` with component `.styleframe.ts` + root `styleframe.config.ts`), "Build the component" (`::framework-switcher` with `#vue`, `#react`, and `#other` slots), "See it in action" (`::story-preview`).
+- **Framework switcher:** the "Build the component" step MUST use `::framework-switcher` with `#vue`, `#react`, and `#other` slot markers (Vue first), not `:::tabs` / `::::tabs-item`. The switcher renders one synced toggle across the whole docs site, so a reader's framework choice persists between pages — per-page tabs don't. The toggle always offers all three options (React, Vanilla, Vue); the `#other` slot is the **Vanilla** view, so provide all three — if a slot is missing, the reader sees a "Not available for X — showing Y" fallback notice instead of code. Some older pages still use `:::tabs`; treat `::framework-switcher` as the standard and do not copy the tabs form. The `#vue` and `#react` slots show idiomatic component code; the `#other` (Vanilla) slot shows the runtime returning a class string applied to plain `.ts` + `.html` (see `card.md`).
+- **Code-fence languages:** use only languages the docs Shiki config loads (`apps/docs/nuxt.config.ts` → `content.build.markdown.highlight.langs`: `bash, diff, json, js, ts, html, css, vue, shell, mdc, md, yaml`). The React block's language token MUST be `ts`, NOT `tsx` (and never `jsx`) — `tsx` is not registered and renders unhighlighted. Put the `.tsx` extension in the filename label only, e.g. ` ```ts [src/components/<ComponentName>.tsx] `.
 - **Story-preview embed:** `::story-preview` with YAML front body `story: theme-recipes-<name>--<story>` and optional `panel: true` or `height: NNN`.
 - **Colors section:** opening sentence, a `::story-preview` of the default-color story, a "Color Reference" sub-heading with a table (`| Color | Token | Use Case |`) and a `::tip` admonition at the end.
 - **Variants section:** one sub-heading per variant style with a 1-sentence description and a `::story-preview` per variant.
@@ -154,8 +156,29 @@ export default s;
 
 Import the `<componentName>` runtime function from the virtual module and pass variant props to compute class names:
 
-:::tabs
-::::tabs-item{icon="i-devicon-react" label="React"}
+::framework-switcher
+
+#vue
+
+` ` `vue [src/components/<ComponentName>.vue]
+<script setup lang="ts">
+import { <componentName> } from "virtual:styleframe";
+
+const { color = "<default>", variant = "<default>", size = "<default>" } = defineProps<{
+	color?: /* union */;
+	variant?: /* union */;
+	size?: /* union */;
+}>();
+</script>
+
+<template>
+	<<element> :class="<componentName>({ color, variant, size })">
+		<slot />
+	</<element>>
+</template>
+` ` `
+
+#react
 
 ` ` `ts [src/components/<ComponentName>.tsx]
 import { <componentName> } from "virtual:styleframe";
@@ -178,29 +201,22 @@ export function <ComponentName>({
 }
 ` ` `
 
-::::
-::::tabs-item{icon="i-devicon-vuejs" label="Vue"}
+#other
 
-` ` `vue [src/components/<ComponentName>.vue]
-<script setup lang="ts">
+The `<componentName>()` runtime returns a class string. Apply it however your framework binds classes:
+
+` ` `ts [src/components/<component-name>.ts]
 import { <componentName> } from "virtual:styleframe";
 
-const { color = "<default>", variant = "<default>", size = "<default>" } = defineProps<{
-	color?: /* union */;
-	variant?: /* union */;
-	size?: /* union */;
-}>();
-</script>
-
-<template>
-	<<element> :class="<componentName>({ color, variant, size })">
-		<slot />
-	</<element>>
-</template>
+const classes = <componentName>({ color: "<default>", variant: "<default>", size: "<default>" });
+// → "<component-name> ..."
 ` ` `
 
-::::
-:::
+` ` `html [src/components/<component-name>.html]
+<<element> class="<component-name> ...">...</<element>>
+` ` `
+
+::
 
 #### See it in action
 
@@ -422,6 +438,7 @@ Compare the draft against the chosen reference page(s). In `<conformance>`, list
 
 - **Structural deviations:** section order, missing sections, extra sections.
 - **Formatting inconsistencies:** heading style, admonition syntax, code-block language tags, table column count.
+- **Framework switcher:** the "Build the component" step uses `::framework-switcher` with `#vue`, `#react`, and `#other` (Vanilla) slots (Vue first), not `:::tabs` / `::::tabs-item`. Flag the tabs form, or a missing `#other` slot, as a deviation.
 - **Story ID validity:** every `::story-preview` story ID must match an entry in `showcase.md`.
 - **Remaining `[VERIFY]` flags:** list them all.
 - **Confidence rating:** High (everything traceable to source + showcase) / Medium (a few `[VERIFY]` flags or mild deviations) / Low (significant gaps or invented behavior — must not ship without human review).

--- a/apps/docs/content/docs/05.components/02.composables/16.input.md
+++ b/apps/docs/content/docs/05.components/02.composables/16.input.md
@@ -1,0 +1,648 @@
+---
+title: Input
+description: A text-field component with a wrapper-owned visual surface, inline prefix/suffix addons, attached prepend/append slots, and invalid/disabled/readonly states. Supports light, dark, and neutral colors, default/soft/ghost styles, and three sizes through the recipe system.
+---
+
+## Overview
+
+The **Input** is a text-field container used to capture single-line user input. It is composed of six recipe parts:
+
+- **`useInputRecipe()`** &mdash; the wrapper that owns the visual field: border, background, padding, and the `:focus-within` ring.
+- **`useInputPrefixRecipe()`** &mdash; an inline leading addon that sits inside the field, sharing its surface.
+- **`useInputSuffixRecipe()`** &mdash; an inline trailing addon that sits inside the field, sharing its surface.
+- **`useInputGroupRecipe()`** &mdash; a layout coordinator for attached blocks placed outside the field, flattening the border radii at the seams.
+- **`useInputPrependRecipe()`** &mdash; a transparent leading slot inside the group for buttons, selects, or other components.
+- **`useInputAppendRecipe()`** &mdash; a transparent trailing slot inside the group for buttons, selects, or other components.
+
+Each composable creates a fully configured [recipe](/docs/api/recipes) with color, variant, and size options &mdash; plus compound variants on the wrapper that handle every color-variant combination and the invalid, disabled, and readonly states automatically.
+
+The Input recipes integrate directly with the default [design tokens preset](/docs/theme/design-tokens/presets) and generate type-safe utility classes at build time with zero runtime CSS.
+
+## Why use the Input recipe?
+
+The Input recipe helps you:
+
+- **Ship faster with sensible defaults**: Get 3 colors, 3 visual styles, 3 sizes, and three native state axes out of the box with a single set of composable calls.
+- **Compose rich fields**: Inline prefix/suffix addons and attached prepend/append slots share the same size axis, so icons, currency symbols, and buttons stay aligned with the field.
+- **Maintain consistency**: Compound variants ensure every color-variant combination and every state follows the same design rules, including dark mode overrides.
+- **Customize without forking**: Override base styles, default variants, or filter out options you don't need &mdash; all through the options API.
+- **Stay type-safe**: Full TypeScript support means your editor catches invalid color, variant, size, or state values at compile time.
+- **Integrate with your tokens**: Every value references the design tokens preset, so theme changes propagate automatically.
+
+## Usage
+
+::steps{level="4"}
+
+#### Register the recipes
+
+Add the Input recipes to a local Styleframe instance. The global `styleframe.config.ts` provides design tokens and utilities, while the component-level file registers the recipes themselves:
+
+:::code-tree{default-value="src/components/input.styleframe.ts"}
+
+```ts [src/components/input.styleframe.ts]
+import { styleframe } from 'virtual:styleframe';
+import {
+    useInputRecipe,
+    useInputPrefixRecipe,
+    useInputSuffixRecipe,
+    useInputGroupRecipe,
+    useInputPrependRecipe,
+    useInputAppendRecipe,
+} from '@styleframe/theme';
+
+const s = styleframe();
+
+const input = useInputRecipe(s);
+const inputPrefix = useInputPrefixRecipe(s);
+const inputSuffix = useInputSuffixRecipe(s);
+const inputGroup = useInputGroupRecipe(s);
+const inputPrepend = useInputPrependRecipe(s);
+const inputAppend = useInputAppendRecipe(s);
+
+export default s;
+```
+
+```ts [styleframe.config.ts]
+import { styleframe } from 'styleframe';
+import { useDesignTokensPreset, useUtilitiesPreset } from '@styleframe/theme';
+
+const s = styleframe();
+
+useDesignTokensPreset(s);
+useUtilitiesPreset(s);
+
+export default s;
+```
+
+:::
+
+#### Build the component
+
+Import the `input`, `inputPrefix`, and `inputSuffix` runtime functions from the virtual module. The wrapper paints the visual field and the nested `.input-field` is a transparent native `<input>` that inherits typography. Map boolean state props to the recipe's `"true"` / `"false"` keys:
+
+::framework-switcher
+
+#vue
+
+```vue [src/components/Input.vue]
+<script setup lang="ts">
+import { computed, useSlots } from "vue";
+import { input, inputPrefix, inputSuffix } from "virtual:styleframe";
+
+const {
+    color = "neutral",
+    variant = "default",
+    size = "md",
+    invalid = false,
+    disabled = false,
+    readonly = false,
+} = defineProps<{
+    color?: "light" | "dark" | "neutral";
+    variant?: "default" | "soft" | "ghost";
+    size?: "sm" | "md" | "lg";
+    invalid?: boolean;
+    disabled?: boolean;
+    readonly?: boolean;
+}>();
+
+const slots = useSlots();
+
+const wrapper = computed(() =>
+    input({
+        color,
+        variant,
+        size,
+        invalid: invalid ? "true" : "false",
+        disabled: disabled ? "true" : "false",
+        readonly: readonly ? "true" : "false",
+    }),
+);
+</script>
+
+<template>
+    <span :class="wrapper">
+        <span v-if="slots.prefix" :class="inputPrefix({ size })">
+            <slot name="prefix" />
+        </span>
+        <input
+            class="input-field"
+            :disabled="disabled"
+            :readonly="readonly"
+            :aria-invalid="invalid"
+        />
+        <span v-if="slots.suffix" :class="inputSuffix({ size })">
+            <slot name="suffix" />
+        </span>
+    </span>
+</template>
+```
+
+#react
+
+```ts [src/components/Input.tsx]
+import { input, inputPrefix, inputSuffix } from "virtual:styleframe";
+
+interface InputProps {
+    color?: "light" | "dark" | "neutral";
+    variant?: "default" | "soft" | "ghost";
+    size?: "sm" | "md" | "lg";
+    invalid?: boolean;
+    disabled?: boolean;
+    readonly?: boolean;
+    prefix?: React.ReactNode;
+    suffix?: React.ReactNode;
+}
+
+export function Input({
+    color = "neutral",
+    variant = "default",
+    size = "md",
+    invalid = false,
+    disabled = false,
+    readonly = false,
+    prefix,
+    suffix,
+    ...inputProps
+}: InputProps & React.InputHTMLAttributes<HTMLInputElement>) {
+    const wrapper = input({
+        color,
+        variant,
+        size,
+        invalid: invalid ? "true" : "false",
+        disabled: disabled ? "true" : "false",
+        readonly: readonly ? "true" : "false",
+    });
+
+    return (
+        <span className={wrapper}>
+            {prefix && <span className={inputPrefix({ size })}>{prefix}</span>}
+            <input
+                className="input-field"
+                disabled={disabled}
+                readOnly={readonly}
+                aria-invalid={invalid}
+                {...inputProps}
+            />
+            {suffix && <span className={inputSuffix({ size })}>{suffix}</span>}
+        </span>
+    );
+}
+```
+
+#other
+
+The `input()`, `inputPrefix()`, and `inputSuffix()` runtimes each return a class string. Pass the state axes as `"true"` / `"false"` keys and apply the result however your framework binds classes:
+
+```ts [src/components/input.ts]
+import { input, inputPrefix, inputSuffix } from "virtual:styleframe";
+
+const wrapperClasses = input({
+    color: "neutral",
+    variant: "default",
+    size: "md",
+    invalid: "false",
+    disabled: "false",
+    readonly: "false",
+});
+// → "input _border-width:thin _border-radius:md ..."
+
+const prefixClasses = inputPrefix({ size: "md" });
+// → "input-prefix _font-size:sm ..."
+
+const suffixClasses = inputSuffix({ size: "md" });
+// → "input-suffix _font-size:sm ..."
+```
+
+```html [src/components/input.html]
+<span class="input _border-width:thin _border-radius:md ...">
+    <span class="input-prefix _font-size:sm ...">$</span>
+    <input class="input-field" type="text" placeholder="0.00" />
+    <span class="input-suffix _font-size:sm ...">.00</span>
+</span>
+```
+
+::
+
+#### See it in action
+
+:::story-preview
+---
+story: theme-recipes-input--default
+panel: true
+---
+:::
+
+::
+
+## Colors
+
+The Input recipe includes 3 color variants: `light`, `dark`, and `neutral`. Like the Card and ChatMessage recipes, Input uses neutral-spectrum colors designed for content surfaces rather than status communication &mdash; a field's color reflects its surface, not a state. The wrapper combines each color with every visual style variant through compound variants, so you get consistent, predictable styling across all combinations &mdash; including dark mode overrides.
+
+The `neutral` color adapts automatically: it uses a light appearance in light mode and a dark appearance in dark mode, making it the safest default for general-purpose forms.
+
+::story-preview
+---
+story: theme-recipes-input--neutral
+panel: true
+---
+::
+
+### Color Reference
+
+::story-preview
+---
+story: theme-recipes-input--all-variants
+height: 420
+---
+::
+
+| Color | Token | Use Case |
+|-------|-------|----------|
+| `light` | `@color.white` / `@color.gray-*` | Light surfaces, stays light in dark mode |
+| `dark` | `@color.gray-900` | Dark surfaces, stays dark in light mode |
+| `neutral` | Adaptive (light &harr; dark) | Default color, adapts to the current color scheme |
+
+::tip
+**Pro tip:** Use `neutral` as your default input color. It adapts to the user's color scheme automatically, so you don't need to manage light and dark variants separately.
+::
+
+## Variants
+
+Three visual style variants control how the field surface is rendered. Each variant is combined with the selected color through [compound variants](/docs/api/recipes#compound-variants), so you always get the correct background, text, and border colors for your chosen color.
+
+### Default
+
+Opaque surface with a visible border &mdash; the standard bordered text field. Sits above the page with a solid background and reveals a primary-colored focus ring on `:focus-within`.
+
+::story-preview
+---
+story: theme-recipes-input--default-variant
+panel: true
+---
+::
+
+### Soft
+
+Tinted gray background with a matching border. A gentler, lower-contrast field that blends into dense forms.
+
+::story-preview
+---
+story: theme-recipes-input--soft
+panel: true
+---
+::
+
+### Ghost
+
+No background and no border until interaction. The field shows only the focus ring on `:focus-within`, making it ideal for inline editing and borderless layouts.
+
+::story-preview
+---
+story: theme-recipes-input--ghost
+panel: true
+---
+::
+
+## Sizes
+
+Three size variants from `sm` to `lg` control the field's font size, padding, and border radius. The prefix and suffix addons share the same size axis, scaling their font size, inner padding, and gap to stay aligned with the field.
+
+::story-preview
+---
+story: theme-recipes-input--all-sizes
+height: 320
+---
+::
+
+### Size Reference
+
+| Size | Font Size | Padding (V / H) | Border Radius |
+|------|-----------|-----------------|---------------|
+| `sm` | `@font-size.xs` | `@0.375` / `@0.625` | `@border-radius.sm` |
+| `md` | `@font-size.sm` | `@0.5` / `@0.75` | `@border-radius.md` |
+| `lg` | `@font-size.md` | `@0.625` / `@0.875` | `@border-radius.md` |
+
+::note
+**Good to know:** Pass the same `size` to the wrapper and to each prefix/suffix or prepend/append part so the whole field scales together. The wrapper owns the radius and padding; the addons manage their own font size and gap.
+::
+
+## States
+
+The wrapper exposes three boolean state axes that map directly to the equivalent native `<input>` attributes. Pass them as the recipe's `"true"` / `"false"` keys (map from your component's booleans, as shown in [Build the component](#build-the-component)).
+
+### Invalid
+
+Overrides the border and the focus ring to the error color. Set it alongside `aria-invalid` on the native input so assistive technology hears the error.
+
+::story-preview
+---
+story: theme-recipes-input--invalid
+panel: true
+---
+::
+
+### Disabled
+
+Dims the field to `0.5` opacity, switches the cursor to `not-allowed`, and blocks pointer interaction. Mirror it with the native `disabled` attribute so the input is also removed from the tab order.
+
+::story-preview
+---
+story: theme-recipes-input--disabled
+panel: true
+---
+::
+
+### Read-only
+
+Applies a subtle background shift and a default cursor while keeping the value selectable. Mirror it with the native `readonly` attribute so the value is submitted but not editable.
+
+::story-preview
+---
+story: theme-recipes-input--read-only
+panel: true
+---
+::
+
+::note
+**Good to know:** `invalid` is applied before `readonly` and `disabled` in the compound variant order, so an invalid field keeps its error border even when it is also read-only, and a disabled field still dims on top of any other state.
+::
+
+## Addons
+
+Input supports two kinds of addons. **Inline** addons (`prefix`, `suffix`) render inside the field and share its surface &mdash; use them for icons, currency symbols, and units. **Attached** addons (`prepend`, `append`) render as joined blocks outside the field inside an `inputGroup` &mdash; use them for buttons, selects, and other components that bring their own styling.
+
+### Prefix and suffix (inline)
+
+The prefix and suffix sit inside the wrapper, to the left and right of the caret, sharing the field's background and focus ring. They are size-aware and use a muted text color.
+
+::story-preview
+---
+story: theme-recipes-input--with-prefix
+panel: true
+---
+::
+
+::story-preview
+---
+story: theme-recipes-input--with-suffix
+panel: true
+---
+::
+
+::story-preview
+---
+story: theme-recipes-input--with-prefix-and-suffix
+panel: true
+---
+::
+
+### Prepend and append (attached)
+
+The prepend and append are transparent slots inside an `inputGroup`. The group flattens the border radius at the seams where the slots meet the field, so a button or select reads as one joined control. Drop any component into the slot &mdash; its own styling takes over.
+
+::story-preview
+---
+story: theme-recipes-input--with-prepend
+panel: true
+---
+::
+
+::story-preview
+---
+story: theme-recipes-input--with-append
+panel: true
+---
+::
+
+::story-preview
+---
+story: theme-recipes-input--with-prepend-and-append
+panel: true
+---
+::
+
+::tip
+**Pro tip:** Reach for `prefix`/`suffix` when the addon is decorative or informational (an icon, a unit) and for `prepend`/`append` when it is interactive (a button, a dropdown). Inline addons share the field's surface; attached addons keep their own.
+::
+
+## Anatomy
+
+The Input is composed of six independent recipes. The first three build a standalone field with inline addons; the last three compose a field with attached blocks:
+
+| Part | Recipe | Role |
+|------|--------|------|
+| **Field** | `useInputRecipe()` | The `.input` wrapper &mdash; owns the visual field (border, background, padding, `:focus-within` ring) and contains the transparent nested `.input-field` input |
+| **Prefix** | `useInputPrefixRecipe()` | Leading inline addon inside the field &mdash; icons, currency symbols, units |
+| **Suffix** | `useInputSuffixRecipe()` | Trailing inline addon inside the field &mdash; icons, clear or reveal buttons |
+| **Group** | `useInputGroupRecipe()` | Layout coordinator for prepend + field + append; flattens border radii at the seams |
+| **Prepend** | `useInputPrependRecipe()` | Transparent leading slot outside the field &mdash; buttons, selects, addons |
+| **Append** | `useInputAppendRecipe()` | Transparent trailing slot outside the field &mdash; buttons, selects, addons |
+
+The nested `.input-field` element is the real `<input>`: it is transparent, has no border or padding of its own, and inherits typography and color from the wrapper. The wrapper owns the entire visual field via `:focus-within`, so the focus ring appears whenever the inner input is focused.
+
+```html
+<!-- Standalone field with inline addons -->
+<span class="input(...)">
+    <span class="inputPrefix(...)">$</span>
+    <input class="input-field" />
+    <span class="inputSuffix(...)">.00</span>
+</span>
+
+<!-- Field with an attached button -->
+<div class="inputGroup(...)">
+    <span class="input(...)"><input class="input-field" /></span>
+    <span class="inputAppend()"><button>Search</button></span>
+</div>
+```
+
+::tip
+**Pro tip:** You don't need the group for a basic field. Use `useInputRecipe()` on its own (with optional prefix/suffix) for most inputs, and reach for the group, prepend, and append recipes only when you attach interactive blocks.
+::
+
+## Accessibility
+
+- **Pair the `invalid` state with `aria-invalid`.** The error border is a visual cue only. Set `aria-invalid="true"` on the native input and reference an error message with `aria-describedby` so screen readers announce the problem.
+- **Mirror states on the native input.** Set the real `disabled` and `readonly` attributes in addition to the recipe state, so the field is correctly removed from (or kept in) the tab order and submitted accordingly.
+- **Give inline addons text alternatives.** A prefix or suffix that conveys meaning (a currency symbol, a unit) should be exposed to assistive technology &mdash; keep it as readable text, or add an `aria-label` to the input that includes it.
+- **Label every field.** Associate a `<label>` with the nested input via `for`/`id`, or wrap the input in the label. The recipe styles the surface but does not provide a name.
+- **Verify contrast ratios.** The `dark` color places light text on a dark surface. Default tokens meet WCAG AA 4.5:1 contrast. If you override colors, verify with the [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/).
+
+## Customization
+
+### Overriding Defaults
+
+Each input composable accepts an optional second argument to override any part of the recipe configuration. Overrides are deep-merged with the defaults, so you only need to specify the properties you want to change:
+
+```ts [src/components/input.styleframe.ts]
+import { styleframe } from 'virtual:styleframe';
+import { useInputRecipe } from '@styleframe/theme';
+
+const s = styleframe();
+
+const input = useInputRecipe(s, {
+    base: {
+        borderRadius: '@border-radius.lg',
+    },
+    defaultVariants: {
+        color: 'neutral',
+        variant: 'soft',
+        size: 'lg',
+    },
+});
+
+export default s;
+```
+
+### Filtering Variants
+
+If you only need a subset of the available variants, use the `filter` option to limit which values are generated. This reduces the output CSS and keeps your component API focused:
+
+```ts [src/components/input.styleframe.ts]
+import { styleframe } from 'virtual:styleframe';
+import { useInputRecipe } from '@styleframe/theme';
+
+const s = styleframe();
+
+// Only generate the neutral color with the default and soft styles
+const input = useInputRecipe(s, {
+    filter: {
+        color: ['neutral'],
+        variant: ['default', 'soft'],
+    },
+});
+
+export default s;
+```
+
+::note
+**Good to know:** Filtering also removes compound variants and adjusts default variants that reference filtered-out values, so your recipe stays consistent.
+::
+
+## API Reference
+
+### `useInputRecipe(s, options?)`
+
+Creates the input wrapper recipe &mdash; the `.input` element that owns the visual field. Registers a nested `.input-field` selector for the transparent native input. Owns the full compound matrix: 9 color-variant combinations plus the 3 state overrides.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `s` | `Styleframe` | The Styleframe instance |
+| `options` | `DeepPartial<RecipeConfig>` | Optional overrides for the recipe configuration |
+| `options.base` | `VariantDeclarationsBlock` | Custom base styles for the field wrapper |
+| `options.variants` | `Variants` | Custom variant definitions for the recipe |
+| `options.defaultVariants` | `Record<keyof Variants, string>` | Default variant values for the recipe |
+| `options.compoundVariants` | `CompoundVariant[]` | Custom compound variant definitions for the recipe |
+| `options.filter` | `Record<string, string[]>` | Limit which variant values are generated |
+
+**Variants:**
+
+| Variant | Options | Default |
+|---------|---------|---------|
+| `color` | `light`, `dark`, `neutral` | `neutral` |
+| `variant` | `default`, `soft`, `ghost` | `default` |
+| `size` | `sm`, `md`, `lg` | `md` |
+| `invalid` | `true`, `false` | `false` |
+| `disabled` | `true`, `false` | `false` |
+| `readonly` | `true`, `false` | `false` |
+
+### `useInputPrefixRecipe(s, options?)`
+
+Creates the inline prefix recipe &mdash; a leading addon rendered inside the field, sharing its surface. Size-aware (font size, inner padding, gap) with a muted text color. Accepts the same parameters as `useInputRecipe`.
+
+**Variants:**
+
+| Variant | Options | Default |
+|---------|---------|---------|
+| `size` | `sm`, `md`, `lg` | `md` |
+
+### `useInputSuffixRecipe(s, options?)`
+
+Creates the inline suffix recipe &mdash; a trailing addon rendered inside the field, sharing its surface. Mirrors the prefix recipe with trailing inner padding. Accepts the same parameters as `useInputRecipe`.
+
+**Variants:**
+
+| Variant | Options | Default |
+|---------|---------|---------|
+| `size` | `sm`, `md`, `lg` | `md` |
+
+### `useInputGroupRecipe(s, options?)`
+
+Creates the input group recipe &mdash; a layout coordinator that wraps a prepend, field, and append. Paints no surface of its own; its only styling job is flattening the border radii at the seams where the slots meet the field. The `size` axis is exposed for prop spreading and produces no styles at the group level. Accepts the same parameters as `useInputRecipe`.
+
+**Variants:**
+
+| Variant | Options | Default |
+|---------|---------|---------|
+| `size` | `sm`, `md`, `lg` | `md` |
+
+### `useInputPrependRecipe(s, options?)`
+
+Creates the prepend recipe &mdash; a transparent leading slot inside an input group. Owns no background, border, or padding; the slotted content brings its own visual language. This recipe has no variants.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `s` | `Styleframe` | The Styleframe instance |
+| `options` | `DeepPartial<RecipeConfig>` | Optional overrides for the recipe configuration |
+
+### `useInputAppendRecipe(s, options?)`
+
+Creates the append recipe &mdash; a transparent trailing slot inside an input group. Mirrors the prepend recipe. The slotted content brings its own visual language. This recipe has no variants.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `s` | `Styleframe` | The Styleframe instance |
+| `options` | `DeepPartial<RecipeConfig>` | Optional overrides for the recipe configuration |
+
+[Learn more about recipes &rarr;](/docs/api/recipes)
+
+## Best Practices
+
+- **Pass `size` consistently**: Spread the same `size` to the wrapper and to every prefix, suffix, prepend, and append part so the whole field scales together.
+- **Map booleans to state keys**: The `invalid`, `disabled`, and `readonly` axes use `"true"` / `"false"` string keys. Convert your component's booleans once at the call site, as shown in [Build the component](#build-the-component).
+- **Mirror states on the native input**: Always set the real `disabled` / `readonly` attributes and `aria-invalid` in addition to the recipe state.
+- **Choose the right addon kind**: Use `prefix`/`suffix` for decorative or informational content inside the field, and `prepend`/`append` for interactive blocks attached to it.
+- **Use `neutral` for general forms**: The neutral color adapts to light and dark mode automatically, making it the safest default.
+- **Filter what you don't need**: If your forms use only one color or two variants, pass a `filter` option to reduce generated CSS.
+- **Override defaults at the recipe level**: Set your most common combination as `defaultVariants` so component consumers write less code.
+
+## FAQ
+
+::accordion
+
+:::accordion-item{label="Why is there a separate wrapper and input-field?" icon="i-lucide-circle-help"}
+The `.input` wrapper owns the visual field &mdash; border, background, padding, and the `:focus-within` ring &mdash; while the nested `.input-field` is a transparent native `<input>` that inherits typography. This split lets inline prefix and suffix addons share the same surface as the typed text, and lets the focus ring respond to the inner input through `:focus-within` without extra JavaScript.
+:::
+
+:::accordion-item{label="What's the difference between prefix/suffix and prepend/append?" icon="i-lucide-circle-help"}
+`prefix` and `suffix` render **inside** the field and share its background and focus ring &mdash; use them for icons, currency symbols, and units. `prepend` and `append` render **outside** the field as joined blocks inside an `inputGroup`, which flattens the border radii at the seams &mdash; use them for buttons, selects, and other interactive components that bring their own styling.
+:::
+
+:::accordion-item{label="How do I pass the invalid, disabled, and readonly states?" icon="i-lucide-circle-help"}
+These three axes use `"true"` / `"false"` string keys on the recipe, not booleans. In a component, accept a boolean prop and map it at the call site: `input({ invalid: invalid ? "true" : "false" })`. Always set the matching native attribute (`disabled`, `readonly`) and `aria-invalid` so the field behaves correctly for keyboard and assistive-technology users.
+:::
+
+:::accordion-item{label="Why doesn't the Input recipe include semantic colors like primary or success?" icon="i-lucide-circle-help"}
+A field's color reflects its surface, not a status. Semantic colors (primary, success, error) communicate meaning through color, which is better suited to focused elements like badges, buttons, and callouts. Input uses `light`, `dark`, and `neutral` to provide surface variations that work across all forms. Error communication is handled by the dedicated `invalid` state, which switches the border and focus ring to the error color.
+:::
+
+:::accordion-item{label="How do compound variants work in the Input recipe?" icon="i-lucide-circle-help"}
+The wrapper recipe (`useInputRecipe`) maps each color-variant combination to specific styles. For example, when `color` is `neutral` and `variant` is `default`, the compound variant applies `background: @color.white`, `borderColor: @color.gray-200`, and `color: @color.text`, along with dark mode overrides. The recipe has 12 compound entries: 9 from the color &times; variant matrix (3 colors &times; 3 variants) plus 3 state overrides for `invalid`, `readonly`, and `disabled`.
+
+[Learn more about compound variants &rarr;](/docs/api/recipes#compound-variants)
+:::
+
+:::accordion-item{label="How does filtering affect compound variants?" icon="i-lucide-circle-help"}
+When you use the `filter` option, compound variants that reference filtered-out values are automatically removed. For example, if you filter `variant` to only `['default', 'soft']`, all compound variants matching `ghost` are excluded from the generated output. Default variants are also adjusted if they reference a removed value.
+:::
+
+:::accordion-item{label="Can I use the Input recipe without the design tokens preset?" icon="i-lucide-circle-help"}
+The Input recipe references design tokens like `@color.white`, `@border-radius.md`, and `@color.error` through string refs. These tokens need to be defined in your Styleframe instance for the recipe to generate valid CSS. The easiest way is to use `useDesignTokensPreset(s)`, but you can also define the required tokens manually.
+:::
+
+::

--- a/apps/docs/content/docs/05.components/02.composables/16.input.md
+++ b/apps/docs/content/docs/05.components/02.composables/16.input.md
@@ -78,7 +78,7 @@ export default s;
 
 #### Build the component
 
-Import the `input`, `inputPrefix`, and `inputSuffix` runtime functions from the virtual module. The wrapper paints the visual field and the nested `.input-field` is a transparent native `<input>` that inherits typography. Map boolean state props to the recipe's `"true"` / `"false"` keys:
+Import the `input`, `inputPrefix`, and `inputSuffix` runtime functions from the virtual module. The wrapper paints the visual field and the nested `.input-field` is a transparent native `<input>` that inherits typography. The `invalid`, `disabled`, and `readonly` axes accept booleans directly:
 
 ::framework-switcher
 
@@ -108,14 +108,7 @@ const {
 const slots = useSlots();
 
 const wrapper = computed(() =>
-    input({
-        color,
-        variant,
-        size,
-        invalid: invalid ? "true" : "false",
-        disabled: disabled ? "true" : "false",
-        readonly: readonly ? "true" : "false",
-    }),
+    input({ color, variant, size, invalid, disabled, readonly }),
 );
 </script>
 
@@ -164,14 +157,7 @@ export function Input({
     suffix,
     ...inputProps
 }: InputProps & React.InputHTMLAttributes<HTMLInputElement>) {
-    const wrapper = input({
-        color,
-        variant,
-        size,
-        invalid: invalid ? "true" : "false",
-        disabled: disabled ? "true" : "false",
-        readonly: readonly ? "true" : "false",
-    });
+    const wrapper = input({ color, variant, size, invalid, disabled, readonly });
 
     return (
         <span className={wrapper}>
@@ -191,7 +177,7 @@ export function Input({
 
 #other
 
-The `input()`, `inputPrefix()`, and `inputSuffix()` runtimes each return a class string. Pass the state axes as `"true"` / `"false"` keys and apply the result however your framework binds classes:
+The `input()`, `inputPrefix()`, and `inputSuffix()` runtimes each return a class string. Apply the result however your framework binds classes:
 
 ```ts [src/components/input.ts]
 import { input, inputPrefix, inputSuffix } from "virtual:styleframe";
@@ -200,9 +186,9 @@ const wrapperClasses = input({
     color: "neutral",
     variant: "default",
     size: "md",
-    invalid: "false",
-    disabled: "false",
-    readonly: "false",
+    invalid: false,
+    disabled: false,
+    readonly: false,
 });
 // → "input _border-width:thin _border-radius:md ..."
 
@@ -328,7 +314,7 @@ height: 320
 
 ## States
 
-The wrapper exposes three boolean state axes that map directly to the equivalent native `<input>` attributes. Pass them as the recipe's `"true"` / `"false"` keys (map from your component's booleans, as shown in [Build the component](#build-the-component)).
+The wrapper exposes three boolean state axes that map directly to the equivalent native `<input>` attributes. Pass each as a boolean &mdash; the recipe also accepts the `"true"` / `"false"` string keys, but the boolean form is simpler (see [Build the component](#build-the-component)).
 
 ### Invalid
 
@@ -604,7 +590,7 @@ Creates the append recipe &mdash; a transparent trailing slot inside an input gr
 ## Best Practices
 
 - **Pass `size` consistently**: Spread the same `size` to the wrapper and to every prefix, suffix, prepend, and append part so the whole field scales together.
-- **Map booleans to state keys**: The `invalid`, `disabled`, and `readonly` axes use `"true"` / `"false"` string keys. Convert your component's booleans once at the call site, as shown in [Build the component](#build-the-component).
+- **Pass states as booleans**: The `invalid`, `disabled`, and `readonly` axes accept a boolean directly &mdash; no `"true"` / `"false"` conversion needed (the string keys still work if you prefer them).
 - **Mirror states on the native input**: Always set the real `disabled` / `readonly` attributes and `aria-invalid` in addition to the recipe state.
 - **Choose the right addon kind**: Use `prefix`/`suffix` for decorative or informational content inside the field, and `prepend`/`append` for interactive blocks attached to it.
 - **Use `neutral` for general forms**: The neutral color adapts to light and dark mode automatically, making it the safest default.
@@ -624,7 +610,7 @@ The `.input` wrapper owns the visual field &mdash; border, background, padding, 
 :::
 
 :::accordion-item{label="How do I pass the invalid, disabled, and readonly states?" icon="i-lucide-circle-help"}
-These three axes use `"true"` / `"false"` string keys on the recipe, not booleans. In a component, accept a boolean prop and map it at the call site: `input({ invalid: invalid ? "true" : "false" })`. Always set the matching native attribute (`disabled`, `readonly`) and `aria-invalid` so the field behaves correctly for keyboard and assistive-technology users.
+Pass each as a boolean: `input({ invalid, disabled, readonly })`. The recipe coerces the value to the matching `"true"` / `"false"` variant key, so the `"true"` / `"false"` strings work too &mdash; the boolean form is just simpler. Always set the matching native attribute (`disabled`, `readonly`) and `aria-invalid` so the field behaves correctly for keyboard and assistive-technology users.
 :::
 
 :::accordion-item{label="Why doesn't the Input recipe include semantic colors like primary or success?" icon="i-lucide-circle-help"}


### PR DESCRIPTION
Adds the Input recipe documentation page covering the full recipe family — the field wrapper, inline prefix/suffix addons, and the group/prepend/append composition — with sections for colors, variants, sizes, states (invalid/disabled/readonly), addons, anatomy, accessibility, customization, a per-recipe API reference, and an FAQ, all grounded in the existing `theme/src/recipes/input/` source and verified against the Storybook story IDs. Also updates the `document-recipe` skill to standardize the "Build the component" step on `::framework-switcher` with `#vue`/`#react`/`#other` (Vanilla) slots instead of per-page tabs, and to restrict code-fence languages to those the docs Shiki config loads (so the React block uses `ts`, never the unregistered `tsx`).