### PR TITLE
docs: disable og-image runtime endpoint (zero-runtime mode)

### DIFF
--- a/apps/docs/nuxt.config.ts
+++ b/apps/docs/nuxt.config.ts
@@ -99,6 +99,14 @@ export default defineNuxtConfig({
 		},
 	},
 	/**
+	 * Prerendering bakes every OG image at build time, so no runtime
+	 * generation endpoint is needed (or exposed unsigned).
+	 * @docs https://nuxtseo.com/og-image/guides/zero-runtime
+	 */
+	ogImage: {
+		zeroRuntime: true,
+	},
+	/**
 	 * @docs https://nuxt.com/modules/sitemap
 	 */
 	sitemap: {


### PR DESCRIPTION
Enables `zeroRuntime: true` for `nuxt-og-image` in the docs site config.

The docs site is fully prerendered via `nitro.prerender.crawlLinks`, so OG images are baked at build time — no runtime generation endpoint is needed. This eliminates the unsigned-endpoint warning that appeared in dev and removes the satori/runtime code from the server bundle.

Scoped to `apps/docs` only; `apps/app` is not fully prerendered and remains unaffected.