### PR TITLE
build(dts): bundle type declarations across packages on build

### DIFF
--- a/.changeset/bundle-type-declarations.md
+++ b/.changeset/bundle-type-declarations.md
@@ -1,0 +1,12 @@
+---
+"@styleframe/config-vite": minor
+"@styleframe/core": patch
+"@styleframe/loader": patch
+"@styleframe/runtime": patch
+"@styleframe/scanner": patch
+"@styleframe/transpiler": patch
+"@styleframe/theme": patch
+"@styleframe/cli": patch
+---
+
+Bundle type declarations on build. The shared Vite config now enables `vite-plugin-dts`'s `bundleTypes`, so each package ships a single rolled-up `.d.ts` per entry (via `@microsoft/api-extractor`) instead of a tree of per-file declarations. `@microsoft/api-extractor` is now a peer dependency of `@styleframe/config-vite`.

--- a/.changeset/styleframe-dual-format-declarations.md
+++ b/.changeset/styleframe-dual-format-declarations.md
@@ -1,0 +1,5 @@
+---
+"styleframe": patch
+---
+
+Emit explicit `.d.mts` and `.d.cts` type declarations per export condition so `import` and `require` consumers each resolve a correctly-formatted declaration file.

--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://openapi.vercel.sh/vercel.json",
+	"framework": "nuxtjs",
+	"installCommand": "pnpm install --frozen-lockfile",
+	"buildCommand": "cd ../.. && pnpm turbo run build --filter=@styleframe/docs"
+}

--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://openapi.vercel.sh/vercel.json",
 	"framework": "nuxtjs",
-	"installCommand": "pnpm install --frozen-lockfile --force",
+	"installCommand": "pnpm install --frozen-lockfile",
 	"buildCommand": "cd ../.. && pnpm turbo run build --filter=@styleframe/docs"
 }

--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://openapi.vercel.sh/vercel.json",
 	"framework": "nuxtjs",
-	"installCommand": "pnpm install --frozen-lockfile",
+	"installCommand": "pnpm install --frozen-lockfile --force",
 	"buildCommand": "cd ../.. && pnpm turbo run build --filter=@styleframe/docs"
 }

--- a/apps/storybook/vercel.json
+++ b/apps/storybook/vercel.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://openapi.vercel.sh/vercel.json",
 	"framework": null,
-	"installCommand": "pnpm install --frozen-lockfile",
+	"installCommand": "pnpm install --frozen-lockfile --force",
 	"buildCommand": "cd ../.. && pnpm turbo run build --filter=@styleframe/storybook",
 	"outputDirectory": "storybook-static"
 }

--- a/apps/storybook/vercel.json
+++ b/apps/storybook/vercel.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://openapi.vercel.sh/vercel.json",
 	"framework": null,
-	"installCommand": "pnpm install --frozen-lockfile --force",
+	"installCommand": "pnpm install --frozen-lockfile",
 	"buildCommand": "cd ../.. && pnpm turbo run build --filter=@styleframe/storybook",
 	"outputDirectory": "storybook-static"
 }

--- a/apps/storybook/vercel.json
+++ b/apps/storybook/vercel.json
@@ -1,0 +1,7 @@
+{
+	"$schema": "https://openapi.vercel.sh/vercel.json",
+	"framework": null,
+	"installCommand": "pnpm install --frozen-lockfile",
+	"buildCommand": "cd ../.. && pnpm turbo run build --filter=@styleframe/storybook",
+	"outputDirectory": "storybook-static"
+}

--- a/config/vite/package.json
+++ b/config/vite/package.json
@@ -27,12 +27,14 @@
 		"url": "https://github.com/styleframe-dev/styleframe/issues"
 	},
 	"devDependencies": {
+		"@microsoft/api-extractor": "catalog:",
 		"@vitest/coverage-v8": "catalog:",
 		"vite": "catalog:",
 		"vitest": "catalog:",
 		"vite-plugin-dts": "catalog:"
 	},
 	"peerDependencies": {
+		"@microsoft/api-extractor": "catalog:",
 		"@vitest/coverage-v8": "catalog:",
 		"vite": "catalog:",
 		"vitest": "catalog:",

--- a/config/vite/vite.config.js
+++ b/config/vite/vite.config.js
@@ -1,3 +1,4 @@
+import { copyFile, readdir } from "node:fs/promises";
 import { resolve } from "node:path";
 import { defineConfig } from "vite";
 import dts from "vite-plugin-dts";
@@ -6,11 +7,69 @@ import { configDefaults as vitestConfig } from "vitest/config";
 /**
  * @typedef {import('vite').UserConfig} UserConfig
  */
+
+/**
+ * Emit `.d.mts` and `.d.cts` copies of every rolled-up `.d.ts` so that
+ * `import` (ESM) and `require` (CJS) consumers each resolve a correctly
+ * flavored declaration instead of a single `.d.ts` that — under
+ * `"type": "module"` — masquerades as ESM for CJS consumers (attw "FalseESM").
+ * The api-extractor rollup is self-contained, so the three flavors are
+ * byte-identical and a copy is safe.
+ *
+ * @returns {import('vite').Plugin}
+ */
+function dualDeclarations() {
+	let outDir;
+	return {
+		name: "styleframe:dual-declarations",
+		apply: "build",
+		configResolved(config) {
+			outDir = resolve(config.root, config.build.outDir);
+		},
+		async closeBundle() {
+			const entries = await readdir(outDir, {
+				recursive: true,
+				withFileTypes: true,
+			});
+			await Promise.all(
+				entries
+					.filter((entry) => entry.isFile() && entry.name.endsWith(".d.ts"))
+					.map((entry) => {
+						const dtsPath = resolve(entry.parentPath ?? entry.path, entry.name);
+						return Promise.all([
+							copyFile(dtsPath, dtsPath.replace(/\.d\.ts$/, ".d.mts")),
+							copyFile(dtsPath, dtsPath.replace(/\.d\.ts$/, ".d.cts")),
+						]);
+					}),
+			);
+		},
+	};
+}
 export const createViteConfig = (name, cwd, options = {}) =>
 	defineConfig({
 		...options,
 		plugins: [
-			dts({ entryRoot: resolve(cwd, "src") }),
+			// Roll all declarations up into a single .d.ts per entry via
+			// @microsoft/api-extractor. `unplugin-dts` only forwards a
+			// tsconfig's own compilerOptions to api-extractor and drops
+			// `extends`-inherited ones, so the inherited `lib` is lost and
+			// the rollup can't resolve globals like `Map`. Re-supply a
+			// superset `lib` so every modern global resolves.
+			dts({
+				entryRoot: resolve(cwd, "src"),
+				bundleTypes: {
+					extractorConfig: {
+						compiler: {
+							overrideTsconfig: {
+								compilerOptions: {
+									lib: ["ESNext", "DOM", "DOM.Iterable"],
+								},
+							},
+						},
+					},
+				},
+			}),
+			dualDeclarations(),
 			...(options.plugins ?? []),
 		],
 		build: {

--- a/engine/core/package.json
+++ b/engine/core/package.json
@@ -7,9 +7,14 @@
 	"main": "./dist/styleframe.umd.cjs",
 	"exports": {
 		".": {
-			"types": "./dist/index.d.ts",
-			"import": "./dist/styleframe.js",
-			"require": "./dist/styleframe.umd.cjs"
+			"import": {
+				"types": "./dist/index.d.mts",
+				"default": "./dist/styleframe.js"
+			},
+			"require": {
+				"types": "./dist/index.d.cts",
+				"default": "./dist/styleframe.umd.cjs"
+			}
 		}
 	},
 	"files": [
@@ -32,6 +37,7 @@
 		"@styleframe/license": "catalog:"
 	},
 	"devDependencies": {
+		"@microsoft/api-extractor": "catalog:",
 		"@styleframe/config-typescript": "workspace:^3.0.0",
 		"@styleframe/config-vite": "workspace:^3.0.1",
 		"@styleframe/license": "catalog:",

--- a/engine/loader/package.json
+++ b/engine/loader/package.json
@@ -7,9 +7,14 @@
 	"main": "./dist/index.cjs",
 	"exports": {
 		".": {
-			"types": "./dist/index.d.ts",
-			"import": "./dist/index.js",
-			"require": "./dist/index.cjs"
+			"import": {
+				"types": "./dist/index.d.mts",
+				"default": "./dist/index.js"
+			},
+			"require": {
+				"types": "./dist/index.d.cts",
+				"default": "./dist/index.cjs"
+			}
 		}
 	},
 	"files": [
@@ -38,6 +43,7 @@
 		"@styleframe/transpiler": "workspace:^3.4.0"
 	},
 	"devDependencies": {
+		"@microsoft/api-extractor": "catalog:",
 		"@styleframe/config-typescript": "workspace:^3.0.0",
 		"@styleframe/config-vite": "workspace:^3.0.1",
 		"@styleframe/core": "workspace:^3.6.0",

--- a/engine/runtime/package.json
+++ b/engine/runtime/package.json
@@ -7,9 +7,14 @@
 	"main": "./dist/runtime.umd.cjs",
 	"exports": {
 		".": {
-			"types": "./dist/index.d.ts",
-			"import": "./dist/runtime.js",
-			"require": "./dist/runtime.umd.cjs"
+			"import": {
+				"types": "./dist/index.d.mts",
+				"default": "./dist/runtime.js"
+			},
+			"require": {
+				"types": "./dist/index.d.cts",
+				"default": "./dist/runtime.umd.cjs"
+			}
 		}
 	},
 	"files": [
@@ -26,6 +31,7 @@
 		"test:dev": "vitest --watch"
 	},
 	"devDependencies": {
+		"@microsoft/api-extractor": "catalog:",
 		"@styleframe/config-typescript": "workspace:^3.0.0",
 		"@styleframe/config-vite": "workspace:^3.0.1",
 		"@styleframe/core": "workspace:^3.6.0",

--- a/engine/scanner/package.json
+++ b/engine/scanner/package.json
@@ -7,14 +7,24 @@
 	"main": "./dist/index.cjs",
 	"exports": {
 		".": {
-			"types": "./dist/index.d.ts",
-			"import": "./dist/index.js",
-			"require": "./dist/index.cjs"
+			"import": {
+				"types": "./dist/index.d.mts",
+				"default": "./dist/index.js"
+			},
+			"require": {
+				"types": "./dist/index.d.cts",
+				"default": "./dist/index.cjs"
+			}
 		},
 		"./node": {
-			"types": "./dist/node.d.ts",
-			"import": "./dist/node.js",
-			"require": "./dist/node.cjs"
+			"import": {
+				"types": "./dist/node.d.mts",
+				"default": "./dist/node.js"
+			},
+			"require": {
+				"types": "./dist/node.d.cts",
+				"default": "./dist/node.cjs"
+			}
 		}
 	},
 	"files": [
@@ -39,6 +49,7 @@
 		"@styleframe/license": "catalog:"
 	},
 	"devDependencies": {
+		"@microsoft/api-extractor": "catalog:",
 		"@styleframe/config-typescript": "workspace:^3.0.0",
 		"@styleframe/config-vite": "workspace:^3.0.1",
 		"@styleframe/core": "workspace:^3.6.0",

--- a/engine/styleframe/package.json
+++ b/engine/styleframe/package.json
@@ -19,64 +19,124 @@
 	"types": "./dist/index.d.ts",
 	"exports": {
 		".": {
-			"types": "./dist/index.d.ts",
-			"import": "./dist/index.js",
-			"require": "./dist/index.cjs"
+			"import": {
+				"types": "./dist/index.d.mts",
+				"default": "./dist/index.js"
+			},
+			"require": {
+				"types": "./dist/index.d.cts",
+				"default": "./dist/index.cjs"
+			}
 		},
 		"./cli": {
-			"types": "./dist/cli.d.ts",
-			"import": "./dist/cli.js",
-			"require": "./dist/cli.cjs"
+			"import": {
+				"types": "./dist/cli.d.mts",
+				"default": "./dist/cli.js"
+			},
+			"require": {
+				"types": "./dist/cli.d.cts",
+				"default": "./dist/cli.cjs"
+			}
 		},
 		"./loader": {
-			"types": "./dist/loader.d.ts",
-			"import": "./dist/loader.js",
-			"require": "./dist/loader.cjs"
+			"import": {
+				"types": "./dist/loader.d.mts",
+				"default": "./dist/loader.js"
+			},
+			"require": {
+				"types": "./dist/loader.d.cts",
+				"default": "./dist/loader.cjs"
+			}
 		},
 		"./transpiler": {
-			"types": "./dist/transpiler.d.ts",
-			"import": "./dist/transpiler.js",
-			"require": "./dist/transpiler.cjs"
+			"import": {
+				"types": "./dist/transpiler.d.mts",
+				"default": "./dist/transpiler.js"
+			},
+			"require": {
+				"types": "./dist/transpiler.d.cts",
+				"default": "./dist/transpiler.cjs"
+			}
 		},
 		"./plugin/astro": {
-			"types": "./dist/plugin/astro.d.ts",
-			"import": "./dist/plugin/astro.js",
-			"require": "./dist/plugin/astro.cjs"
+			"import": {
+				"types": "./dist/plugin/astro.d.mts",
+				"default": "./dist/plugin/astro.js"
+			},
+			"require": {
+				"types": "./dist/plugin/astro.d.cts",
+				"default": "./dist/plugin/astro.cjs"
+			}
 		},
 		"./plugin/esbuild": {
-			"types": "./dist/plugin/esbuild.d.ts",
-			"import": "./dist/plugin/esbuild.js",
-			"require": "./dist/plugin/esbuild.cjs"
+			"import": {
+				"types": "./dist/plugin/esbuild.d.mts",
+				"default": "./dist/plugin/esbuild.js"
+			},
+			"require": {
+				"types": "./dist/plugin/esbuild.d.cts",
+				"default": "./dist/plugin/esbuild.cjs"
+			}
 		},
 		"./plugin/farm": {
-			"types": "./dist/plugin/farm.d.ts",
-			"import": "./dist/plugin/farm.js",
-			"require": "./dist/plugin/farm.cjs"
+			"import": {
+				"types": "./dist/plugin/farm.d.mts",
+				"default": "./dist/plugin/farm.js"
+			},
+			"require": {
+				"types": "./dist/plugin/farm.d.cts",
+				"default": "./dist/plugin/farm.cjs"
+			}
 		},
 		"./plugin/nuxt": {
-			"types": "./dist/plugin/nuxt.d.ts",
-			"import": "./dist/plugin/nuxt.js",
-			"require": "./dist/plugin/nuxt.cjs"
+			"import": {
+				"types": "./dist/plugin/nuxt.d.mts",
+				"default": "./dist/plugin/nuxt.js"
+			},
+			"require": {
+				"types": "./dist/plugin/nuxt.d.cts",
+				"default": "./dist/plugin/nuxt.cjs"
+			}
 		},
 		"./plugin/rollup": {
-			"types": "./dist/plugin/rollup.d.ts",
-			"import": "./dist/plugin/rollup.js",
-			"require": "./dist/plugin/rollup.cjs"
+			"import": {
+				"types": "./dist/plugin/rollup.d.mts",
+				"default": "./dist/plugin/rollup.js"
+			},
+			"require": {
+				"types": "./dist/plugin/rollup.d.cts",
+				"default": "./dist/plugin/rollup.cjs"
+			}
 		},
 		"./plugin/rspack": {
-			"types": "./dist/plugin/rspack.d.ts",
-			"import": "./dist/plugin/rspack.js",
-			"require": "./dist/plugin/rspack.cjs"
+			"import": {
+				"types": "./dist/plugin/rspack.d.mts",
+				"default": "./dist/plugin/rspack.js"
+			},
+			"require": {
+				"types": "./dist/plugin/rspack.d.cts",
+				"default": "./dist/plugin/rspack.cjs"
+			}
 		},
 		"./plugin/vite": {
-			"types": "./dist/plugin/vite.d.ts",
-			"import": "./dist/plugin/vite.js",
-			"require": "./dist/plugin/vite.cjs"
+			"import": {
+				"types": "./dist/plugin/vite.d.mts",
+				"default": "./dist/plugin/vite.js"
+			},
+			"require": {
+				"types": "./dist/plugin/vite.d.cts",
+				"default": "./dist/plugin/vite.cjs"
+			}
 		},
 		"./plugin/webpack": {
-			"types": "./dist/plugin/webpack.d.ts",
-			"import": "./dist/plugin/webpack.js",
-			"require": "./dist/plugin/webpack.cjs"
+			"import": {
+				"types": "./dist/plugin/webpack.d.mts",
+				"default": "./dist/plugin/webpack.js"
+			},
+			"require": {
+				"types": "./dist/plugin/webpack.d.cts",
+				"default": "./dist/plugin/webpack.cjs"
+			}
 		},
 		"./package.json": "./package.json"
 	},

--- a/engine/styleframe/tsdown.config.ts
+++ b/engine/styleframe/tsdown.config.ts
@@ -1,4 +1,34 @@
+import { copyFile, readdir } from "node:fs/promises";
+import { resolve } from "node:path";
 import { defineConfig } from "tsdown";
+
+const distDir = resolve(new URL(".", import.meta.url).pathname, "dist");
+
+/**
+ * tsdown emits `<name>.d.ts` (ESM) and `<name>.d.cts` (CJS) per entry. Copy
+ * each `.d.ts` to a `.d.mts` so the `import` condition resolves an explicit
+ * ESM declaration (paired with tsdown's `.d.cts` for `require`), preventing
+ * the single declaration from masquerading as ESM for CJS consumers.
+ *
+ * Attached to every entry's `build:done`; each fire is idempotent and at
+ * minimum covers its own entry's declarations.
+ */
+async function emitEsmDeclarations() {
+	const entries = await readdir(distDir, {
+		recursive: true,
+		withFileTypes: true,
+	});
+	await Promise.all(
+		entries
+			.filter((entry) => entry.isFile() && entry.name.endsWith(".d.ts"))
+			.map((entry) => {
+				const dtsPath = resolve(entry.parentPath ?? entry.path, entry.name);
+				return copyFile(dtsPath, dtsPath.replace(/\.d\.ts$/, ".d.mts"));
+			}),
+	);
+}
+
+const hooks = { "build:done": emitEsmDeclarations };
 
 export default defineConfig([
 	{
@@ -6,24 +36,28 @@ export default defineConfig([
 		platform: "neutral",
 		dts: true,
 		format: ["esm", "cjs"],
+		hooks,
 	},
 	{
 		entry: ["./src/cli.ts"],
 		platform: "node",
 		dts: true,
 		format: ["esm", "cjs"],
+		hooks,
 	},
 	{
 		entry: ["./src/loader.ts"],
 		platform: "node",
 		dts: true,
 		format: ["esm", "cjs"],
+		hooks,
 	},
 	{
 		entry: ["./src/transpiler.ts"],
 		platform: "neutral",
 		dts: true,
 		format: ["esm", "cjs"],
+		hooks,
 	},
 	{
 		entry: ["./src/plugin/*.ts"],
@@ -31,5 +65,6 @@ export default defineConfig([
 		platform: "node",
 		dts: true,
 		format: ["esm", "cjs"],
+		hooks,
 	},
 ]);

--- a/engine/transpiler/package.json
+++ b/engine/transpiler/package.json
@@ -7,9 +7,14 @@
 	"main": "./dist/transpiler.umd.cjs",
 	"exports": {
 		".": {
-			"types": "./dist/index.d.ts",
-			"import": "./dist/transpiler.js",
-			"require": "./dist/transpiler.umd.cjs"
+			"import": {
+				"types": "./dist/index.d.mts",
+				"default": "./dist/transpiler.js"
+			},
+			"require": {
+				"types": "./dist/index.d.cts",
+				"default": "./dist/transpiler.umd.cjs"
+			}
 		}
 	},
 	"files": [
@@ -33,6 +38,7 @@
 		"@styleframe/license": "catalog:"
 	},
 	"devDependencies": {
+		"@microsoft/api-extractor": "catalog:",
 		"@styleframe/config-typescript": "workspace:^3.0.0",
 		"@styleframe/config-vite": "workspace:^3.0.1",
 		"@styleframe/core": "workspace:^3.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ settings:
 
 catalogs:
   default:
+    '@microsoft/api-extractor':
+      specifier: ^7.58.7
+      version: 7.58.7
     '@styleframe/license':
       specifier: ^2.0.2
       version: 2.0.2
@@ -44,7 +47,7 @@ catalogs:
       version: 2.5.4
     typescript:
       specifier: ^5.8.3
-      version: 5.8.3
+      version: 5.9.3
     vite:
       specifier: ^8.0.14
       version: 8.0.14
@@ -173,7 +176,7 @@ importers:
         version: 2.5.4
       typescript:
         specifier: 'catalog:'
-        version: 5.8.3
+        version: 5.9.3
 
   apps/app:
     dependencies:
@@ -300,7 +303,7 @@ importers:
     dependencies:
       '@nuxt/content':
         specifier: catalog:nuxt
-        version: 3.7.1(@valibot/to-json-schema@1.7.0(valibot@1.4.0(typescript@5.8.3)))(better-sqlite3@12.4.5)(magicast@0.3.5)(valibot@1.4.0(typescript@5.8.3))
+        version: 3.7.1(@valibot/to-json-schema@1.7.0(valibot@1.4.0(typescript@5.9.3)))(better-sqlite3@12.4.5)(magicast@0.3.5)(valibot@1.4.0(typescript@5.9.3))
       '@nuxt/fonts':
         specifier: catalog:nuxt
         version: 0.14.0(@netlify/blobs@9.1.2)(db0@0.3.4(better-sqlite3@12.4.5))(ioredis@5.10.1)(magicast@0.3.5)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))
@@ -309,43 +312,43 @@ importers:
         version: 1.11.0(@netlify/blobs@9.1.2)(db0@0.3.4(better-sqlite3@12.4.5))(ioredis@5.10.1)(magicast@0.3.5)
       '@nuxt/scripts':
         specifier: catalog:nuxt
-        version: 0.11.13(@netlify/blobs@9.1.2)(@unhead/vue@2.0.19(vue@3.5.34(typescript@5.8.3)))(db0@0.3.4(better-sqlite3@12.4.5))(ioredis@5.10.1)(magicast@0.3.5)(typescript@5.8.3)(vue@3.5.34(typescript@5.8.3))
+        version: 0.11.13(@netlify/blobs@9.1.2)(@unhead/vue@2.0.19(vue@3.5.34(typescript@5.9.3)))(db0@0.3.4(better-sqlite3@12.4.5))(ioredis@5.10.1)(magicast@0.3.5)(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3))
       '@nuxt/ui':
         specifier: catalog:nuxt
-        version: 4.8.0(@internationalized/date@3.10.0)(@internationalized/number@3.6.5)(@netlify/blobs@9.1.2)(@nuxt/content@3.7.1(@valibot/to-json-schema@1.7.0(valibot@1.4.0(typescript@5.8.3)))(better-sqlite3@12.4.5)(magicast@0.3.5)(valibot@1.4.0(typescript@5.8.3)))(@tiptap/extensions@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6))(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(change-case@5.4.4)(db0@0.3.4(better-sqlite3@12.4.5))(embla-carousel@8.6.0)(ioredis@5.10.1)(jwt-decode@4.0.0)(magicast@0.3.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.3.0)(typescript@5.8.3)(valibot@1.4.0(typescript@5.8.3))(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue-router@4.5.1(vue@3.5.34(typescript@5.8.3)))(vue@3.5.34(typescript@5.8.3))(yjs@13.6.30)(zod@4.1.12)
+        version: 4.8.0(@internationalized/date@3.10.0)(@internationalized/number@3.6.5)(@netlify/blobs@9.1.2)(@nuxt/content@3.7.1(@valibot/to-json-schema@1.7.0(valibot@1.4.0(typescript@5.9.3)))(better-sqlite3@12.4.5)(magicast@0.3.5)(valibot@1.4.0(typescript@5.9.3)))(@tiptap/extensions@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6))(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(change-case@5.4.4)(db0@0.3.4(better-sqlite3@12.4.5))(embla-carousel@8.6.0)(ioredis@5.10.1)(jwt-decode@4.0.0)(magicast@0.3.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.3.0)(typescript@5.9.3)(valibot@1.4.0(typescript@5.9.3))(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue-router@4.5.1(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))(yjs@13.6.30)(zod@4.1.12)
       '@nuxtjs/i18n':
         specifier: catalog:nuxt
-        version: 10.1.0(@netlify/blobs@9.1.2)(@vue/compiler-dom@3.5.34)(db0@0.3.4(better-sqlite3@12.4.5))(eslint@9.37.0(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.3.5)(rollup@4.60.4)(vue@3.5.34(typescript@5.8.3))
+        version: 10.1.0(@netlify/blobs@9.1.2)(@vue/compiler-dom@3.5.34)(db0@0.3.4(better-sqlite3@12.4.5))(eslint@9.37.0(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.3.5)(rollup@4.60.4)(vue@3.5.34(typescript@5.9.3))
       '@nuxtjs/mdc':
         specifier: catalog:nuxt
         version: 0.17.4(magicast@0.3.5)
       '@nuxtjs/robots':
         specifier: catalog:nuxt
-        version: 6.0.8(@nuxt/schema@4.4.6)(magicast@0.3.5)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.2.2)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.4)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.4.5)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.4.5))(eslint@9.37.0(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.2.0)(rolldown@1.0.2)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.2)(rollup@4.60.4))(rollup@4.60.4)(terser@5.44.0)(tsx@4.20.6)(typescript@5.8.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue-tsc@3.2.1(typescript@5.8.3))(yaml@2.9.0))(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.8.3))(zod@4.1.12)
+        version: 6.0.8(@nuxt/schema@4.4.6)(magicast@0.3.5)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.2.2)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.4)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.4.5)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.4.5))(eslint@9.37.0(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.2.0)(rolldown@1.0.2)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.2)(rollup@4.60.4))(rollup@4.60.4)(terser@5.44.0)(tsx@4.20.6)(typescript@5.9.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue-tsc@3.2.1(typescript@5.9.3))(yaml@2.9.0))(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))(zod@4.1.12)
       '@nuxtjs/sitemap':
         specifier: catalog:nuxt
-        version: 8.0.15(@nuxt/schema@4.4.6)(magicast@0.3.5)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.2.2)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.4)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.4.5)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.4.5))(eslint@9.37.0(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.2.0)(rolldown@1.0.2)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.2)(rollup@4.60.4))(rollup@4.60.4)(terser@5.44.0)(tsx@4.20.6)(typescript@5.8.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue-tsc@3.2.1(typescript@5.8.3))(yaml@2.9.0))(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.8.3))(zod@4.1.12)
+        version: 8.0.15(@nuxt/schema@4.4.6)(magicast@0.3.5)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.2.2)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.4)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.4.5)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.4.5))(eslint@9.37.0(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.2.0)(rolldown@1.0.2)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.2)(rollup@4.60.4))(rollup@4.60.4)(terser@5.44.0)(tsx@4.20.6)(typescript@5.9.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue-tsc@3.2.1(typescript@5.9.3))(yaml@2.9.0))(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))(zod@4.1.12)
       '@unhead/vue':
         specifier: 2.0.19
-        version: 2.0.19(vue@3.5.34(typescript@5.8.3))
+        version: 2.0.19(vue@3.5.34(typescript@5.9.3))
       '@vueuse/core':
         specifier: 13.9.0
-        version: 13.9.0(vue@3.5.34(typescript@5.8.3))
+        version: 13.9.0(vue@3.5.34(typescript@5.9.3))
       defu:
         specifier: catalog:nuxt
         version: 6.1.4
       motion-v:
         specifier: 1.7.2
-        version: 1.7.2(@vueuse/core@13.9.0(vue@3.5.34(typescript@5.8.3)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.8.3))
+        version: 1.7.2(@vueuse/core@13.9.0(vue@3.5.34(typescript@5.9.3)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))
       nuxt:
         specifier: catalog:nuxt
-        version: 4.4.6(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.2.2)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.4)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.4.5)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.4.5))(eslint@9.37.0(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.2.0)(rolldown@1.0.2)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.2)(rollup@4.60.4))(rollup@4.60.4)(terser@5.44.0)(tsx@4.20.6)(typescript@5.8.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue-tsc@3.2.1(typescript@5.8.3))(yaml@2.9.0)
+        version: 4.4.6(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.2.2)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.4)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.4.5)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.4.5))(eslint@9.37.0(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.2.0)(rolldown@1.0.2)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.2)(rollup@4.60.4))(rollup@4.60.4)(terser@5.44.0)(tsx@4.20.6)(typescript@5.9.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue-tsc@3.2.1(typescript@5.9.3))(yaml@2.9.0)
       nuxt-llms:
         specifier: catalog:nuxt
         version: 0.1.3(magicast@0.3.5)
       nuxt-og-image:
         specifier: catalog:nuxt
-        version: 6.5.1(967f4a3de4acbdc0d75e02a1c5e544bd)
+        version: 6.5.1(6731f1c4d7efe985dfa23dea89fcab9e)
       posthog-js:
         specifier: catalog:nuxt
         version: 1.293.0
@@ -360,10 +363,10 @@ importers:
         version: 1.6.1
       vue:
         specifier: catalog:nuxt
-        version: 3.5.34(typescript@5.8.3)
+        version: 3.5.34(typescript@5.9.3)
       vue-router:
         specifier: 4.5.1
-        version: 4.5.1(vue@3.5.34(typescript@5.8.3))
+        version: 4.5.1(vue@3.5.34(typescript@5.9.3))
       zod:
         specifier: 'catalog:'
         version: 4.1.12
@@ -391,7 +394,7 @@ importers:
         version: 4.4.6(magicast@0.3.5)
       '@nuxt/test-utils':
         specifier: catalog:nuxt
-        version: 3.19.2(@playwright/test@1.56.1)(jsdom@25.0.1)(magicast@0.3.5)(playwright-core@1.57.0)(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.10.4)(jiti@2.7.0)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))
+        version: 3.19.2(@playwright/test@1.56.1)(jsdom@25.0.1)(magicast@0.3.5)(playwright-core@1.57.0)(typescript@5.9.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.10.4)(jiti@2.7.0)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))
       better-sqlite3:
         specifier: catalog:nuxt
         version: 12.4.5
@@ -415,7 +418,7 @@ importers:
         version: 4.3.0
       typescript:
         specifier: 'catalog:'
-        version: 5.8.3
+        version: 5.9.3
       unist-util-visit:
         specifier: 5.0.0
         version: 5.0.0
@@ -475,7 +478,7 @@ importers:
         version: link:../../engine/styleframe
       vue:
         specifier: catalog:nuxt
-        version: 3.5.34(typescript@5.8.3)
+        version: 3.5.34(typescript@5.9.3)
     devDependencies:
       '@styleframe/plugin':
         specifier: workspace:*
@@ -485,19 +488,19 @@ importers:
         version: 22.15.32
       '@vitejs/plugin-vue':
         specifier: catalog:nuxt
-        version: 6.0.7(vite@8.0.14(@types/node@22.15.32)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.8.3))
+        version: 6.0.7(vite@8.0.14(@types/node@22.15.32)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.7(@vitest/browser@4.1.7)(vitest@4.1.7)
       '@vue/tsconfig':
         specifier: catalog:nuxt
-        version: 0.8.1(typescript@5.8.3)(vue@3.5.34(typescript@5.8.3))
+        version: 0.8.1(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3))
       jsdom:
         specifier: 'catalog:'
         version: 25.0.1
       typescript:
         specifier: 'catalog:'
-        version: 5.8.3
+        version: 5.9.3
       vite:
         specifier: catalog:nuxt
         version: 8.0.14(@types/node@22.15.32)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0)
@@ -506,7 +509,7 @@ importers:
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@22.15.32)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(jsdom@25.0.1)(vite@8.0.14(@types/node@22.15.32)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))
       vue-tsc:
         specifier: catalog:nuxt
-        version: 3.2.1(typescript@5.8.3)
+        version: 3.2.1(typescript@5.9.3)
 
   apps/shared:
     dependencies:
@@ -597,7 +600,7 @@ importers:
         version: link:../../engine/styleframe
       vue:
         specifier: catalog:nuxt
-        version: 3.5.34(typescript@5.8.3)
+        version: 3.5.34(typescript@5.9.3)
     devDependencies:
       '@chromatic-com/storybook':
         specifier: ^4.1.3
@@ -619,13 +622,13 @@ importers:
         version: 10.4.1(@vitest/browser-playwright@4.1.7)(@vitest/browser@4.1.7)(@vitest/runner@4.1.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.7)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vitest@4.1.7)
       '@storybook/vue3-vite':
         specifier: ^10.4.1
-        version: 10.4.1(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.7)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.14(@types/node@22.15.32)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.8.3))(webpack@5.102.1(esbuild@0.28.0))
+        version: 10.4.1(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.7)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.14(@types/node@22.15.32)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))(webpack@5.102.1(esbuild@0.28.0))
       '@types/node':
         specifier: 'catalog:'
         version: 22.15.32
       '@vitejs/plugin-vue':
         specifier: catalog:nuxt
-        version: 6.0.7(vite@8.0.14(@types/node@22.15.32)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.8.3))
+        version: 6.0.7(vite@8.0.14(@types/node@22.15.32)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))
       '@vitest/browser-playwright':
         specifier: ^4.1.7
         version: 4.1.7(playwright@1.57.0)(vite@8.0.14(@types/node@22.15.32)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vitest@4.1.7)
@@ -634,7 +637,7 @@ importers:
         version: 4.1.7(@vitest/browser@4.1.7)(vitest@4.1.7)
       '@vue/tsconfig':
         specifier: catalog:nuxt
-        version: 0.8.1(typescript@5.8.3)(vue@3.5.34(typescript@5.8.3))
+        version: 0.8.1(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3))
       '@vueless/storybook-dark-mode':
         specifier: ^10.0.7
         version: 10.0.7(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.7)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
@@ -646,7 +649,7 @@ importers:
         version: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.7)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       typescript:
         specifier: 'catalog:'
-        version: 5.8.3
+        version: 5.9.3
       vite:
         specifier: catalog:nuxt
         version: 8.0.14(@types/node@22.15.32)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0)
@@ -655,16 +658,19 @@ importers:
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@22.15.32)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(jsdom@25.0.1)(vite@8.0.14(@types/node@22.15.32)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))
       vue-tsc:
         specifier: catalog:nuxt
-        version: 3.2.1(typescript@5.8.3)
+        version: 3.2.1(typescript@5.9.3)
 
   config/typescript:
     devDependencies:
       typescript:
         specifier: 'catalog:'
-        version: 5.8.3
+        version: 5.9.3
 
   config/vite:
     devDependencies:
+      '@microsoft/api-extractor':
+        specifier: 'catalog:'
+        version: 7.58.7(@types/node@24.10.4)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.7(@vitest/browser@4.1.7)(vitest@4.1.7)
@@ -684,6 +690,9 @@ importers:
         specifier: ^3.1.3
         version: 3.1.3
     devDependencies:
+      '@microsoft/api-extractor':
+        specifier: 'catalog:'
+        version: 7.58.7(@types/node@24.10.4)
       '@styleframe/config-typescript':
         specifier: workspace:^3.0.0
         version: link:../../config/typescript
@@ -698,13 +707,13 @@ importers:
         version: 4.1.7(@vitest/browser@4.1.7)(vitest@4.1.7)
       typescript:
         specifier: 'catalog:'
-        version: 5.8.3
+        version: 5.9.3
       vite:
         specifier: 'catalog:'
         version: 8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0)
       vite-plugin-dts:
         specifier: 'catalog:'
-        version: 5.0.1(@microsoft/api-extractor@7.58.7(@types/node@24.10.4))(esbuild@0.28.0)(rolldown@1.0.2)(rollup@4.60.4)(typescript@5.8.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(webpack@5.102.1(esbuild@0.28.0))
+        version: 5.0.1(@microsoft/api-extractor@7.58.7(@types/node@24.10.4))(esbuild@0.28.0)(rolldown@1.0.2)(rollup@4.60.4)(typescript@5.9.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(webpack@5.102.1(esbuild@0.28.0))
       vitest:
         specifier: 'catalog:'
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@24.10.4)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(jsdom@25.0.1)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))
@@ -718,6 +727,9 @@ importers:
         specifier: ^2.4.2
         version: 2.6.1
     devDependencies:
+      '@microsoft/api-extractor':
+        specifier: 'catalog:'
+        version: 7.58.7(@types/node@24.10.4)
       '@styleframe/config-typescript':
         specifier: workspace:^3.0.0
         version: link:../../config/typescript
@@ -741,19 +753,22 @@ importers:
         version: 4.20.6
       typescript:
         specifier: 'catalog:'
-        version: 5.8.3
+        version: 5.9.3
       vite:
         specifier: 'catalog:'
         version: 8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0)
       vite-plugin-dts:
         specifier: 'catalog:'
-        version: 5.0.1(@microsoft/api-extractor@7.58.7(@types/node@24.10.4))(esbuild@0.28.0)(rolldown@1.0.2)(rollup@4.60.4)(typescript@5.8.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(webpack@5.102.1(esbuild@0.28.0))
+        version: 5.0.1(@microsoft/api-extractor@7.58.7(@types/node@24.10.4))(esbuild@0.28.0)(rolldown@1.0.2)(rollup@4.60.4)(typescript@5.9.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(webpack@5.102.1(esbuild@0.28.0))
       vitest:
         specifier: 'catalog:'
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@24.10.4)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(jsdom@25.0.1)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))
 
   engine/runtime:
     devDependencies:
+      '@microsoft/api-extractor':
+        specifier: 'catalog:'
+        version: 7.58.7(@types/node@24.10.4)
       '@styleframe/config-typescript':
         specifier: workspace:^3.0.0
         version: link:../../config/typescript
@@ -768,13 +783,13 @@ importers:
         version: 4.1.7(@vitest/browser@4.1.7)(vitest@4.1.7)
       typescript:
         specifier: 'catalog:'
-        version: 5.8.3
+        version: 5.9.3
       vite:
         specifier: 'catalog:'
         version: 8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0)
       vite-plugin-dts:
         specifier: 'catalog:'
-        version: 5.0.1(@microsoft/api-extractor@7.58.7(@types/node@24.10.4))(esbuild@0.28.0)(rolldown@1.0.2)(rollup@4.60.4)(typescript@5.8.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(webpack@5.102.1(esbuild@0.28.0))
+        version: 5.0.1(@microsoft/api-extractor@7.58.7(@types/node@24.10.4))(esbuild@0.28.0)(rolldown@1.0.2)(rollup@4.60.4)(typescript@5.9.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(webpack@5.102.1(esbuild@0.28.0))
       vitest:
         specifier: 'catalog:'
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@24.10.4)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(jsdom@25.0.1)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))
@@ -788,6 +803,9 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1
     devDependencies:
+      '@microsoft/api-extractor':
+        specifier: 'catalog:'
+        version: 7.58.7(@types/node@24.10.4)
       '@styleframe/config-typescript':
         specifier: workspace:^3.0.0
         version: link:../../config/typescript
@@ -805,13 +823,13 @@ importers:
         version: 4.1.7(@vitest/browser@4.1.7)(vitest@4.1.7)
       typescript:
         specifier: 'catalog:'
-        version: 5.8.3
+        version: 5.9.3
       vite:
         specifier: 'catalog:'
         version: 8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0)
       vite-plugin-dts:
         specifier: 'catalog:'
-        version: 5.0.1(@microsoft/api-extractor@7.58.7(@types/node@24.10.4))(esbuild@0.28.0)(rolldown@1.0.2)(rollup@4.60.4)(typescript@5.8.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(webpack@5.102.1(esbuild@0.28.0))
+        version: 5.0.1(@microsoft/api-extractor@7.58.7(@types/node@24.10.4))(esbuild@0.28.0)(rolldown@1.0.2)(rollup@4.60.4)(typescript@5.9.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(webpack@5.102.1(esbuild@0.28.0))
       vitest:
         specifier: 'catalog:'
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@24.10.4)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(jsdom@25.0.1)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))
@@ -865,6 +883,9 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0
     devDependencies:
+      '@microsoft/api-extractor':
+        specifier: 'catalog:'
+        version: 7.58.7(@types/node@24.10.4)
       '@styleframe/config-typescript':
         specifier: workspace:^3.0.0
         version: link:../../config/typescript
@@ -882,13 +903,13 @@ importers:
         version: 4.1.7(@vitest/browser@4.1.7)(vitest@4.1.7)
       typescript:
         specifier: 'catalog:'
-        version: 5.8.3
+        version: 5.9.3
       vite:
         specifier: 'catalog:'
         version: 8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0)
       vite-plugin-dts:
         specifier: 'catalog:'
-        version: 5.0.1(@microsoft/api-extractor@7.58.7(@types/node@24.10.4))(esbuild@0.28.0)(rolldown@1.0.2)(rollup@4.60.4)(typescript@5.8.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(webpack@5.102.1(esbuild@0.28.0))
+        version: 5.0.1(@microsoft/api-extractor@7.58.7(@types/node@24.10.4))(esbuild@0.28.0)(rolldown@1.0.2)(rollup@4.60.4)(typescript@5.9.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(webpack@5.102.1(esbuild@0.28.0))
       vitest:
         specifier: 'catalog:'
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@24.10.4)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(jsdom@25.0.1)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))
@@ -936,7 +957,7 @@ importers:
         version: 4.20.6
       typescript:
         specifier: 'catalog:'
-        version: 5.8.3
+        version: 5.9.3
       vitest:
         specifier: 'catalog:'
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@22.15.32)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(jsdom@25.0.1)(vite@8.0.14(@types/node@22.15.32)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))
@@ -950,6 +971,9 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0
     devDependencies:
+      '@microsoft/api-extractor':
+        specifier: 'catalog:'
+        version: 7.58.7(@types/node@22.15.32)
       '@playwright/test':
         specifier: ^1.56.1
         version: 1.56.1
@@ -985,13 +1009,13 @@ importers:
         version: 4.20.6
       typescript:
         specifier: 'catalog:'
-        version: 5.8.3
+        version: 5.9.3
       vite:
         specifier: 'catalog:'
         version: 8.0.14(@types/node@22.15.32)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0)
       vite-plugin-dts:
         specifier: 'catalog:'
-        version: 5.0.1(@microsoft/api-extractor@7.58.7(@types/node@22.15.32))(esbuild@0.28.0)(rolldown@1.0.2)(rollup@4.60.4)(typescript@5.8.3)(vite@8.0.14(@types/node@22.15.32)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(webpack@5.102.1(esbuild@0.28.0))
+        version: 5.0.1(@microsoft/api-extractor@7.58.7(@types/node@22.15.32))(esbuild@0.28.0)(rolldown@1.0.2)(rollup@4.60.4)(typescript@5.9.3)(vite@8.0.14(@types/node@22.15.32)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(webpack@5.102.1(esbuild@0.28.0))
       vitest:
         specifier: 'catalog:'
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@22.15.32)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(jsdom@25.0.1)(vite@8.0.14(@types/node@22.15.32)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))
@@ -1008,6 +1032,9 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0
     devDependencies:
+      '@microsoft/api-extractor':
+        specifier: 'catalog:'
+        version: 7.58.7(@types/node@24.10.4)
       '@styleframe/config-typescript':
         specifier: workspace:^3.0.0
         version: link:../config/typescript
@@ -1025,13 +1052,13 @@ importers:
         version: 4.1.7(@vitest/browser@4.1.7)(vitest@4.1.7)
       typescript:
         specifier: 'catalog:'
-        version: 5.8.3
+        version: 5.9.3
       vite:
         specifier: 'catalog:'
         version: 8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0)
       vite-plugin-dts:
         specifier: 'catalog:'
-        version: 5.0.1(@microsoft/api-extractor@7.58.7(@types/node@24.10.4))(esbuild@0.28.0)(rolldown@1.0.2)(rollup@4.60.4)(typescript@5.8.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(webpack@5.102.1(esbuild@0.28.0))
+        version: 5.0.1(@microsoft/api-extractor@7.58.7(@types/node@24.10.4))(esbuild@0.28.0)(rolldown@1.0.2)(rollup@4.60.4)(typescript@5.9.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(webpack@5.102.1(esbuild@0.28.0))
       vitest:
         specifier: 'catalog:'
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@24.10.4)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(jsdom@25.0.1)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))
@@ -1054,6 +1081,9 @@ importers:
         specifier: ^0.5.0
         version: 0.5.0
     devDependencies:
+      '@microsoft/api-extractor':
+        specifier: 'catalog:'
+        version: 7.58.7(@types/node@24.10.4)
       '@styleframe/config-typescript':
         specifier: workspace:^3.0.0
         version: link:../../config/typescript
@@ -1080,13 +1110,13 @@ importers:
         version: 4.20.6
       typescript:
         specifier: 'catalog:'
-        version: 5.8.3
+        version: 5.9.3
       vite:
         specifier: 'catalog:'
         version: 8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0)
       vite-plugin-dts:
         specifier: 'catalog:'
-        version: 5.0.1(@microsoft/api-extractor@7.58.7(@types/node@24.10.4))(esbuild@0.28.0)(rolldown@1.0.2)(rollup@4.60.4)(typescript@5.8.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(webpack@5.102.1(esbuild@0.28.0))
+        version: 5.0.1(@microsoft/api-extractor@7.58.7(@types/node@24.10.4))(esbuild@0.28.0)(rolldown@1.0.2)(rollup@4.60.4)(typescript@5.9.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(webpack@5.102.1(esbuild@0.28.0))
       vite-plugin-node:
         specifier: 'catalog:'
         version: 8.0.0(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))
@@ -1111,10 +1141,10 @@ importers:
         version: 4.1.7(@vitest/browser@4.1.7)(vitest@4.1.7)
       tsdown:
         specifier: ^0.12.0
-        version: 0.12.9(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@5.8.3)(vue-tsc@3.2.1(typescript@5.8.3))
+        version: 0.12.9(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@5.9.3)(vue-tsc@3.2.1(typescript@5.9.3))
       typescript:
         specifier: 'catalog:'
-        version: 5.8.3
+        version: 5.9.3
       vitest:
         specifier: 'catalog:'
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@24.10.4)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(jsdom@25.0.1)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))
@@ -11103,11 +11133,6 @@ packages:
   type-level-regexp@0.1.17:
     resolution: {integrity: sha512-wTk4DH3cxwk196uGLK/E9pE45aLfeKJacKmcEgEOA/q5dnPGNxXt0cfYdFxb57L+sEpf1oJH4Dnx/pnRcku9jg==}
 
-  typescript@5.8.3:
-    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -12819,18 +12844,6 @@ snapshots:
 
   '@csstools/css-tokenizer@3.0.4': {}
 
-  '@dxup/nuxt@0.4.1(magicast@0.3.5)(typescript@5.8.3)':
-    dependencies:
-      '@dxup/unimport': 0.1.2
-      '@nuxt/kit': 4.4.6(magicast@0.3.5)
-      chokidar: 5.0.0
-      pathe: 2.0.3
-      tinyglobby: 0.2.16
-    optionalDependencies:
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - magicast
-
   '@dxup/nuxt@0.4.1(magicast@0.3.5)(typescript@5.9.3)':
     dependencies:
       '@dxup/unimport': 0.1.2
@@ -13380,15 +13393,6 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
-  '@floating-ui/vue@1.1.9(vue@3.5.34(typescript@5.8.3))':
-    dependencies:
-      '@floating-ui/dom': 1.7.6
-      '@floating-ui/utils': 0.2.10
-      vue-demi: 0.14.10(vue@3.5.34(typescript@5.8.3))
-    transitivePeerDependencies:
-      - '@vue/composition-api'
-      - vue
-
   '@floating-ui/vue@1.1.9(vue@3.5.34(typescript@5.9.3))':
     dependencies:
       '@floating-ui/dom': 1.7.6
@@ -13445,11 +13449,6 @@ snapshots:
       '@iconify/types': 2.0.0
       import-meta-resolve: 4.2.0
 
-  '@iconify/vue@5.0.1(vue@3.5.34(typescript@5.8.3))':
-    dependencies:
-      '@iconify/types': 2.0.0
-      vue: 3.5.34(typescript@5.8.3)
-
   '@iconify/vue@5.0.1(vue@3.5.34(typescript@5.9.3))':
     dependencies:
       '@iconify/types': 2.0.0
@@ -13476,20 +13475,6 @@ snapshots:
   '@internationalized/number@3.6.5':
     dependencies:
       '@swc/helpers': 0.5.17
-
-  '@intlify/bundle-utils@11.0.1(vue-i18n@11.1.12(vue@3.5.34(typescript@5.8.3)))':
-    dependencies:
-      '@intlify/message-compiler': 11.1.12
-      '@intlify/shared': 11.1.12
-      acorn: 8.15.0
-      esbuild: 0.25.11
-      escodegen: 2.1.0
-      estree-walker: 2.0.2
-      jsonc-eslint-parser: 2.4.1
-      source-map-js: 1.2.1
-      yaml-eslint-parser: 1.3.0
-    optionalDependencies:
-      vue-i18n: 11.1.12(vue@3.5.34(typescript@5.8.3))
 
   '@intlify/bundle-utils@11.0.1(vue-i18n@11.1.12(vue@3.5.34(typescript@5.9.3)))':
     dependencies:
@@ -13527,30 +13512,6 @@ snapshots:
 
   '@intlify/shared@11.1.12': {}
 
-  '@intlify/unplugin-vue-i18n@11.0.1(@vue/compiler-dom@3.5.34)(eslint@9.37.0(jiti@2.7.0))(rollup@4.60.4)(typescript@5.9.3)(vue-i18n@11.1.12(vue@3.5.34(typescript@5.8.3)))(vue@3.5.34(typescript@5.8.3))':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.37.0(jiti@2.7.0))
-      '@intlify/bundle-utils': 11.0.1(vue-i18n@11.1.12(vue@3.5.34(typescript@5.8.3)))
-      '@intlify/shared': 11.1.12
-      '@intlify/vue-i18n-extensions': 8.0.0(@intlify/shared@11.1.12)(@vue/compiler-dom@3.5.34)(vue-i18n@11.1.12(vue@3.5.34(typescript@5.8.3)))(vue@3.5.34(typescript@5.8.3))
-      '@rollup/pluginutils': 5.3.0(rollup@4.60.4)
-      '@typescript-eslint/scope-manager': 8.46.2
-      '@typescript-eslint/typescript-estree': 8.46.2(typescript@5.9.3)
-      debug: 4.4.3(supports-color@5.5.0)
-      fast-glob: 3.3.3
-      pathe: 2.0.3
-      picocolors: 1.1.1
-      unplugin: 2.3.11
-      vue: 3.5.34(typescript@5.8.3)
-    optionalDependencies:
-      vue-i18n: 11.1.12(vue@3.5.34(typescript@5.8.3))
-    transitivePeerDependencies:
-      - '@vue/compiler-dom'
-      - eslint
-      - rollup
-      - supports-color
-      - typescript
-
   '@intlify/unplugin-vue-i18n@11.0.1(@vue/compiler-dom@3.5.34)(eslint@9.37.0(jiti@2.7.0))(rollup@4.60.4)(typescript@5.9.3)(vue-i18n@11.1.12(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@9.37.0(jiti@2.7.0))
@@ -13576,15 +13537,6 @@ snapshots:
       - typescript
 
   '@intlify/utils@0.13.0': {}
-
-  '@intlify/vue-i18n-extensions@8.0.0(@intlify/shared@11.1.12)(@vue/compiler-dom@3.5.34)(vue-i18n@11.1.12(vue@3.5.34(typescript@5.8.3)))(vue@3.5.34(typescript@5.8.3))':
-    dependencies:
-      '@babel/parser': 7.28.5
-    optionalDependencies:
-      '@intlify/shared': 11.1.12
-      '@vue/compiler-dom': 3.5.34
-      vue: 3.5.34(typescript@5.8.3)
-      vue-i18n: 11.1.12(vue@3.5.34(typescript@5.8.3))
 
   '@intlify/vue-i18n-extensions@8.0.0(@intlify/shared@11.1.12)(@vue/compiler-dom@3.5.34)(vue-i18n@11.1.12(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))':
     dependencies:
@@ -13728,7 +13680,6 @@ snapshots:
       '@rushstack/node-core-library': 5.23.1(@types/node@22.15.32)
     transitivePeerDependencies:
       - '@types/node'
-    optional: true
 
   '@microsoft/api-extractor-model@7.33.8(@types/node@24.10.4)':
     dependencies:
@@ -13737,7 +13688,6 @@ snapshots:
       '@rushstack/node-core-library': 5.23.1(@types/node@24.10.4)
     transitivePeerDependencies:
       - '@types/node'
-    optional: true
 
   '@microsoft/api-extractor@7.58.7(@types/node@22.15.32)':
     dependencies:
@@ -13756,7 +13706,6 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - '@types/node'
-    optional: true
 
   '@microsoft/api-extractor@7.58.7(@types/node@24.10.4)':
     dependencies:
@@ -13775,7 +13724,6 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - '@types/node'
-    optional: true
 
   '@microsoft/tsdoc-config@0.18.1':
     dependencies:
@@ -13783,10 +13731,8 @@ snapshots:
       ajv: 8.18.0
       jju: 1.4.0
       resolve: 1.22.11
-    optional: true
 
-  '@microsoft/tsdoc@0.16.0':
-    optional: true
+  '@microsoft/tsdoc@0.16.0': {}
 
   '@miyaneee/rollup-plugin-json5@1.2.0(rollup@4.60.4)':
     dependencies:
@@ -13947,67 +13893,6 @@ snapshots:
       - commander
       - magicast
       - supports-color
-
-  '@nuxt/content@3.7.1(@valibot/to-json-schema@1.7.0(valibot@1.4.0(typescript@5.8.3)))(better-sqlite3@12.4.5)(magicast@0.3.5)(valibot@1.4.0(typescript@5.8.3))':
-    dependencies:
-      '@nuxt/kit': 4.4.6(magicast@0.3.5)
-      '@nuxtjs/mdc': 0.17.4(magicast@0.3.5)
-      '@shikijs/langs': 3.13.0
-      '@sqlite.org/sqlite-wasm': 3.50.4-build1
-      '@standard-schema/spec': 1.0.0
-      '@webcontainer/env': 1.1.1
-      c12: 3.3.0(magicast@0.3.5)
-      chokidar: 4.0.3
-      consola: 3.4.2
-      db0: 0.3.4(better-sqlite3@12.4.5)
-      defu: 6.1.4
-      destr: 2.0.5
-      git-url-parse: 16.1.0
-      jiti: 2.6.1
-      json-schema-to-typescript: 15.0.4
-      knitwork: 1.2.0
-      listhen: 1.9.0
-      mdast-util-to-hast: 13.2.0
-      mdast-util-to-string: 4.0.0
-      micromark: 4.0.2
-      micromark-util-character: 2.1.1
-      micromark-util-chunked: 2.0.1
-      micromark-util-resolve-all: 2.0.1
-      micromark-util-sanitize-uri: 2.0.1
-      micromatch: 4.0.8
-      minimark: 0.2.0
-      minimatch: 10.0.3
-      nuxt-component-meta: 0.14.0(magicast@0.3.5)
-      nypm: 0.6.2
-      ohash: 2.0.11
-      pathe: 2.0.3
-      pkg-types: 2.3.0
-      remark-mdc: 3.6.0
-      scule: 1.3.0
-      shiki: 3.13.0
-      slugify: 1.6.6
-      socket.io-client: 4.8.1
-      tar: 7.5.1
-      tinyglobby: 0.2.15
-      ufo: 1.6.1
-      unctx: 2.4.1
-      unified: 11.0.5
-      unist-util-stringify-position: 4.0.0
-      unist-util-visit: 5.0.0
-      ws: 8.18.3
-      zod: 3.25.76
-      zod-to-json-schema: 3.24.6(zod@3.25.76)
-    optionalDependencies:
-      '@valibot/to-json-schema': 1.7.0(valibot@1.4.0(typescript@5.8.3))
-      better-sqlite3: 12.4.5
-      valibot: 1.4.0(typescript@5.8.3)
-    transitivePeerDependencies:
-      - bufferutil
-      - drizzle-orm
-      - magicast
-      - mysql2
-      - supports-color
-      - utf-8-validate
 
   '@nuxt/content@3.7.1(@valibot/to-json-schema@1.7.0(valibot@1.4.0(typescript@5.9.3)))(better-sqlite3@12.4.5)(magicast@0.3.5)(valibot@1.4.0(typescript@5.9.3))':
     dependencies:
@@ -14176,47 +14061,6 @@ snapshots:
       pkg-types: 2.3.0
       semver: 7.8.1
 
-  '@nuxt/devtools@3.2.4(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.8.3))':
-    dependencies:
-      '@nuxt/devtools-kit': 3.2.4(magicast@0.5.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))
-      '@nuxt/devtools-wizard': 3.2.4
-      '@nuxt/kit': 4.4.6(magicast@0.5.3)
-      '@vue/devtools-core': 8.1.2(vue@3.5.34(typescript@5.8.3))
-      '@vue/devtools-kit': 8.1.2
-      birpc: 4.0.0
-      consola: 3.4.2
-      destr: 2.0.5
-      error-stack-parser-es: 1.0.5
-      execa: 8.0.1
-      fast-npm-meta: 1.5.1
-      get-port-please: 3.2.0
-      hookable: 6.1.1
-      image-meta: 0.2.2
-      is-installed-globally: 1.0.0
-      launch-editor: 2.13.2
-      local-pkg: 1.1.2
-      magicast: 0.5.3
-      nypm: 0.6.6
-      ohash: 2.0.11
-      pathe: 2.0.3
-      perfect-debounce: 2.1.0
-      pkg-types: 2.3.0
-      semver: 7.8.1
-      simple-git: 3.36.0
-      sirv: 3.0.2
-      structured-clone-es: 2.0.0
-      tinyglobby: 0.2.16
-      vite: 8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0)
-      vite-plugin-inspect: 11.3.3(@nuxt/kit@4.4.6(magicast@0.3.5))(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))
-      vite-plugin-vue-tracer: 1.4.0(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.8.3))
-      which: 6.0.1
-      ws: 8.21.0
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - vue
-
   '@nuxt/devtools@3.2.4(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))':
     dependencies:
       '@nuxt/devtools-kit': 3.2.4(magicast@0.5.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))
@@ -14337,27 +14181,6 @@ snapshots:
       - magicast
       - uploadthing
       - vite
-
-  '@nuxt/icon@2.2.2(magicast@0.3.5)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.8.3))':
-    dependencies:
-      '@iconify/collections': 1.0.688
-      '@iconify/types': 2.0.0
-      '@iconify/utils': 3.1.3
-      '@iconify/vue': 5.0.1(vue@3.5.34(typescript@5.8.3))
-      '@nuxt/devtools-kit': 3.2.4(magicast@0.3.5)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))
-      '@nuxt/kit': 4.4.6(magicast@0.3.5)
-      consola: 3.4.2
-      local-pkg: 1.1.2
-      mlly: 1.8.2
-      ohash: 2.0.11
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
-      tinyglobby: 0.2.16
-    transitivePeerDependencies:
-      - magicast
-      - vite
-      - vue
 
   '@nuxt/icon@2.2.2(magicast@0.3.5)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))':
     dependencies:
@@ -14583,73 +14406,6 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/nitro-server@4.4.6(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(better-sqlite3@12.4.5)(db0@0.3.4(better-sqlite3@12.4.5))(ioredis@5.10.1)(magicast@0.3.5)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.2.2)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.4)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.4.5)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.4.5))(eslint@9.37.0(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.2.0)(rolldown@1.0.2)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.2)(rollup@4.60.4))(rollup@4.60.4)(terser@5.44.0)(tsx@4.20.6)(typescript@5.8.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue-tsc@3.2.1(typescript@5.8.3))(yaml@2.9.0))(oxc-parser@0.131.0)(rolldown@1.0.2)(typescript@5.8.3)':
-    dependencies:
-      '@nuxt/devalue': 2.0.2
-      '@nuxt/kit': 4.4.6(magicast@0.3.5)
-      '@unhead/vue': 2.1.15(vue@3.5.34(typescript@5.8.3))
-      '@vue/shared': 3.5.34
-      consola: 3.4.2
-      defu: 6.1.7
-      destr: 2.0.5
-      devalue: 5.8.1
-      errx: 0.1.0
-      escape-string-regexp: 5.0.0
-      exsolve: 1.0.8
-      h3: 1.15.11
-      impound: 1.1.5
-      klona: 2.0.6
-      mocked-exports: 0.1.1
-      nitropack: 2.13.4(@netlify/blobs@9.1.2)(better-sqlite3@12.4.5)(oxc-parser@0.131.0)(rolldown@1.0.2)
-      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.2.2)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.4)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.4.5)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.4.5))(eslint@9.37.0(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.2.0)(rolldown@1.0.2)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.2)(rollup@4.60.4))(rollup@4.60.4)(terser@5.44.0)(tsx@4.20.6)(typescript@5.8.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue-tsc@3.2.1(typescript@5.8.3))(yaml@2.9.0)
-      nypm: 0.6.6
-      ohash: 2.0.11
-      pathe: 2.0.3
-      rou3: 0.8.1
-      std-env: 4.1.0
-      ufo: 1.6.4
-      unctx: 2.5.0
-      unstorage: 1.17.5(@netlify/blobs@9.1.2)(db0@0.3.4(better-sqlite3@12.4.5))(ioredis@5.10.1)
-      vue: 3.5.34(typescript@5.8.3)
-      vue-bundle-renderer: 2.2.0
-      vue-devtools-stub: 0.1.0
-    optionalDependencies:
-      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@electric-sql/pglite'
-      - '@libsql/client'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - better-sqlite3
-      - db0
-      - drizzle-orm
-      - encoding
-      - idb-keyval
-      - ioredis
-      - magicast
-      - mysql2
-      - oxc-parser
-      - react-native-b4a
-      - rolldown
-      - sqlite3
-      - supports-color
-      - typescript
-      - uploadthing
-      - xml2js
-
   '@nuxt/nitro-server@4.4.6(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(better-sqlite3@12.4.5)(db0@0.3.4(better-sqlite3@12.4.5))(ioredis@5.10.1)(magicast@0.3.5)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.2.2)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.4)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.4.5)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.4.5))(eslint@9.37.0(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.2.0)(rolldown@1.0.2)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.2)(rollup@4.60.4))(rollup@4.60.4)(terser@5.44.0)(tsx@4.20.6)(typescript@5.9.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue-tsc@3.2.1(typescript@5.9.3))(yaml@2.9.0))(oxc-parser@0.131.0)(rolldown@1.0.2)(typescript@5.9.3)':
     dependencies:
       '@nuxt/devalue': 2.0.2
@@ -14792,11 +14548,11 @@ snapshots:
       pkg-types: 2.3.1
       std-env: 4.1.0
 
-  '@nuxt/scripts@0.11.13(@netlify/blobs@9.1.2)(@unhead/vue@2.0.19(vue@3.5.34(typescript@5.8.3)))(db0@0.3.4(better-sqlite3@12.4.5))(ioredis@5.10.1)(magicast@0.3.5)(typescript@5.8.3)(vue@3.5.34(typescript@5.8.3))':
+  '@nuxt/scripts@0.11.13(@netlify/blobs@9.1.2)(@unhead/vue@2.0.19(vue@3.5.34(typescript@5.9.3)))(db0@0.3.4(better-sqlite3@12.4.5))(ioredis@5.10.1)(magicast@0.3.5)(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3))':
     dependencies:
       '@nuxt/kit': 4.4.6(magicast@0.3.5)
-      '@unhead/vue': 2.0.19(vue@3.5.34(typescript@5.8.3))
-      '@vueuse/core': 13.9.0(vue@3.5.34(typescript@5.8.3))
+      '@unhead/vue': 2.0.19(vue@3.5.34(typescript@5.9.3))
+      '@vueuse/core': 13.9.0(vue@3.5.34(typescript@5.9.3))
       consola: 3.4.2
       defu: 6.1.4
       h3: 1.15.4
@@ -14810,7 +14566,7 @@ snapshots:
       ufo: 1.6.1
       unplugin: 2.3.10
       unstorage: 1.17.1(@netlify/blobs@9.1.2)(db0@0.3.4(better-sqlite3@12.4.5))(ioredis@5.10.1)
-      valibot: 1.1.0(typescript@5.8.3)
+      valibot: 1.1.0(typescript@5.9.3)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -14939,41 +14695,6 @@ snapshots:
       rc9: 3.0.1
       std-env: 4.1.0
 
-  '@nuxt/test-utils@3.19.2(@playwright/test@1.56.1)(jsdom@25.0.1)(magicast@0.3.5)(playwright-core@1.57.0)(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.10.4)(jiti@2.7.0)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))':
-    dependencies:
-      '@nuxt/kit': 3.19.3(magicast@0.3.5)
-      c12: 3.3.0(magicast@0.3.5)
-      consola: 3.4.2
-      defu: 6.1.4
-      destr: 2.0.5
-      estree-walker: 3.0.3
-      fake-indexeddb: 6.2.2
-      get-port-please: 3.2.0
-      h3: 1.15.4
-      local-pkg: 1.1.2
-      magic-string: 0.30.21
-      node-fetch-native: 1.6.7
-      node-mock-http: 1.0.3
-      ofetch: 1.4.1
-      pathe: 2.0.3
-      perfect-debounce: 1.0.0
-      radix3: 1.1.2
-      scule: 1.3.0
-      std-env: 3.10.0
-      tinyexec: 1.0.1
-      ufo: 1.6.1
-      unplugin: 2.3.10
-      vitest-environment-nuxt: 1.0.1(@playwright/test@1.56.1)(jsdom@25.0.1)(magicast@0.3.5)(playwright-core@1.57.0)(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.10.4)(jiti@2.7.0)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))
-      vue: 3.5.34(typescript@5.8.3)
-    optionalDependencies:
-      '@playwright/test': 1.56.1
-      jsdom: 25.0.1
-      playwright-core: 1.57.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.4)(jiti@2.7.0)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - magicast
-      - typescript
-
   '@nuxt/test-utils@3.19.2(@playwright/test@1.56.1)(jsdom@25.0.1)(magicast@0.3.5)(playwright-core@1.57.0)(typescript@5.9.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.10.4)(jiti@2.7.0)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))':
     dependencies:
       '@nuxt/kit': 3.19.3(magicast@0.3.5)
@@ -15044,26 +14765,26 @@ snapshots:
       - magicast
       - typescript
 
-  '@nuxt/ui@4.8.0(@internationalized/date@3.10.0)(@internationalized/number@3.6.5)(@netlify/blobs@9.1.2)(@nuxt/content@3.7.1(@valibot/to-json-schema@1.7.0(valibot@1.4.0(typescript@5.8.3)))(better-sqlite3@12.4.5)(magicast@0.3.5)(valibot@1.4.0(typescript@5.8.3)))(@tiptap/extensions@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6))(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(change-case@5.4.4)(db0@0.3.4(better-sqlite3@12.4.5))(embla-carousel@8.6.0)(ioredis@5.10.1)(jwt-decode@4.0.0)(magicast@0.3.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.3.0)(typescript@5.8.3)(valibot@1.4.0(typescript@5.8.3))(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue-router@4.5.1(vue@3.5.34(typescript@5.8.3)))(vue@3.5.34(typescript@5.8.3))(yjs@13.6.30)(zod@4.1.12)':
+  '@nuxt/ui@4.8.0(@internationalized/date@3.10.0)(@internationalized/number@3.6.5)(@netlify/blobs@9.1.2)(@nuxt/content@3.7.1(@valibot/to-json-schema@1.7.0(valibot@1.4.0(typescript@5.9.3)))(better-sqlite3@12.4.5)(magicast@0.3.5)(valibot@1.4.0(typescript@5.9.3)))(@tiptap/extensions@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6))(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(change-case@5.4.4)(db0@0.3.4(better-sqlite3@12.4.5))(embla-carousel@8.6.0)(ioredis@5.10.1)(jwt-decode@4.0.0)(magicast@0.3.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.3.0)(typescript@5.9.3)(valibot@1.4.0(typescript@5.9.3))(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue-router@4.5.1(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))(yjs@13.6.30)(zod@4.1.12)':
     dependencies:
       '@floating-ui/dom': 1.7.6
-      '@iconify/vue': 5.0.1(vue@3.5.34(typescript@5.8.3))
+      '@iconify/vue': 5.0.1(vue@3.5.34(typescript@5.9.3))
       '@nuxt/fonts': 0.14.0(@netlify/blobs@9.1.2)(db0@0.3.4(better-sqlite3@12.4.5))(ioredis@5.10.1)(magicast@0.3.5)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))
-      '@nuxt/icon': 2.2.2(magicast@0.3.5)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.8.3))
+      '@nuxt/icon': 2.2.2(magicast@0.3.5)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))
       '@nuxt/kit': 4.4.6(magicast@0.3.5)
       '@nuxt/schema': 4.4.6
       '@nuxtjs/color-mode': 3.5.2(magicast@0.3.5)
       '@standard-schema/spec': 1.1.0
       '@tailwindcss/postcss': 4.3.0
       '@tailwindcss/vite': 4.3.0(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))
-      '@tanstack/vue-table': 8.21.3(vue@3.5.34(typescript@5.8.3))
-      '@tanstack/vue-virtual': 3.13.25(vue@3.5.34(typescript@5.8.3))
+      '@tanstack/vue-table': 8.21.3(vue@3.5.34(typescript@5.9.3))
+      '@tanstack/vue-virtual': 3.13.25(vue@3.5.34(typescript@5.9.3))
       '@tiptap/core': 3.23.6(@tiptap/pm@3.23.6)
       '@tiptap/extension-bubble-menu': 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)
       '@tiptap/extension-code': 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))
       '@tiptap/extension-collaboration': 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(yjs@13.6.30)
       '@tiptap/extension-drag-handle': 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/extension-collaboration@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(yjs@13.6.30))(@tiptap/extension-node-range@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))
-      '@tiptap/extension-drag-handle-vue-3': 3.23.6(@tiptap/extension-drag-handle@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/extension-collaboration@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(yjs@13.6.30))(@tiptap/extension-node-range@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30)))(@tiptap/pm@3.23.6)(@tiptap/vue-3@3.23.6(@floating-ui/dom@1.7.6)(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)(vue@3.5.34(typescript@5.8.3)))(vue@3.5.34(typescript@5.8.3))
+      '@tiptap/extension-drag-handle-vue-3': 3.23.6(@tiptap/extension-drag-handle@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/extension-collaboration@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(yjs@13.6.30))(@tiptap/extension-node-range@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30)))(@tiptap/pm@3.23.6)(@tiptap/vue-3@3.23.6(@floating-ui/dom@1.7.6)(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
       '@tiptap/extension-floating-menu': 3.23.6(@floating-ui/dom@1.7.6)(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)
       '@tiptap/extension-horizontal-rule': 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)
       '@tiptap/extension-image': 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))
@@ -15074,11 +14795,11 @@ snapshots:
       '@tiptap/pm': 3.23.6
       '@tiptap/starter-kit': 3.23.6
       '@tiptap/suggestion': 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)
-      '@tiptap/vue-3': 3.23.6(@floating-ui/dom@1.7.6)(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)(vue@3.5.34(typescript@5.8.3))
-      '@unhead/vue': 2.1.15(vue@3.5.34(typescript@5.8.3))
-      '@vueuse/core': 14.3.0(vue@3.5.34(typescript@5.8.3))
-      '@vueuse/integrations': 14.3.0(change-case@5.4.4)(fuse.js@7.3.0)(jwt-decode@4.0.0)(vue@3.5.34(typescript@5.8.3))
-      '@vueuse/shared': 14.3.0(vue@3.5.34(typescript@5.8.3))
+      '@tiptap/vue-3': 3.23.6(@floating-ui/dom@1.7.6)(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)(vue@3.5.34(typescript@5.9.3))
+      '@unhead/vue': 2.1.15(vue@3.5.34(typescript@5.9.3))
+      '@vueuse/core': 14.3.0(vue@3.5.34(typescript@5.9.3))
+      '@vueuse/integrations': 14.3.0(change-case@5.4.4)(fuse.js@7.3.0)(jwt-decode@4.0.0)(vue@3.5.34(typescript@5.9.3))
+      '@vueuse/shared': 14.3.0(vue@3.5.34(typescript@5.9.3))
       colortranslator: 5.0.0
       consola: 3.4.2
       defu: 6.1.7
@@ -15087,35 +14808,35 @@ snapshots:
       embla-carousel-autoplay: 8.6.0(embla-carousel@8.6.0)
       embla-carousel-class-names: 8.6.0(embla-carousel@8.6.0)
       embla-carousel-fade: 8.6.0(embla-carousel@8.6.0)
-      embla-carousel-vue: 8.6.0(vue@3.5.34(typescript@5.8.3))
+      embla-carousel-vue: 8.6.0(vue@3.5.34(typescript@5.9.3))
       embla-carousel-wheel-gestures: 8.1.0(embla-carousel@8.6.0)
       fuse.js: 7.3.0
       hookable: 6.1.1
       knitwork: 1.3.0
       magic-string: 0.30.21
       mlly: 1.8.2
-      motion-v: 2.2.1(@vueuse/core@14.3.0(vue@3.5.34(typescript@5.8.3)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.8.3))
+      motion-v: 2.2.1(@vueuse/core@14.3.0(vue@3.5.34(typescript@5.9.3)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))
       ohash: 2.0.11
       pathe: 2.0.3
-      reka-ui: 2.9.7(vue@3.5.34(typescript@5.8.3))
+      reka-ui: 2.9.7(vue@3.5.34(typescript@5.9.3))
       scule: 1.3.0
       tailwind-merge: 3.6.0
       tailwind-variants: 3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.0)
       tailwindcss: 4.3.0
       tinyglobby: 0.2.16
-      typescript: 5.8.3
+      typescript: 5.9.3
       ufo: 1.6.4
       unplugin: 3.0.0
-      unplugin-auto-import: 21.0.0(@nuxt/kit@4.4.6(magicast@0.3.5))(@vueuse/core@14.3.0(vue@3.5.34(typescript@5.8.3)))
-      unplugin-vue-components: 32.1.0(@nuxt/kit@4.4.6(magicast@0.3.5))(vue@3.5.34(typescript@5.8.3))
-      vaul-vue: 0.4.1(reka-ui@2.9.7(vue@3.5.34(typescript@5.8.3)))(vue@3.5.34(typescript@5.8.3))
+      unplugin-auto-import: 21.0.0(@nuxt/kit@4.4.6(magicast@0.3.5))(@vueuse/core@14.3.0(vue@3.5.34(typescript@5.9.3)))
+      unplugin-vue-components: 32.1.0(@nuxt/kit@4.4.6(magicast@0.3.5))(vue@3.5.34(typescript@5.9.3))
+      vaul-vue: 0.4.1(reka-ui@2.9.7(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
       vue-component-type-helpers: 3.3.1
     optionalDependencies:
       '@internationalized/date': 3.10.0
       '@internationalized/number': 3.6.5
-      '@nuxt/content': 3.7.1(@valibot/to-json-schema@1.7.0(valibot@1.4.0(typescript@5.8.3)))(better-sqlite3@12.4.5)(magicast@0.3.5)(valibot@1.4.0(typescript@5.8.3))
-      valibot: 1.4.0(typescript@5.8.3)
-      vue-router: 4.5.1(vue@3.5.34(typescript@5.8.3))
+      '@nuxt/content': 3.7.1(@valibot/to-json-schema@1.7.0(valibot@1.4.0(typescript@5.9.3)))(better-sqlite3@12.4.5)(magicast@0.3.5)(valibot@1.4.0(typescript@5.9.3))
+      valibot: 1.4.0(typescript@5.9.3)
+      vue-router: 4.5.1(vue@3.5.34(typescript@5.9.3))
       zod: 4.1.12
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -15389,67 +15110,6 @@ snapshots:
       - vue
       - yjs
 
-  '@nuxt/vite-builder@4.4.6(37095f6553ffbfdba21e7dd2b270df29)':
-    dependencies:
-      '@nuxt/kit': 4.4.6(magicast@0.3.5)
-      '@rollup/plugin-replace': 6.0.3(rollup@4.60.4)
-      '@vitejs/plugin-vue': 6.0.7(vite@7.3.3(@types/node@24.10.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.8.3))
-      '@vitejs/plugin-vue-jsx': 5.1.5(vite@7.3.3(@types/node@24.10.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.8.3))
-      autoprefixer: 10.5.0(postcss@8.5.15)
-      consola: 3.4.2
-      cssnano: 8.0.1(postcss@8.5.15)
-      defu: 6.1.7
-      escape-string-regexp: 5.0.0
-      exsolve: 1.0.8
-      get-port-please: 3.2.0
-      jiti: 2.7.0
-      knitwork: 1.3.0
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      mocked-exports: 0.1.1
-      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.2.2)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.4)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.4.5)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.4.5))(eslint@9.37.0(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.2.0)(rolldown@1.0.2)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.2)(rollup@4.60.4))(rollup@4.60.4)(terser@5.44.0)(tsx@4.20.6)(typescript@5.8.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue-tsc@3.2.1(typescript@5.8.3))(yaml@2.9.0)
-      nypm: 0.6.6
-      pathe: 2.0.3
-      pkg-types: 2.3.1
-      postcss: 8.5.15
-      seroval: 1.5.4
-      std-env: 4.1.0
-      ufo: 1.6.4
-      unenv: 2.0.0-rc.24
-      vite: 7.3.3(@types/node@24.10.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0)
-      vite-node: 5.3.0(@types/node@24.10.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0)
-      vite-plugin-checker: 0.13.0(@biomejs/biome@2.2.2)(eslint@9.37.0(jiti@2.7.0))(optionator@0.9.4)(oxlint@1.2.0)(typescript@5.8.3)(vite@7.3.3(@types/node@24.10.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue-tsc@3.2.1(typescript@5.8.3))
-      vue: 3.5.34(typescript@5.8.3)
-      vue-bundle-renderer: 2.2.0
-    optionalDependencies:
-      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.0)
-      rolldown: 1.0.2
-      rollup-plugin-visualizer: 7.0.1(rolldown@1.0.2)(rollup@4.60.4)
-    transitivePeerDependencies:
-      - '@biomejs/biome'
-      - '@types/node'
-      - eslint
-      - less
-      - lightningcss
-      - magicast
-      - meow
-      - optionator
-      - oxlint
-      - rollup
-      - sass
-      - sass-embedded
-      - stylelint
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - typescript
-      - vls
-      - vti
-      - vue-tsc
-      - yaml
-
   '@nuxt/vite-builder@4.4.6(614eef23fd40bbdc9f53ade7a8225586)':
     dependencies:
       '@nuxt/kit': 4.4.6(magicast@0.3.5)
@@ -15589,65 +15249,6 @@ snapshots:
       semver: 7.8.1
     transitivePeerDependencies:
       - magicast
-
-  '@nuxtjs/i18n@10.1.0(@netlify/blobs@9.1.2)(@vue/compiler-dom@3.5.34)(db0@0.3.4(better-sqlite3@12.4.5))(eslint@9.37.0(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.3.5)(rollup@4.60.4)(vue@3.5.34(typescript@5.8.3))':
-    dependencies:
-      '@intlify/core': 11.1.12
-      '@intlify/h3': 0.7.1
-      '@intlify/shared': 11.1.12
-      '@intlify/unplugin-vue-i18n': 11.0.1(@vue/compiler-dom@3.5.34)(eslint@9.37.0(jiti@2.7.0))(rollup@4.60.4)(typescript@5.9.3)(vue-i18n@11.1.12(vue@3.5.34(typescript@5.8.3)))(vue@3.5.34(typescript@5.8.3))
-      '@intlify/utils': 0.13.0
-      '@miyaneee/rollup-plugin-json5': 1.2.0(rollup@4.60.4)
-      '@nuxt/kit': 4.4.6(magicast@0.3.5)
-      '@rollup/plugin-yaml': 4.1.2(rollup@4.60.4)
-      '@vue/compiler-sfc': 3.5.26
-      cookie-es: 2.0.0
-      defu: 6.1.4
-      devalue: 5.3.2
-      h3: 1.15.4
-      knitwork: 1.2.0
-      magic-string: 0.30.21
-      mlly: 1.8.0
-      nuxt-define: 1.0.0
-      ohash: 2.0.11
-      oxc-parser: 0.81.0
-      oxc-transform: 0.81.0
-      oxc-walker: 0.4.0(oxc-parser@0.81.0)
-      pathe: 2.0.3
-      typescript: 5.9.3
-      ufo: 1.6.1
-      unplugin: 2.3.10
-      unplugin-vue-router: 0.14.0(@vue/compiler-sfc@3.5.26)(vue-router@4.5.1(vue@3.5.34(typescript@5.8.3)))(vue@3.5.34(typescript@5.8.3))
-      unstorage: 1.17.1(@netlify/blobs@9.1.2)(db0@0.3.4(better-sqlite3@12.4.5))(ioredis@5.10.1)
-      vue-i18n: 11.1.12(vue@3.5.34(typescript@5.8.3))
-      vue-router: 4.5.1(vue@3.5.34(typescript@5.8.3))
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - '@vue/compiler-dom'
-      - aws4fetch
-      - db0
-      - eslint
-      - idb-keyval
-      - ioredis
-      - magicast
-      - petite-vue-i18n
-      - rollup
-      - supports-color
-      - uploadthing
-      - vue
 
   '@nuxtjs/i18n@10.1.0(@netlify/blobs@9.1.2)(@vue/compiler-dom@3.5.34)(db0@0.3.4(better-sqlite3@12.4.5))(eslint@9.37.0(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.3.5)(rollup@4.60.4)(vue@3.5.34(typescript@5.9.3))':
     dependencies:
@@ -15865,27 +15466,6 @@ snapshots:
       - magicast
       - supports-color
 
-  '@nuxtjs/robots@6.0.8(@nuxt/schema@4.4.6)(magicast@0.3.5)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.2.2)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.4)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.4.5)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.4.5))(eslint@9.37.0(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.2.0)(rolldown@1.0.2)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.2)(rollup@4.60.4))(rollup@4.60.4)(terser@5.44.0)(tsx@4.20.6)(typescript@5.8.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue-tsc@3.2.1(typescript@5.8.3))(yaml@2.9.0))(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.8.3))(zod@4.1.12)':
-    dependencies:
-      '@fingerprintjs/botd': 2.0.0
-      '@nuxt/kit': 4.4.6(magicast@0.3.5)
-      consola: 3.4.2
-      defu: 6.1.7
-      h3: 1.15.11
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.3.5)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.2.2)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.4)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.4.5)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.4.5))(eslint@9.37.0(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.2.0)(rolldown@1.0.2)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.2)(rollup@4.60.4))(rollup@4.60.4)(terser@5.44.0)(tsx@4.20.6)(typescript@5.8.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue-tsc@3.2.1(typescript@5.8.3))(yaml@2.9.0))(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.8.3))(zod@4.1.12)
-      nuxtseo-shared: 5.1.3(34be1a3a093e48815a03fc8327c0c761)
-      pathe: 2.0.3
-      pkg-types: 2.3.0
-      ufo: 1.6.4
-    optionalDependencies:
-      zod: 4.1.12
-    transitivePeerDependencies:
-      - '@nuxt/schema'
-      - magicast
-      - nuxt
-      - vite
-      - vue
-
   '@nuxtjs/robots@6.0.8(@nuxt/schema@4.4.6)(magicast@0.3.5)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.2.2)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.4)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.4.5)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.4.5))(eslint@9.37.0(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.2.0)(rolldown@1.0.2)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.2)(rollup@4.60.4))(rollup@4.60.4)(terser@5.44.0)(tsx@4.20.6)(typescript@5.9.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue-tsc@3.2.1(typescript@5.9.3))(yaml@2.9.0))(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))(zod@4.1.12)':
     dependencies:
       '@fingerprintjs/botd': 2.0.0
@@ -15928,14 +15508,14 @@ snapshots:
       - vite
       - vue
 
-  '@nuxtjs/sitemap@8.0.15(@nuxt/schema@4.4.6)(magicast@0.3.5)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.2.2)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.4)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.4.5)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.4.5))(eslint@9.37.0(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.2.0)(rolldown@1.0.2)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.2)(rollup@4.60.4))(rollup@4.60.4)(terser@5.44.0)(tsx@4.20.6)(typescript@5.8.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue-tsc@3.2.1(typescript@5.8.3))(yaml@2.9.0))(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.8.3))(zod@4.1.12)':
+  '@nuxtjs/sitemap@8.0.15(@nuxt/schema@4.4.6)(magicast@0.3.5)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.2.2)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.4)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.4.5)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.4.5))(eslint@9.37.0(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.2.0)(rolldown@1.0.2)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.2)(rollup@4.60.4))(rollup@4.60.4)(terser@5.44.0)(tsx@4.20.6)(typescript@5.9.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue-tsc@3.2.1(typescript@5.9.3))(yaml@2.9.0))(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))(zod@4.1.12)':
     dependencies:
       '@nuxt/kit': 4.4.6(magicast@0.3.5)
       consola: 3.4.2
       defu: 6.1.7
       fast-xml-parser: 5.8.0
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.3.5)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.2.2)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.4)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.4.5)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.4.5))(eslint@9.37.0(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.2.0)(rolldown@1.0.2)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.2)(rollup@4.60.4))(rollup@4.60.4)(terser@5.44.0)(tsx@4.20.6)(typescript@5.8.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue-tsc@3.2.1(typescript@5.8.3))(yaml@2.9.0))(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.8.3))(zod@4.1.12)
-      nuxtseo-shared: 5.1.3(34be1a3a093e48815a03fc8327c0c761)
+      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.3.5)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.2.2)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.4)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.4.5)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.4.5))(eslint@9.37.0(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.2.0)(rolldown@1.0.2)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.2)(rollup@4.60.4))(rollup@4.60.4)(terser@5.44.0)(tsx@4.20.6)(typescript@5.9.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue-tsc@3.2.1(typescript@5.9.3))(yaml@2.9.0))(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))(zod@4.1.12)
+      nuxtseo-shared: 5.1.3(d0f0fbd9b7b2a62d03f65ee60cceb3c1)
       ofetch: 1.5.1
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -17190,7 +16770,6 @@ snapshots:
       semver: 7.7.4
     optionalDependencies:
       '@types/node': 22.15.32
-    optional: true
 
   '@rushstack/node-core-library@5.23.1(@types/node@24.10.4)':
     dependencies:
@@ -17204,23 +16783,19 @@ snapshots:
       semver: 7.7.4
     optionalDependencies:
       '@types/node': 24.10.4
-    optional: true
 
   '@rushstack/problem-matcher@0.2.1(@types/node@22.15.32)':
     optionalDependencies:
       '@types/node': 22.15.32
-    optional: true
 
   '@rushstack/problem-matcher@0.2.1(@types/node@24.10.4)':
     optionalDependencies:
       '@types/node': 24.10.4
-    optional: true
 
   '@rushstack/rig-package@0.7.3':
     dependencies:
       jju: 1.4.0
       resolve: 1.22.11
-    optional: true
 
   '@rushstack/terminal@0.24.0(@types/node@22.15.32)':
     dependencies:
@@ -17229,7 +16804,6 @@ snapshots:
       supports-color: 8.1.1
     optionalDependencies:
       '@types/node': 22.15.32
-    optional: true
 
   '@rushstack/terminal@0.24.0(@types/node@24.10.4)':
     dependencies:
@@ -17238,7 +16812,6 @@ snapshots:
       supports-color: 8.1.1
     optionalDependencies:
       '@types/node': 24.10.4
-    optional: true
 
   '@rushstack/ts-command-line@5.3.9(@types/node@22.15.32)':
     dependencies:
@@ -17248,7 +16821,6 @@ snapshots:
       string-argv: 0.3.2
     transitivePeerDependencies:
       - '@types/node'
-    optional: true
 
   '@rushstack/ts-command-line@5.3.9(@types/node@24.10.4)':
     dependencies:
@@ -17258,7 +16830,6 @@ snapshots:
       string-argv: 0.3.2
     transitivePeerDependencies:
       - '@types/node'
-    optional: true
 
   '@shikijs/core@3.13.0':
     dependencies:
@@ -17409,28 +16980,28 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
 
-  '@storybook/vue3-vite@10.4.1(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.7)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.14(@types/node@22.15.32)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.8.3))(webpack@5.102.1(esbuild@0.28.0))':
+  '@storybook/vue3-vite@10.4.1(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.7)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.14(@types/node@22.15.32)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))(webpack@5.102.1(esbuild@0.28.0))':
     dependencies:
       '@storybook/builder-vite': 10.4.1(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.7)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.14(@types/node@22.15.32)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(webpack@5.102.1(esbuild@0.28.0))
-      '@storybook/vue3': 10.4.1(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.7)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vue@3.5.34(typescript@5.8.3))
+      '@storybook/vue3': 10.4.1(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.7)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vue@3.5.34(typescript@5.9.3))
       magic-string: 0.30.21
       storybook: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.7)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       typescript: 5.9.3
       vite: 8.0.14(@types/node@22.15.32)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0)
       vue-component-meta: 2.2.12(typescript@5.9.3)
-      vue-docgen-api: 4.79.2(vue@3.5.34(typescript@5.8.3))
+      vue-docgen-api: 4.79.2(vue@3.5.34(typescript@5.9.3))
     transitivePeerDependencies:
       - esbuild
       - rollup
       - vue
       - webpack
 
-  '@storybook/vue3@10.4.1(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.7)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vue@3.5.34(typescript@5.8.3))':
+  '@storybook/vue3@10.4.1(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.7)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vue@3.5.34(typescript@5.9.3))':
     dependencies:
       '@storybook/global': 5.0.0
       storybook: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.7)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       type-fest: 2.19.0
-      vue: 3.5.34(typescript@5.8.3)
+      vue: 3.5.34(typescript@5.9.3)
       vue-component-type-helpers: 3.3.1
 
   '@styleframe/license@2.0.2': {}
@@ -17632,20 +17203,10 @@ snapshots:
 
   '@tanstack/virtual-core@3.15.0': {}
 
-  '@tanstack/vue-table@8.21.3(vue@3.5.34(typescript@5.8.3))':
-    dependencies:
-      '@tanstack/table-core': 8.21.3
-      vue: 3.5.34(typescript@5.8.3)
-
   '@tanstack/vue-table@8.21.3(vue@3.5.34(typescript@5.9.3))':
     dependencies:
       '@tanstack/table-core': 8.21.3
       vue: 3.5.34(typescript@5.9.3)
-
-  '@tanstack/vue-virtual@3.13.25(vue@3.5.34(typescript@5.8.3))':
-    dependencies:
-      '@tanstack/virtual-core': 3.15.0
-      vue: 3.5.34(typescript@5.8.3)
 
   '@tanstack/vue-virtual@3.13.25(vue@3.5.34(typescript@5.9.3))':
     dependencies:
@@ -17717,13 +17278,6 @@ snapshots:
   '@tiptap/extension-document@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))':
     dependencies:
       '@tiptap/core': 3.23.6(@tiptap/pm@3.23.6)
-
-  '@tiptap/extension-drag-handle-vue-3@3.23.6(@tiptap/extension-drag-handle@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/extension-collaboration@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(yjs@13.6.30))(@tiptap/extension-node-range@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30)))(@tiptap/pm@3.23.6)(@tiptap/vue-3@3.23.6(@floating-ui/dom@1.7.6)(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)(vue@3.5.34(typescript@5.8.3)))(vue@3.5.34(typescript@5.8.3))':
-    dependencies:
-      '@tiptap/extension-drag-handle': 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/extension-collaboration@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(yjs@13.6.30))(@tiptap/extension-node-range@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))
-      '@tiptap/pm': 3.23.6
-      '@tiptap/vue-3': 3.23.6(@floating-ui/dom@1.7.6)(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)(vue@3.5.34(typescript@5.8.3))
-      vue: 3.5.34(typescript@5.8.3)
 
   '@tiptap/extension-drag-handle-vue-3@3.23.6(@tiptap/extension-drag-handle@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/extension-collaboration@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(yjs@13.6.30))(@tiptap/extension-node-range@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30)))(@tiptap/pm@3.23.6)(@tiptap/vue-3@3.23.6(@floating-ui/dom@1.7.6)(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))':
     dependencies:
@@ -17888,16 +17442,6 @@ snapshots:
       '@tiptap/core': 3.23.6(@tiptap/pm@3.23.6)
       '@tiptap/pm': 3.23.6
 
-  '@tiptap/vue-3@3.23.6(@floating-ui/dom@1.7.6)(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)(vue@3.5.34(typescript@5.8.3))':
-    dependencies:
-      '@floating-ui/dom': 1.7.6
-      '@tiptap/core': 3.23.6(@tiptap/pm@3.23.6)
-      '@tiptap/pm': 3.23.6
-      vue: 3.5.34(typescript@5.8.3)
-    optionalDependencies:
-      '@tiptap/extension-bubble-menu': 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)
-      '@tiptap/extension-floating-menu': 3.23.6(@floating-ui/dom@1.7.6)(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)
-
   '@tiptap/vue-3@3.23.6(@floating-ui/dom@1.7.6)(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)(vue@3.5.34(typescript@5.9.3))':
     dependencies:
       '@floating-ui/dom': 1.7.6
@@ -17925,8 +17469,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@types/argparse@1.0.38':
-    optional: true
+  '@types/argparse@1.0.38': {}
 
   '@types/aria-query@5.0.4': {}
 
@@ -18066,23 +17609,11 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@unhead/vue@2.0.19(vue@3.5.34(typescript@5.8.3))':
-    dependencies:
-      hookable: 5.5.3
-      unhead: 2.0.19
-      vue: 3.5.34(typescript@5.8.3)
-
   '@unhead/vue@2.0.19(vue@3.5.34(typescript@5.9.3))':
     dependencies:
       hookable: 5.5.3
       unhead: 2.0.19
       vue: 3.5.34(typescript@5.9.3)
-
-  '@unhead/vue@2.1.15(vue@3.5.34(typescript@5.8.3))':
-    dependencies:
-      hookable: 6.1.1
-      unhead: 2.1.15
-      vue: 3.5.34(typescript@5.8.3)
 
   '@unhead/vue@2.1.15(vue@3.5.34(typescript@5.9.3))':
     dependencies:
@@ -18098,11 +17629,6 @@ snapshots:
       unconfig: 7.5.0
 
   '@unocss/core@66.7.0': {}
-
-  '@valibot/to-json-schema@1.7.0(valibot@1.4.0(typescript@5.8.3))':
-    dependencies:
-      valibot: 1.4.0(typescript@5.8.3)
-    optional: true
 
   '@valibot/to-json-schema@1.7.0(valibot@1.4.0(typescript@5.9.3))':
     dependencies:
@@ -18144,18 +17670,6 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@vitejs/plugin-vue-jsx@5.1.5(vite@7.3.3(@types/node@24.10.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.8.3))':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
-      '@rolldown/pluginutils': 1.0.1
-      '@vue/babel-plugin-jsx': 2.0.1(@babel/core@7.29.0)
-      vite: 7.3.3(@types/node@24.10.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0)
-      vue: 3.5.34(typescript@5.8.3)
-    transitivePeerDependencies:
-      - supports-color
-
   '@vitejs/plugin-vue-jsx@5.1.5(vite@7.3.3(@types/node@24.10.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))':
     dependencies:
       '@babel/core': 7.29.0
@@ -18168,23 +17682,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@6.0.7(vite@7.3.3(@types/node@24.10.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.8.3))':
-    dependencies:
-      '@rolldown/pluginutils': 1.0.1
-      vite: 7.3.3(@types/node@24.10.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0)
-      vue: 3.5.34(typescript@5.8.3)
-
   '@vitejs/plugin-vue@6.0.7(vite@7.3.3(@types/node@24.10.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
       vite: 7.3.3(@types/node@24.10.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0)
       vue: 3.5.34(typescript@5.9.3)
 
-  '@vitejs/plugin-vue@6.0.7(vite@8.0.14(@types/node@22.15.32)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.8.3))':
+  '@vitejs/plugin-vue@6.0.7(vite@8.0.14(@types/node@22.15.32)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.0.14(@types/node@22.15.32)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0)
-      vue: 3.5.34(typescript@5.8.3)
+      vue: 3.5.34(typescript@5.9.3)
 
   '@vitejs/plugin-vue@6.0.7(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))':
     dependencies:
@@ -18480,16 +17988,6 @@ snapshots:
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
 
-  '@vue-macros/common@3.0.0-beta.15(vue@3.5.34(typescript@5.8.3))':
-    dependencies:
-      '@vue/compiler-sfc': 3.5.26
-      ast-kit: 2.1.3
-      local-pkg: 1.1.2
-      magic-string-ast: 1.0.3
-      unplugin-utils: 0.2.5
-    optionalDependencies:
-      vue: 3.5.34(typescript@5.8.3)
-
   '@vue-macros/common@3.0.0-beta.15(vue@3.5.34(typescript@5.9.3))':
     dependencies:
       '@vue/compiler-sfc': 3.5.26
@@ -18499,16 +17997,6 @@ snapshots:
       unplugin-utils: 0.2.5
     optionalDependencies:
       vue: 3.5.34(typescript@5.9.3)
-
-  '@vue-macros/common@3.1.2(vue@3.5.34(typescript@5.8.3))':
-    dependencies:
-      '@vue/compiler-sfc': 3.5.34
-      ast-kit: 2.1.3
-      local-pkg: 1.1.2
-      magic-string-ast: 1.0.3
-      unplugin-utils: 0.3.1
-    optionalDependencies:
-      vue: 3.5.34(typescript@5.8.3)
 
   '@vue-macros/common@3.1.2(vue@3.5.34(typescript@5.9.3))':
     dependencies:
@@ -18620,12 +18108,6 @@ snapshots:
     dependencies:
       '@vue/devtools-kit': 8.1.2
 
-  '@vue/devtools-core@8.1.2(vue@3.5.34(typescript@5.8.3))':
-    dependencies:
-      '@vue/devtools-kit': 8.1.2
-      '@vue/devtools-shared': 8.1.2
-      vue: 3.5.34(typescript@5.8.3)
-
   '@vue/devtools-core@8.1.2(vue@3.5.34(typescript@5.9.3))':
     dependencies:
       '@vue/devtools-kit': 8.1.2
@@ -18692,12 +18174,6 @@ snapshots:
       '@vue/shared': 3.5.34
       csstype: 3.2.3
 
-  '@vue/server-renderer@3.5.34(vue@3.5.34(typescript@5.8.3))':
-    dependencies:
-      '@vue/compiler-ssr': 3.5.34
-      '@vue/shared': 3.5.34
-      vue: 3.5.34(typescript@5.8.3)
-
   '@vue/server-renderer@3.5.34(vue@3.5.34(typescript@5.9.3))':
     dependencies:
       '@vue/compiler-ssr': 3.5.34
@@ -18708,26 +18184,16 @@ snapshots:
 
   '@vue/shared@3.5.34': {}
 
-  '@vue/tsconfig@0.8.1(typescript@5.8.3)(vue@3.5.34(typescript@5.8.3))':
+  '@vue/tsconfig@0.8.1(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3))':
     optionalDependencies:
-      typescript: 5.8.3
-      vue: 3.5.34(typescript@5.8.3)
+      typescript: 5.9.3
+      vue: 3.5.34(typescript@5.9.3)
 
   '@vueless/storybook-dark-mode@10.0.7(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.7)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
     dependencies:
       '@storybook/global': 5.0.0
       lodash-es: 4.17.23
       storybook: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.7)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-
-  '@vueuse/core@10.11.1(vue@3.5.34(typescript@5.8.3))':
-    dependencies:
-      '@types/web-bluetooth': 0.0.20
-      '@vueuse/metadata': 10.11.1
-      '@vueuse/shared': 10.11.1(vue@3.5.34(typescript@5.8.3))
-      vue-demi: 0.14.10(vue@3.5.34(typescript@5.8.3))
-    transitivePeerDependencies:
-      - '@vue/composition-api'
-      - vue
 
   '@vueuse/core@10.11.1(vue@3.5.34(typescript@5.9.3))':
     dependencies:
@@ -18739,13 +18205,6 @@ snapshots:
       - '@vue/composition-api'
       - vue
 
-  '@vueuse/core@13.9.0(vue@3.5.34(typescript@5.8.3))':
-    dependencies:
-      '@types/web-bluetooth': 0.0.21
-      '@vueuse/metadata': 13.9.0
-      '@vueuse/shared': 13.9.0(vue@3.5.34(typescript@5.8.3))
-      vue: 3.5.34(typescript@5.8.3)
-
   '@vueuse/core@13.9.0(vue@3.5.34(typescript@5.9.3))':
     dependencies:
       '@types/web-bluetooth': 0.0.21
@@ -18753,29 +18212,12 @@ snapshots:
       '@vueuse/shared': 13.9.0(vue@3.5.34(typescript@5.9.3))
       vue: 3.5.34(typescript@5.9.3)
 
-  '@vueuse/core@14.3.0(vue@3.5.34(typescript@5.8.3))':
-    dependencies:
-      '@types/web-bluetooth': 0.0.21
-      '@vueuse/metadata': 14.3.0
-      '@vueuse/shared': 14.3.0(vue@3.5.34(typescript@5.8.3))
-      vue: 3.5.34(typescript@5.8.3)
-
   '@vueuse/core@14.3.0(vue@3.5.34(typescript@5.9.3))':
     dependencies:
       '@types/web-bluetooth': 0.0.21
       '@vueuse/metadata': 14.3.0
       '@vueuse/shared': 14.3.0(vue@3.5.34(typescript@5.9.3))
       vue: 3.5.34(typescript@5.9.3)
-
-  '@vueuse/integrations@14.3.0(change-case@5.4.4)(fuse.js@7.3.0)(jwt-decode@4.0.0)(vue@3.5.34(typescript@5.8.3))':
-    dependencies:
-      '@vueuse/core': 14.3.0(vue@3.5.34(typescript@5.8.3))
-      '@vueuse/shared': 14.3.0(vue@3.5.34(typescript@5.8.3))
-      vue: 3.5.34(typescript@5.8.3)
-    optionalDependencies:
-      change-case: 5.4.4
-      fuse.js: 7.3.0
-      jwt-decode: 4.0.0
 
   '@vueuse/integrations@14.3.0(change-case@5.4.4)(fuse.js@7.3.0)(jwt-decode@4.0.0)(vue@3.5.34(typescript@5.9.3))':
     dependencies:
@@ -18793,13 +18235,6 @@ snapshots:
 
   '@vueuse/metadata@14.3.0': {}
 
-  '@vueuse/shared@10.11.1(vue@3.5.34(typescript@5.8.3))':
-    dependencies:
-      vue-demi: 0.14.10(vue@3.5.34(typescript@5.8.3))
-    transitivePeerDependencies:
-      - '@vue/composition-api'
-      - vue
-
   '@vueuse/shared@10.11.1(vue@3.5.34(typescript@5.9.3))':
     dependencies:
       vue-demi: 0.14.10(vue@3.5.34(typescript@5.9.3))
@@ -18807,17 +18242,9 @@ snapshots:
       - '@vue/composition-api'
       - vue
 
-  '@vueuse/shared@13.9.0(vue@3.5.34(typescript@5.8.3))':
-    dependencies:
-      vue: 3.5.34(typescript@5.8.3)
-
   '@vueuse/shared@13.9.0(vue@3.5.34(typescript@5.9.3))':
     dependencies:
       vue: 3.5.34(typescript@5.9.3)
-
-  '@vueuse/shared@14.3.0(vue@3.5.34(typescript@5.8.3))':
-    dependencies:
-      vue: 3.5.34(typescript@5.8.3)
 
   '@vueuse/shared@14.3.0(vue@3.5.34(typescript@5.9.3))':
     dependencies:
@@ -18972,7 +18399,6 @@ snapshots:
   ajv-draft-04@1.0.0(ajv@8.18.0):
     optionalDependencies:
       ajv: 8.18.0
-    optional: true
 
   ajv-formats@2.1.1(ajv@8.13.0):
     optionalDependencies:
@@ -18981,7 +18407,6 @@ snapshots:
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
       ajv: 8.18.0
-    optional: true
 
   ajv-keywords@5.1.0(ajv@8.13.0):
     dependencies:
@@ -19008,7 +18433,6 @@ snapshots:
       fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
-    optional: true
 
   alien-signals@1.0.13: {}
 
@@ -19970,12 +19394,6 @@ snapshots:
     dependencies:
       embla-carousel: 8.6.0
 
-  embla-carousel-vue@8.6.0(vue@3.5.34(typescript@5.8.3)):
-    dependencies:
-      embla-carousel: 8.6.0
-      embla-carousel-reactive-utils: 8.6.0(embla-carousel@8.6.0)
-      vue: 3.5.34(typescript@5.8.3)
-
   embla-carousel-vue@8.6.0(vue@3.5.34(typescript@5.9.3)):
     dependencies:
       embla-carousel: 8.6.0
@@ -20450,8 +19868,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.2:
-    optional: true
+  fast-uri@3.1.2: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:
@@ -21091,8 +20508,7 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
-  import-lazy@4.0.0:
-    optional: true
+  import-lazy@4.0.0: {}
 
   import-meta-resolve@4.2.0: {}
 
@@ -21338,8 +20754,7 @@ snapshots:
 
   jiti@2.7.0: {}
 
-  jju@1.4.0:
-    optional: true
+  jju@1.4.0: {}
 
   js-stringify@1.0.2: {}
 
@@ -21845,7 +21260,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.7.3
+      semver: 7.8.1
 
   markdown-table@3.0.4: {}
 
@@ -22269,18 +21684,6 @@ snapshots:
 
   motion-utils@12.39.0: {}
 
-  motion-v@1.7.2(@vueuse/core@13.9.0(vue@3.5.34(typescript@5.8.3)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.8.3)):
-    dependencies:
-      '@vueuse/core': 13.9.0(vue@3.5.34(typescript@5.8.3))
-      framer-motion: 12.23.12(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      hey-listen: 1.0.8
-      motion-dom: 12.23.12
-      vue: 3.5.34(typescript@5.8.3)
-    transitivePeerDependencies:
-      - '@emotion/is-prop-valid'
-      - react
-      - react-dom
-
   motion-v@1.7.2(@vueuse/core@13.9.0(vue@3.5.34(typescript@5.9.3)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3)):
     dependencies:
       '@vueuse/core': 13.9.0(vue@3.5.34(typescript@5.9.3))
@@ -22288,19 +21691,6 @@ snapshots:
       hey-listen: 1.0.8
       motion-dom: 12.23.12
       vue: 3.5.34(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@emotion/is-prop-valid'
-      - react
-      - react-dom
-
-  motion-v@2.2.1(@vueuse/core@14.3.0(vue@3.5.34(typescript@5.8.3)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.8.3)):
-    dependencies:
-      '@vueuse/core': 14.3.0(vue@3.5.34(typescript@5.8.3))
-      framer-motion: 12.40.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      hey-listen: 1.0.8
-      motion-dom: 12.40.0
-      motion-utils: 12.39.0
-      vue: 3.5.34(typescript@5.8.3)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - react
@@ -22695,11 +22085,11 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  nuxt-og-image@6.5.1(967f4a3de4acbdc0d75e02a1c5e544bd):
+  nuxt-og-image@6.5.1(6731f1c4d7efe985dfa23dea89fcab9e):
     dependencies:
       '@clack/prompts': 1.4.0
       '@nuxt/kit': 4.4.6(magicast@0.5.3)
-      '@unhead/vue': 2.0.19(vue@3.5.34(typescript@5.8.3))
+      '@unhead/vue': 2.0.19(vue@3.5.34(typescript@5.9.3))
       '@unocss/config': 66.7.0
       '@unocss/core': 66.7.0
       '@vue/compiler-sfc': 3.5.34
@@ -22713,8 +22103,8 @@ snapshots:
       magic-string: 0.30.21
       magicast: 0.5.3
       mocked-exports: 0.1.1
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.2.2)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.4)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.4.5)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.4.5))(eslint@9.37.0(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.2.0)(rolldown@1.0.2)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.2)(rollup@4.60.4))(rollup@4.60.4)(terser@5.44.0)(tsx@4.20.6)(typescript@5.8.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue-tsc@3.2.1(typescript@5.8.3))(yaml@2.9.0))(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.8.3))(zod@4.4.3)
-      nuxtseo-shared: 5.1.3(1a6881b15417bdf8ad5d9e8ec38eefa1)
+      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.2.2)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.4)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.4.5)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.4.5))(eslint@9.37.0(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.2.0)(rolldown@1.0.2)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.2)(rollup@4.60.4))(rollup@4.60.4)(terser@5.44.0)(tsx@4.20.6)(typescript@5.9.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue-tsc@3.2.1(typescript@5.9.3))(yaml@2.9.0))(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))(zod@4.4.3)
+      nuxtseo-shared: 5.1.3(9734e69e983189807d311cd1ca80c85c)
       nypm: 0.6.6
       ofetch: 1.5.1
       ohash: 2.0.11
@@ -22857,30 +22247,10 @@ snapshots:
       - vite
       - vue
 
-  nuxt-site-config-kit@4.0.8(magicast@0.3.5)(vue@3.5.34(typescript@5.8.3)):
-    dependencies:
-      '@nuxt/kit': 4.4.6(magicast@0.3.5)
-      site-config-stack: 4.0.8(vue@3.5.34(typescript@5.8.3))
-      std-env: 4.1.0
-      ufo: 1.6.4
-    transitivePeerDependencies:
-      - magicast
-      - vue
-
   nuxt-site-config-kit@4.0.8(magicast@0.3.5)(vue@3.5.34(typescript@5.9.3)):
     dependencies:
       '@nuxt/kit': 4.4.6(magicast@0.3.5)
       site-config-stack: 4.0.8(vue@3.5.34(typescript@5.9.3))
-      std-env: 4.1.0
-      ufo: 1.6.4
-    transitivePeerDependencies:
-      - magicast
-      - vue
-
-  nuxt-site-config-kit@4.0.8(magicast@0.5.3)(vue@3.5.34(typescript@5.8.3)):
-    dependencies:
-      '@nuxt/kit': 4.4.6(magicast@0.5.3)
-      site-config-stack: 4.0.8(vue@3.5.34(typescript@5.8.3))
       std-env: 4.1.0
       ufo: 1.6.4
     transitivePeerDependencies:
@@ -22896,24 +22266,6 @@ snapshots:
     transitivePeerDependencies:
       - magicast
       - vue
-
-  nuxt-site-config@4.0.8(@nuxt/schema@4.4.6)(magicast@0.3.5)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.2.2)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.4)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.4.5)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.4.5))(eslint@9.37.0(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.2.0)(rolldown@1.0.2)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.2)(rollup@4.60.4))(rollup@4.60.4)(terser@5.44.0)(tsx@4.20.6)(typescript@5.8.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue-tsc@3.2.1(typescript@5.8.3))(yaml@2.9.0))(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.8.3))(zod@4.1.12):
-    dependencies:
-      '@nuxt/kit': 4.4.6(magicast@0.3.5)
-      h3: 1.15.11
-      nuxt-site-config-kit: 4.0.8(magicast@0.3.5)(vue@3.5.34(typescript@5.8.3))
-      nuxtseo-shared: 5.1.3(34be1a3a093e48815a03fc8327c0c761)
-      pathe: 2.0.3
-      pkg-types: 2.3.0
-      site-config-stack: 4.0.8(vue@3.5.34(typescript@5.8.3))
-      ufo: 1.6.4
-    transitivePeerDependencies:
-      - '@nuxt/schema'
-      - magicast
-      - nuxt
-      - vite
-      - vue
-      - zod
 
   nuxt-site-config@4.0.8(@nuxt/schema@4.4.6)(magicast@0.3.5)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.2.2)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.4)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.4.5)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.4.5))(eslint@9.37.0(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.2.0)(rolldown@1.0.2)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.2)(rollup@4.60.4))(rollup@4.60.4)(terser@5.44.0)(tsx@4.20.6)(typescript@5.9.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue-tsc@3.2.1(typescript@5.9.3))(yaml@2.9.0))(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))(zod@4.1.12):
     dependencies:
@@ -22942,24 +22294,6 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 2.3.0
       site-config-stack: 4.0.8(vue@3.5.34(typescript@5.9.3))
-      ufo: 1.6.4
-    transitivePeerDependencies:
-      - '@nuxt/schema'
-      - magicast
-      - nuxt
-      - vite
-      - vue
-      - zod
-
-  nuxt-site-config@4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.2.2)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.4)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.4.5)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.4.5))(eslint@9.37.0(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.2.0)(rolldown@1.0.2)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.2)(rollup@4.60.4))(rollup@4.60.4)(terser@5.44.0)(tsx@4.20.6)(typescript@5.8.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue-tsc@3.2.1(typescript@5.8.3))(yaml@2.9.0))(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.8.3))(zod@4.4.3):
-    dependencies:
-      '@nuxt/kit': 4.4.6(magicast@0.5.3)
-      h3: 1.15.11
-      nuxt-site-config-kit: 4.0.8(magicast@0.5.3)(vue@3.5.34(typescript@5.8.3))
-      nuxtseo-shared: 5.1.3(1a6881b15417bdf8ad5d9e8ec38eefa1)
-      pathe: 2.0.3
-      pkg-types: 2.3.0
-      site-config-stack: 4.0.8(vue@3.5.34(typescript@5.8.3))
       ufo: 1.6.4
     transitivePeerDependencies:
       - '@nuxt/schema'
@@ -23044,133 +22378,6 @@ snapshots:
       untyped: 2.0.0
       vue: 3.5.34(typescript@5.9.3)
       vue-router: 5.0.7(@vue/compiler-sfc@3.5.26)(vue@3.5.34(typescript@5.9.3))
-    optionalDependencies:
-      '@parcel/watcher': 2.5.6
-      '@types/node': 24.10.4
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@babel/plugin-proposal-decorators'
-      - '@babel/plugin-syntax-jsx'
-      - '@babel/plugin-syntax-typescript'
-      - '@biomejs/biome'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@electric-sql/pglite'
-      - '@libsql/client'
-      - '@netlify/blobs'
-      - '@pinia/colada'
-      - '@planetscale/database'
-      - '@rollup/plugin-babel'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - '@vitejs/devtools'
-      - '@vue/compiler-sfc'
-      - aws4fetch
-      - better-sqlite3
-      - bufferutil
-      - cac
-      - commander
-      - db0
-      - drizzle-orm
-      - encoding
-      - eslint
-      - idb-keyval
-      - ioredis
-      - less
-      - lightningcss
-      - magicast
-      - meow
-      - mysql2
-      - optionator
-      - oxlint
-      - pinia
-      - react-native-b4a
-      - rolldown
-      - rollup
-      - rollup-plugin-visualizer
-      - sass
-      - sass-embedded
-      - sqlite3
-      - stylelint
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - vite
-      - vls
-      - vti
-      - vue-tsc
-      - xml2js
-      - yaml
-
-  nuxt@4.4.6(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.2.2)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.4)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.4.5)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.4.5))(eslint@9.37.0(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.2.0)(rolldown@1.0.2)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.2)(rollup@4.60.4))(rollup@4.60.4)(terser@5.44.0)(tsx@4.20.6)(typescript@5.8.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue-tsc@3.2.1(typescript@5.8.3))(yaml@2.9.0):
-    dependencies:
-      '@dxup/nuxt': 0.4.1(magicast@0.3.5)(typescript@5.8.3)
-      '@nuxt/cli': 3.35.2(@nuxt/schema@4.4.6)(cac@6.7.14)(magicast@0.3.5)
-      '@nuxt/devtools': 3.2.4(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.8.3))
-      '@nuxt/kit': 4.4.6(magicast@0.3.5)
-      '@nuxt/nitro-server': 4.4.6(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@netlify/blobs@9.1.2)(better-sqlite3@12.4.5)(db0@0.3.4(better-sqlite3@12.4.5))(ioredis@5.10.1)(magicast@0.3.5)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.2.2)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.4)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.4.5)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.4.5))(eslint@9.37.0(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.2.0)(rolldown@1.0.2)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.2)(rollup@4.60.4))(rollup@4.60.4)(terser@5.44.0)(tsx@4.20.6)(typescript@5.8.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue-tsc@3.2.1(typescript@5.8.3))(yaml@2.9.0))(oxc-parser@0.131.0)(rolldown@1.0.2)(typescript@5.8.3)
-      '@nuxt/schema': 4.4.6
-      '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.6(magicast@0.3.5))
-      '@nuxt/vite-builder': 4.4.6(37095f6553ffbfdba21e7dd2b270df29)
-      '@unhead/vue': 2.1.15(vue@3.5.34(typescript@5.8.3))
-      '@vue/shared': 3.5.34
-      chokidar: 5.0.0
-      compatx: 0.2.0
-      consola: 3.4.2
-      cookie-es: 3.1.1
-      defu: 6.1.7
-      devalue: 5.8.1
-      errx: 0.1.0
-      escape-string-regexp: 5.0.0
-      exsolve: 1.0.8
-      hookable: 6.1.1
-      ignore: 7.0.5
-      impound: 1.1.5
-      jiti: 2.7.0
-      klona: 2.0.6
-      knitwork: 1.3.0
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      nanotar: 0.3.0
-      nypm: 0.6.6
-      ofetch: 1.5.1
-      ohash: 2.0.11
-      on-change: 6.0.2
-      oxc-minify: 0.131.0
-      oxc-parser: 0.131.0
-      oxc-transform: 0.131.0
-      oxc-walker: 1.0.0(oxc-parser@0.131.0)(rolldown@1.0.2)
-      pathe: 2.0.3
-      perfect-debounce: 2.1.0
-      picomatch: 4.0.4
-      pkg-types: 2.3.1
-      rou3: 0.8.1
-      scule: 1.3.0
-      semver: 7.8.1
-      std-env: 4.1.0
-      tinyglobby: 0.2.16
-      ufo: 1.6.4
-      ultrahtml: 1.6.0
-      uncrypto: 0.1.3
-      unctx: 2.5.0
-      unimport: 6.3.0(oxc-parser@0.131.0)(rolldown@1.0.2)
-      unplugin: 3.0.0
-      unrouting: 0.1.7
-      untyped: 2.0.0
-      vue: 3.5.34(typescript@5.8.3)
-      vue-router: 5.0.7(@vue/compiler-sfc@3.5.34)(vue@3.5.34(typescript@5.8.3))
     optionalDependencies:
       '@parcel/watcher': 2.5.6
       '@types/node': 24.10.4
@@ -23367,56 +22574,6 @@ snapshots:
       - vue-tsc
       - xml2js
       - yaml
-
-  nuxtseo-shared@5.1.3(1a6881b15417bdf8ad5d9e8ec38eefa1):
-    dependencies:
-      '@clack/prompts': 1.4.0
-      '@nuxt/devtools-kit': 4.0.0-alpha.3(magicast@0.5.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))
-      '@nuxt/kit': 4.4.6(magicast@0.5.3)
-      '@nuxt/schema': 4.4.6
-      birpc: 4.0.0
-      consola: 3.4.2
-      defu: 6.1.7
-      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.2.2)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.4)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.4.5)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.4.5))(eslint@9.37.0(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.2.0)(rolldown@1.0.2)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.2)(rollup@4.60.4))(rollup@4.60.4)(terser@5.44.0)(tsx@4.20.6)(typescript@5.8.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue-tsc@3.2.1(typescript@5.8.3))(yaml@2.9.0)
-      ofetch: 1.5.1
-      pathe: 2.0.3
-      pkg-types: 2.3.0
-      radix3: 1.1.2
-      sirv: 3.0.2
-      std-env: 4.1.0
-      ufo: 1.6.4
-      vue: 3.5.34(typescript@5.8.3)
-    optionalDependencies:
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.3.5)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.2.2)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.4)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.4.5)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.4.5))(eslint@9.37.0(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.2.0)(rolldown@1.0.2)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.2)(rollup@4.60.4))(rollup@4.60.4)(terser@5.44.0)(tsx@4.20.6)(typescript@5.8.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue-tsc@3.2.1(typescript@5.8.3))(yaml@2.9.0))(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.8.3))(zod@4.1.12)
-      zod: 4.4.3
-    transitivePeerDependencies:
-      - magicast
-      - vite
-
-  nuxtseo-shared@5.1.3(34be1a3a093e48815a03fc8327c0c761):
-    dependencies:
-      '@clack/prompts': 1.4.0
-      '@nuxt/devtools-kit': 4.0.0-alpha.3(magicast@0.3.5)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))
-      '@nuxt/kit': 4.4.6(magicast@0.3.5)
-      '@nuxt/schema': 4.4.6
-      birpc: 4.0.0
-      consola: 3.4.2
-      defu: 6.1.7
-      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.2.2)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.4)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.4.5)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.4.5))(eslint@9.37.0(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.2.0)(rolldown@1.0.2)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.2)(rollup@4.60.4))(rollup@4.60.4)(terser@5.44.0)(tsx@4.20.6)(typescript@5.8.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue-tsc@3.2.1(typescript@5.8.3))(yaml@2.9.0)
-      ofetch: 1.5.1
-      pathe: 2.0.3
-      pkg-types: 2.3.0
-      radix3: 1.1.2
-      sirv: 3.0.2
-      std-env: 4.1.0
-      ufo: 1.6.4
-      vue: 3.5.34(typescript@5.8.3)
-    optionalDependencies:
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.3.5)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.2.2)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.4)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.4.5)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.4.5))(eslint@9.37.0(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.2.0)(rolldown@1.0.2)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.2)(rollup@4.60.4))(rollup@4.60.4)(terser@5.44.0)(tsx@4.20.6)(typescript@5.8.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue-tsc@3.2.1(typescript@5.8.3))(yaml@2.9.0))(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.8.3))(zod@4.1.12)
-      zod: 4.1.12
-    transitivePeerDependencies:
-      - magicast
-      - vite
 
   nuxtseo-shared@5.1.3(7fefc03b4d6a76e6f71beacb5923afcf):
     dependencies:
@@ -24607,22 +23764,6 @@ snapshots:
       '@types/hast': 3.0.4
       unist-util-visit: 5.0.0
 
-  reka-ui@2.9.7(vue@3.5.34(typescript@5.8.3)):
-    dependencies:
-      '@floating-ui/dom': 1.7.6
-      '@floating-ui/vue': 1.1.9(vue@3.5.34(typescript@5.8.3))
-      '@internationalized/date': 3.10.0
-      '@internationalized/number': 3.6.5
-      '@tanstack/vue-virtual': 3.13.25(vue@3.5.34(typescript@5.8.3))
-      '@vueuse/core': 14.3.0(vue@3.5.34(typescript@5.8.3))
-      '@vueuse/shared': 14.3.0(vue@3.5.34(typescript@5.8.3))
-      aria-hidden: 1.2.6
-      defu: 6.1.7
-      ohash: 2.0.11
-      vue: 3.5.34(typescript@5.8.3)
-    transitivePeerDependencies:
-      - '@vue/composition-api'
-
   reka-ui@2.9.7(vue@3.5.34(typescript@5.9.3)):
     dependencies:
       '@floating-ui/dom': 1.7.6
@@ -24735,24 +23876,6 @@ snapshots:
   reusify@1.1.0: {}
 
   rfdc@1.4.1: {}
-
-  rolldown-plugin-dts@0.13.14(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rolldown@1.0.0-beta.42)(typescript@5.8.3)(vue-tsc@3.2.1(typescript@5.8.3)):
-    dependencies:
-      '@babel/generator': 7.28.3
-      '@babel/parser': 7.28.4
-      '@babel/types': 7.28.4
-      ast-kit: 2.1.3
-      birpc: 2.6.1
-      debug: 4.4.3(supports-color@5.5.0)
-      dts-resolver: 2.1.2(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))
-      get-tsconfig: 4.13.0
-      rolldown: 1.0.0-beta.42
-    optionalDependencies:
-      typescript: 5.8.3
-      vue-tsc: 3.2.1(typescript@5.8.3)
-    transitivePeerDependencies:
-      - oxc-resolver
-      - supports-color
 
   rolldown-plugin-dts@0.13.14(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rolldown@1.0.0-beta.42)(typescript@5.9.3)(vue-tsc@3.2.1(typescript@5.9.3)):
     dependencies:
@@ -25013,8 +24136,7 @@ snapshots:
 
   semver@7.7.3: {}
 
-  semver@7.7.4:
-    optional: true
+  semver@7.7.4: {}
 
   semver@7.8.1: {}
 
@@ -25170,11 +24292,6 @@ snapshots:
       totalist: 3.0.1
 
   sisteransi@1.0.5: {}
-
-  site-config-stack@4.0.8(vue@3.5.34(typescript@5.8.3)):
-    dependencies:
-      ufo: 1.6.4
-      vue: 3.5.34(typescript@5.8.3)
 
   site-config-stack@4.0.8(vue@3.5.34(typescript@5.9.3)):
     dependencies:
@@ -25619,29 +24736,6 @@ snapshots:
       - supports-color
       - vue-tsc
 
-  tsdown@0.12.9(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@5.8.3)(vue-tsc@3.2.1(typescript@5.8.3)):
-    dependencies:
-      ansis: 4.2.0
-      cac: 6.7.14
-      chokidar: 4.0.3
-      debug: 4.4.3(supports-color@5.5.0)
-      diff: 8.0.2
-      empathic: 2.0.0
-      hookable: 5.5.3
-      rolldown: 1.0.0-beta.42
-      rolldown-plugin-dts: 0.13.14(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rolldown@1.0.0-beta.42)(typescript@5.8.3)(vue-tsc@3.2.1(typescript@5.8.3))
-      semver: 7.7.3
-      tinyexec: 1.0.1
-      tinyglobby: 0.2.15
-      unconfig: 7.3.3
-    optionalDependencies:
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - '@typescript/native-preview'
-      - oxc-resolver
-      - supports-color
-      - vue-tsc
-
   tsdown@0.12.9(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@5.9.3)(vue-tsc@3.2.1(typescript@5.9.3)):
     dependencies:
       ansis: 4.2.0
@@ -25726,8 +24820,6 @@ snapshots:
       mime-types: 2.1.35
 
   type-level-regexp@0.1.17: {}
-
-  typescript@5.8.3: {}
 
   typescript@5.9.3: {}
 
@@ -25935,18 +25027,6 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  unplugin-auto-import@21.0.0(@nuxt/kit@4.4.6(magicast@0.3.5))(@vueuse/core@14.3.0(vue@3.5.34(typescript@5.8.3))):
-    dependencies:
-      local-pkg: 1.1.2
-      magic-string: 0.30.21
-      picomatch: 4.0.4
-      unimport: 5.7.0
-      unplugin: 2.3.11
-      unplugin-utils: 0.3.1
-    optionalDependencies:
-      '@nuxt/kit': 4.4.6(magicast@0.3.5)
-      '@vueuse/core': 14.3.0(vue@3.5.34(typescript@5.8.3))
-
   unplugin-auto-import@21.0.0(@nuxt/kit@4.4.6(magicast@0.3.5))(@vueuse/core@14.3.0(vue@3.5.34(typescript@5.9.3))):
     dependencies:
       local-pkg: 1.1.2
@@ -25971,7 +25051,7 @@ snapshots:
       '@nuxt/kit': 4.4.6(magicast@0.5.3)
       '@vueuse/core': 14.3.0(vue@3.5.34(typescript@5.9.3))
 
-  unplugin-dts@1.0.1(@microsoft/api-extractor@7.58.7(@types/node@22.15.32))(esbuild@0.28.0)(rolldown@1.0.2)(rollup@4.60.4)(typescript@5.8.3)(vite@8.0.14(@types/node@22.15.32)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(webpack@5.102.1(esbuild@0.28.0)):
+  unplugin-dts@1.0.1(@microsoft/api-extractor@7.58.7(@types/node@22.15.32))(esbuild@0.28.0)(rolldown@1.0.2)(rollup@4.60.4)(typescript@5.9.3)(vite@8.0.14(@types/node@22.15.32)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(webpack@5.102.1(esbuild@0.28.0)):
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.60.4)
       '@volar/typescript': 2.4.27
@@ -25980,7 +25060,7 @@ snapshots:
       kolorist: 1.8.0
       local-pkg: 1.1.2
       magic-string: 0.30.21
-      typescript: 5.8.3
+      typescript: 5.9.3
       unplugin: 2.3.11
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.7(@types/node@22.15.32)
@@ -25992,7 +25072,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  unplugin-dts@1.0.1(@microsoft/api-extractor@7.58.7(@types/node@24.10.4))(esbuild@0.28.0)(rolldown@1.0.2)(rollup@4.60.4)(typescript@5.8.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(webpack@5.102.1(esbuild@0.28.0)):
+  unplugin-dts@1.0.1(@microsoft/api-extractor@7.58.7(@types/node@24.10.4))(esbuild@0.28.0)(rolldown@1.0.2)(rollup@4.60.4)(typescript@5.9.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(webpack@5.102.1(esbuild@0.28.0)):
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.60.4)
       '@volar/typescript': 2.4.27
@@ -26001,7 +25081,7 @@ snapshots:
       kolorist: 1.8.0
       local-pkg: 1.1.2
       magic-string: 0.30.21
-      typescript: 5.8.3
+      typescript: 5.9.3
       unplugin: 2.3.11
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.7(@types/node@24.10.4)
@@ -26009,27 +25089,6 @@ snapshots:
       rolldown: 1.0.2
       rollup: 4.60.4
       vite: 8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0)
-      webpack: 5.102.1(esbuild@0.28.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  unplugin-dts@1.0.1(@microsoft/api-extractor@7.58.7(@types/node@24.10.4))(esbuild@0.28.0)(rolldown@1.0.2)(rollup@4.60.4)(typescript@5.8.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(webpack@5.102.1(esbuild@0.28.0)):
-    dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.60.4)
-      '@volar/typescript': 2.4.27
-      compare-versions: 6.1.1
-      debug: 4.4.3(supports-color@5.5.0)
-      kolorist: 1.8.0
-      local-pkg: 1.1.2
-      magic-string: 0.30.21
-      typescript: 5.8.3
-      unplugin: 2.3.11
-    optionalDependencies:
-      '@microsoft/api-extractor': 7.58.7(@types/node@24.10.4)
-      esbuild: 0.28.0
-      rolldown: 1.0.2
-      rollup: 4.60.4
-      vite: 8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0)
       webpack: 5.102.1(esbuild@0.28.0)
     transitivePeerDependencies:
       - supports-color
@@ -26065,21 +25124,6 @@ snapshots:
       pathe: 2.0.3
       picomatch: 4.0.3
 
-  unplugin-vue-components@32.1.0(@nuxt/kit@4.4.6(magicast@0.3.5))(vue@3.5.34(typescript@5.8.3)):
-    dependencies:
-      chokidar: 5.0.0
-      local-pkg: 1.2.1
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      obug: 2.1.1
-      picomatch: 4.0.4
-      tinyglobby: 0.2.16
-      unplugin: 3.0.0
-      unplugin-utils: 0.3.1
-      vue: 3.5.34(typescript@5.8.3)
-    optionalDependencies:
-      '@nuxt/kit': 4.4.6(magicast@0.3.5)
-
   unplugin-vue-components@32.1.0(@nuxt/kit@4.4.6(magicast@0.3.5))(vue@3.5.34(typescript@5.9.3)):
     dependencies:
       chokidar: 5.0.0
@@ -26109,28 +25153,6 @@ snapshots:
       vue: 3.5.34(typescript@5.9.3)
     optionalDependencies:
       '@nuxt/kit': 4.4.6(magicast@0.5.3)
-
-  unplugin-vue-router@0.14.0(@vue/compiler-sfc@3.5.26)(vue-router@4.5.1(vue@3.5.34(typescript@5.8.3)))(vue@3.5.34(typescript@5.8.3)):
-    dependencies:
-      '@vue-macros/common': 3.0.0-beta.15(vue@3.5.34(typescript@5.8.3))
-      '@vue/compiler-sfc': 3.5.26
-      ast-walker-scope: 0.8.3
-      chokidar: 4.0.3
-      fast-glob: 3.3.3
-      json5: 2.2.3
-      local-pkg: 1.1.2
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      pathe: 2.0.3
-      picomatch: 4.0.3
-      scule: 1.3.0
-      unplugin: 2.3.11
-      unplugin-utils: 0.2.5
-      yaml: 2.8.1
-    optionalDependencies:
-      vue-router: 4.5.1(vue@3.5.34(typescript@5.8.3))
-    transitivePeerDependencies:
-      - vue
 
   unplugin-vue-router@0.14.0(@vue/compiler-sfc@3.5.26)(vue-router@4.5.1(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3)):
     dependencies:
@@ -26275,32 +25297,15 @@ snapshots:
   uuid@11.1.0:
     optional: true
 
-  valibot@1.1.0(typescript@5.8.3):
-    optionalDependencies:
-      typescript: 5.8.3
-
   valibot@1.1.0(typescript@5.9.3):
     optionalDependencies:
       typescript: 5.9.3
-
-  valibot@1.4.0(typescript@5.8.3):
-    optionalDependencies:
-      typescript: 5.8.3
-    optional: true
 
   valibot@1.4.0(typescript@5.9.3):
     optionalDependencies:
       typescript: 5.9.3
 
   vary@1.1.2: {}
-
-  vaul-vue@0.4.1(reka-ui@2.9.7(vue@3.5.34(typescript@5.8.3)))(vue@3.5.34(typescript@5.8.3)):
-    dependencies:
-      '@vueuse/core': 10.11.1(vue@3.5.34(typescript@5.8.3))
-      reka-ui: 2.9.7(vue@3.5.34(typescript@5.8.3))
-      vue: 3.5.34(typescript@5.8.3)
-    transitivePeerDependencies:
-      - '@vue/composition-api'
 
   vaul-vue@0.4.1(reka-ui@2.9.7(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3)):
     dependencies:
@@ -26377,26 +25382,6 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-checker@0.13.0(@biomejs/biome@2.2.2)(eslint@9.37.0(jiti@2.7.0))(optionator@0.9.4)(oxlint@1.2.0)(typescript@5.8.3)(vite@7.3.3(@types/node@24.10.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue-tsc@3.2.1(typescript@5.8.3)):
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      chokidar: 4.0.3
-      npm-run-path: 6.0.0
-      picocolors: 1.1.1
-      picomatch: 4.0.4
-      proper-lockfile: 4.1.2
-      tiny-invariant: 1.3.3
-      tinyglobby: 0.2.16
-      vite: 7.3.3(@types/node@24.10.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0)
-      vscode-uri: 3.1.0
-    optionalDependencies:
-      '@biomejs/biome': 2.2.2
-      eslint: 9.37.0(jiti@2.7.0)
-      optionator: 0.9.4
-      oxlint: 1.2.0
-      typescript: 5.8.3
-      vue-tsc: 3.2.1(typescript@5.8.3)
-
   vite-plugin-checker@0.13.0(@biomejs/biome@2.2.2)(eslint@9.37.0(jiti@2.7.0))(optionator@0.9.4)(oxlint@1.2.0)(typescript@5.9.3)(vite@7.3.3(@types/node@24.10.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue-tsc@3.2.1(typescript@5.9.3)):
     dependencies:
       '@babel/code-frame': 7.27.1
@@ -26417,9 +25402,9 @@ snapshots:
       typescript: 5.9.3
       vue-tsc: 3.2.1(typescript@5.9.3)
 
-  vite-plugin-dts@5.0.1(@microsoft/api-extractor@7.58.7(@types/node@22.15.32))(esbuild@0.28.0)(rolldown@1.0.2)(rollup@4.60.4)(typescript@5.8.3)(vite@8.0.14(@types/node@22.15.32)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(webpack@5.102.1(esbuild@0.28.0)):
+  vite-plugin-dts@5.0.1(@microsoft/api-extractor@7.58.7(@types/node@22.15.32))(esbuild@0.28.0)(rolldown@1.0.2)(rollup@4.60.4)(typescript@5.9.3)(vite@8.0.14(@types/node@22.15.32)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(webpack@5.102.1(esbuild@0.28.0)):
     dependencies:
-      unplugin-dts: 1.0.1(@microsoft/api-extractor@7.58.7(@types/node@22.15.32))(esbuild@0.28.0)(rolldown@1.0.2)(rollup@4.60.4)(typescript@5.8.3)(vite@8.0.14(@types/node@22.15.32)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(webpack@5.102.1(esbuild@0.28.0))
+      unplugin-dts: 1.0.1(@microsoft/api-extractor@7.58.7(@types/node@22.15.32))(esbuild@0.28.0)(rolldown@1.0.2)(rollup@4.60.4)(typescript@5.9.3)(vite@8.0.14(@types/node@22.15.32)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(webpack@5.102.1(esbuild@0.28.0))
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.7(@types/node@22.15.32)
       rollup: 4.60.4
@@ -26433,29 +25418,13 @@ snapshots:
       - typescript
       - webpack
 
-  vite-plugin-dts@5.0.1(@microsoft/api-extractor@7.58.7(@types/node@24.10.4))(esbuild@0.28.0)(rolldown@1.0.2)(rollup@4.60.4)(typescript@5.8.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(webpack@5.102.1(esbuild@0.28.0)):
+  vite-plugin-dts@5.0.1(@microsoft/api-extractor@7.58.7(@types/node@24.10.4))(esbuild@0.28.0)(rolldown@1.0.2)(rollup@4.60.4)(typescript@5.9.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(webpack@5.102.1(esbuild@0.28.0)):
     dependencies:
-      unplugin-dts: 1.0.1(@microsoft/api-extractor@7.58.7(@types/node@24.10.4))(esbuild@0.28.0)(rolldown@1.0.2)(rollup@4.60.4)(typescript@5.8.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(webpack@5.102.1(esbuild@0.28.0))
+      unplugin-dts: 1.0.1(@microsoft/api-extractor@7.58.7(@types/node@24.10.4))(esbuild@0.28.0)(rolldown@1.0.2)(rollup@4.60.4)(typescript@5.9.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(webpack@5.102.1(esbuild@0.28.0))
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.7(@types/node@24.10.4)
       rollup: 4.60.4
       vite: 8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - '@vue/language-core'
-      - esbuild
-      - rolldown
-      - supports-color
-      - typescript
-      - webpack
-
-  vite-plugin-dts@5.0.1(@microsoft/api-extractor@7.58.7(@types/node@24.10.4))(esbuild@0.28.0)(rolldown@1.0.2)(rollup@4.60.4)(typescript@5.8.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(webpack@5.102.1(esbuild@0.28.0)):
-    dependencies:
-      unplugin-dts: 1.0.1(@microsoft/api-extractor@7.58.7(@types/node@24.10.4))(esbuild@0.28.0)(rolldown@1.0.2)(rollup@4.60.4)(typescript@5.8.3)(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(webpack@5.102.1(esbuild@0.28.0))
-    optionalDependencies:
-      '@microsoft/api-extractor': 7.58.7(@types/node@24.10.4)
-      rollup: 4.60.4
-      vite: 8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - '@vue/language-core'
@@ -26480,23 +25449,6 @@ snapshots:
       - supports-color
       - typescript
       - webpack
-
-  vite-plugin-inspect@11.3.3(@nuxt/kit@4.4.6(magicast@0.3.5))(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0)):
-    dependencies:
-      ansis: 4.3.0
-      debug: 4.4.3(supports-color@5.5.0)
-      error-stack-parser-es: 1.0.5
-      ohash: 2.0.11
-      open: 10.2.0
-      perfect-debounce: 2.1.0
-      sirv: 3.0.2
-      unplugin-utils: 0.3.1
-      vite: 8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0)
-      vite-dev-rpc: 1.1.0(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))
-    optionalDependencies:
-      '@nuxt/kit': 4.4.6(magicast@0.3.5)
-    transitivePeerDependencies:
-      - supports-color
 
   vite-plugin-inspect@11.3.3(@nuxt/kit@4.4.6(magicast@0.5.3))(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0)):
     dependencies:
@@ -26549,16 +25501,6 @@ snapshots:
       vite: 8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0)
     optionalDependencies:
       rollup: 4.60.4
-
-  vite-plugin-vue-tracer@1.4.0(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.8.3)):
-    dependencies:
-      estree-walker: 3.0.3
-      exsolve: 1.0.8
-      magic-string: 0.30.21
-      pathe: 2.0.3
-      source-map-js: 1.2.1
-      vite: 8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0)
-      vue: 3.5.34(typescript@5.8.3)
 
   vite-plugin-vue-tracer@1.4.0(vite@8.0.14(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3)):
     dependencies:
@@ -26650,23 +25592,6 @@ snapshots:
       terser: 5.44.0
       tsx: 4.20.6
       yaml: 2.9.0
-
-  vitest-environment-nuxt@1.0.1(@playwright/test@1.56.1)(jsdom@25.0.1)(magicast@0.3.5)(playwright-core@1.57.0)(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.10.4)(jiti@2.7.0)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0)):
-    dependencies:
-      '@nuxt/test-utils': 3.19.2(@playwright/test@1.56.1)(jsdom@25.0.1)(magicast@0.3.5)(playwright-core@1.57.0)(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.10.4)(jiti@2.7.0)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0))
-    transitivePeerDependencies:
-      - '@cucumber/cucumber'
-      - '@jest/globals'
-      - '@playwright/test'
-      - '@testing-library/vue'
-      - '@vitest/ui'
-      - '@vue/test-utils'
-      - happy-dom
-      - jsdom
-      - magicast
-      - playwright-core
-      - typescript
-      - vitest
 
   vitest-environment-nuxt@1.0.1(@playwright/test@1.56.1)(jsdom@25.0.1)(magicast@0.3.5)(playwright-core@1.57.0)(typescript@5.9.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.10.4)(jiti@2.7.0)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.9.0)):
     dependencies:
@@ -26901,17 +25826,13 @@ snapshots:
 
   vue-component-type-helpers@3.3.1: {}
 
-  vue-demi@0.14.10(vue@3.5.34(typescript@5.8.3)):
-    dependencies:
-      vue: 3.5.34(typescript@5.8.3)
-
   vue-demi@0.14.10(vue@3.5.34(typescript@5.9.3)):
     dependencies:
       vue: 3.5.34(typescript@5.9.3)
 
   vue-devtools-stub@0.1.0: {}
 
-  vue-docgen-api@4.79.2(vue@3.5.34(typescript@5.8.3)):
+  vue-docgen-api@4.79.2(vue@3.5.34(typescript@5.9.3)):
     dependencies:
       '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
@@ -26924,15 +25845,8 @@ snapshots:
       pug: 3.0.3
       recast: 0.23.11
       ts-map: 1.0.3
-      vue: 3.5.34(typescript@5.8.3)
-      vue-inbrowser-compiler-independent-utils: 4.71.1(vue@3.5.34(typescript@5.8.3))
-
-  vue-i18n@11.1.12(vue@3.5.34(typescript@5.8.3)):
-    dependencies:
-      '@intlify/core-base': 11.1.12
-      '@intlify/shared': 11.1.12
-      '@vue/devtools-api': 6.6.4
-      vue: 3.5.34(typescript@5.8.3)
+      vue: 3.5.34(typescript@5.9.3)
+      vue-inbrowser-compiler-independent-utils: 4.71.1(vue@3.5.34(typescript@5.9.3))
 
   vue-i18n@11.1.12(vue@3.5.34(typescript@5.9.3)):
     dependencies:
@@ -26941,14 +25855,9 @@ snapshots:
       '@vue/devtools-api': 6.6.4
       vue: 3.5.34(typescript@5.9.3)
 
-  vue-inbrowser-compiler-independent-utils@4.71.1(vue@3.5.34(typescript@5.8.3)):
+  vue-inbrowser-compiler-independent-utils@4.71.1(vue@3.5.34(typescript@5.9.3)):
     dependencies:
-      vue: 3.5.34(typescript@5.8.3)
-
-  vue-router@4.5.1(vue@3.5.34(typescript@5.8.3)):
-    dependencies:
-      '@vue/devtools-api': 6.6.4
-      vue: 3.5.34(typescript@5.8.3)
+      vue: 3.5.34(typescript@5.9.3)
 
   vue-router@4.5.1(vue@3.5.34(typescript@5.9.3)):
     dependencies:
@@ -26978,29 +25887,6 @@ snapshots:
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.26
 
-  vue-router@5.0.7(@vue/compiler-sfc@3.5.34)(vue@3.5.34(typescript@5.8.3)):
-    dependencies:
-      '@babel/generator': 8.0.0-rc.5
-      '@vue-macros/common': 3.1.2(vue@3.5.34(typescript@5.8.3))
-      '@vue/devtools-api': 8.1.2
-      ast-walker-scope: 0.8.3
-      chokidar: 5.0.0
-      json5: 2.2.3
-      local-pkg: 1.1.2
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      muggle-string: 0.4.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      scule: 1.3.0
-      tinyglobby: 0.2.16
-      unplugin: 3.0.0
-      unplugin-utils: 0.3.1
-      vue: 3.5.34(typescript@5.8.3)
-      yaml: 2.9.0
-    optionalDependencies:
-      '@vue/compiler-sfc': 3.5.34
-
   vue-router@5.0.7(@vue/compiler-sfc@3.5.34)(vue@3.5.34(typescript@5.9.3)):
     dependencies:
       '@babel/generator': 8.0.0-rc.5
@@ -27024,28 +25910,11 @@ snapshots:
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.34
 
-  vue-tsc@3.2.1(typescript@5.8.3):
-    dependencies:
-      '@volar/typescript': 2.4.27
-      '@vue/language-core': 3.2.1
-      typescript: 5.8.3
-
   vue-tsc@3.2.1(typescript@5.9.3):
     dependencies:
       '@volar/typescript': 2.4.27
       '@vue/language-core': 3.2.1
       typescript: 5.9.3
-    optional: true
-
-  vue@3.5.34(typescript@5.8.3):
-    dependencies:
-      '@vue/compiler-dom': 3.5.34
-      '@vue/compiler-sfc': 3.5.34
-      '@vue/runtime-dom': 3.5.34
-      '@vue/server-renderer': 3.5.34(vue@3.5.34(typescript@5.8.3))
-      '@vue/shared': 3.5.34
-    optionalDependencies:
-      typescript: 5.8.3
 
   vue@3.5.34(typescript@5.9.3):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,7 @@ packages:
     - tooling/**
 
 catalog:
+    "@microsoft/api-extractor": ^7.58.7
     "@styleframe/license": ^2.0.2
     "@types/node": ^22.15.32
     "@vitest/coverage-v8": ^4.1.7

--- a/testing/integration/package.json
+++ b/testing/integration/package.json
@@ -2,14 +2,14 @@
 	"name": "@styleframe/testing-integration",
 	"version": "0.0.1",
 	"type": "module",
-	"types": "./dist/theme.d.ts",
-	"module": "./dist/theme.js",
-	"main": "./dist/theme.umd.cjs",
+	"types": "./dist/index.d.ts",
+	"module": "./dist/testing-integration.js",
+	"main": "./dist/testing-integration.umd.cjs",
 	"exports": {
 		".": {
-			"types": "./dist/theme.d.ts",
-			"import": "./dist/theme.js",
-			"require": "./dist/theme.umd.cjs"
+			"types": "./dist/index.d.ts",
+			"import": "./dist/testing-integration.js",
+			"require": "./dist/testing-integration.umd.cjs"
 		}
 	},
 	"scripts": {
@@ -24,6 +24,7 @@
 		"test:e2e": "pnpm exec playwright test"
 	},
 	"devDependencies": {
+		"@microsoft/api-extractor": "catalog:",
 		"@playwright/test": "^1.56.1",
 		"@styleframe/config-typescript": "workspace:^3.0.0",
 		"@styleframe/config-vite": "workspace:^3.0.1",

--- a/theme/package.json
+++ b/theme/package.json
@@ -7,9 +7,14 @@
 	"main": "./dist/theme.umd.cjs",
 	"exports": {
 		".": {
-			"types": "./dist/index.d.ts",
-			"import": "./dist/theme.js",
-			"require": "./dist/theme.umd.cjs"
+			"import": {
+				"types": "./dist/index.d.mts",
+				"default": "./dist/theme.js"
+			},
+			"require": {
+				"types": "./dist/index.d.cts",
+				"default": "./dist/theme.umd.cjs"
+			}
 		}
 	},
 	"files": [
@@ -26,6 +31,7 @@
 		"test:dev": "vitest --watch"
 	},
 	"devDependencies": {
+		"@microsoft/api-extractor": "catalog:",
 		"@styleframe/config-typescript": "workspace:^3.0.0",
 		"@styleframe/config-vite": "workspace:^3.0.1",
 		"@styleframe/core": "workspace:^3.6.0",

--- a/tooling/cli/package.json
+++ b/tooling/cli/package.json
@@ -8,9 +8,14 @@
 	"main": "./dist/index.cjs",
 	"exports": {
 		".": {
-			"types": "./dist/index.d.ts",
-			"import": "./dist/index.js",
-			"require": "./dist/index.cjs"
+			"import": {
+				"types": "./dist/index.d.mts",
+				"default": "./dist/index.js"
+			},
+			"require": {
+				"types": "./dist/index.d.cts",
+				"default": "./dist/index.cjs"
+			}
 		}
 	},
 	"files": [
@@ -39,6 +44,7 @@
 		"@styleframe/loader": "workspace:^3.0.2"
 	},
 	"devDependencies": {
+		"@microsoft/api-extractor": "catalog:",
 		"@styleframe/config-typescript": "workspace:^3.0.0",
 		"@styleframe/config-vite": "workspace:^3.0.1",
 		"@styleframe/core": "workspace:^3.6.0",


### PR DESCRIPTION
Enables `vite-plugin-dts`'s `bundleTypes` in the shared Vite config so every Vite-built package (core, loader, runtime, scanner, transpiler, theme, cli) rolls its declarations into a single `.d.ts` per entry via `@microsoft/api-extractor`, which is added to the pnpm catalog and to each building package. A superset `lib` is re-supplied to api-extractor because `unplugin-dts` forwards only a tsconfig's own compilerOptions and drops `extends`-inherited ones, which would otherwise break resolution of globals like `Map`. The `styleframe` barrel now emits explicit `.d.mts`/`.d.cts` declarations per export condition via a tsdown build hook, and `testing/integration`'s dist entry names are aligned.