### PR TITLE
feat(theme): add Checkbox, CheckboxField, and CheckboxGroup recipes

### DIFF
--- a/.changeset/checkbox-recipe.md
+++ b/.changeset/checkbox-recipe.md
@@ -1,0 +1,10 @@
+---
+"@styleframe/theme": minor
+"styleframe": minor
+---
+
+Add Checkbox, CheckboxField, and CheckboxGroup recipes.
+
+Adds three Inkline-style form-control recipes built on the native `<input type="checkbox">`. The `useCheckboxFieldRecipe()` composable styles the box with `appearance: none` and an SVG checkmark/dash `background-image`; `:checked`, `:indeterminate`, `:disabled`, and `:focus-visible` states are driven by native pseudo-classes. The `useCheckboxRecipe()` composable wraps the label, and `useCheckboxGroupRecipe()` lays out a set with `vertical` / `horizontal` orientation. All three support `light`, `dark`, and `neutral` surface colors and `sm` / `md` / `lg` sizes.
+
+Also adds `useWebkitAppearanceUtility` (`-webkit-appearance`) to `@styleframe/theme` and registers it in `useUtilitiesPreset`, enabling recipes to set the vendor-prefixed appearance property.

--- a/apps/docs/content/docs/05.components/05.forms/01.checkbox.md
+++ b/apps/docs/content/docs/05.components/05.forms/01.checkbox.md
@@ -1,6 +1,6 @@
 ---
 title: Checkbox
-description: A custom checkbox built on the native input, with a CSS checkmark, checked / indeterminate / disabled / focus states, light, dark, and neutral surface colors, and three sizes through the recipe system.
+description: A custom checkbox built on the native input, with a CSS checkmark, checked, indeterminate, disabled, and focus states, light, dark, and neutral surface colors, and three sizes through the recipe system.
 navigation:
     icon: false
 ---

--- a/apps/docs/content/docs/05.components/05.forms/01.checkbox.md
+++ b/apps/docs/content/docs/05.components/05.forms/01.checkbox.md
@@ -1,0 +1,432 @@
+---
+title: Checkbox
+description: A custom checkbox built on the native input, with a CSS checkmark, checked / indeterminate / disabled / focus states, light, dark, and neutral surface colors, and three sizes through the recipe system.
+navigation:
+    icon: false
+---
+
+## Overview
+
+The **Checkbox** is a binary form control that lets users toggle an option on or off. It is composed of two recipe parts:
+
+- **`useCheckboxRecipe()`** &mdash; the `<label>` wrapper that owns the inline layout (gap, alignment), label typography, and dims itself when the field is disabled.
+- **`useCheckboxFieldRecipe()`** &mdash; the native `<input type="checkbox">` styled with `appearance: none`, a white SVG checkmark/dash painted as a `background-image`, and the checked, indeterminate, focus, and disabled states.
+
+The field is the real native input, so every state is driven by the browser: `:checked` and `:indeterminate` fill the box with `@color.primary`, `:focus-visible` shows a focus ring, and `:disabled` dims it. The `color` axis sets the *unchecked* surface (`light`, `dark`, `neutral`); the checked fill stays `@color.primary` across all three. To lay several checkboxes out as a set, see the [Checkbox Group](/docs/components/forms/checkbox-group) recipe.
+
+The Checkbox recipes integrate directly with the default [design tokens preset](/docs/theme/design-tokens/presets) and generate type-safe utility classes at build time with zero runtime CSS.
+
+## Why use the Checkbox recipe?
+
+The Checkbox recipe helps you:
+
+- **Ship faster with sensible defaults**: Get 3 surface colors and 3 sizes out of the box with a single set of composable calls.
+- **Build on the native input**: States ride on native pseudo-classes (`:checked`, `:indeterminate`, `:disabled`, `:focus-visible`), so the control stays keyboard-accessible and form-associated with zero runtime JavaScript.
+- **Maintain consistency**: The checked fill, checkmark, focus ring, and dark-mode surfaces follow the same design rules everywhere.
+- **Customize without forking**: Override base styles, default variants, or filter out options you don't need &mdash; all through the options API.
+- **Stay type-safe**: Full TypeScript support means your editor catches invalid color or size values at compile time.
+- **Integrate with your tokens**: Every value references the design tokens preset, so theme changes propagate automatically.
+
+## Usage
+
+::steps{level="4"}
+
+#### Register the recipes
+
+Add the Checkbox recipes to a local Styleframe instance. The global `styleframe.config.ts` provides design tokens and utilities, while the component-level file registers the recipes themselves:
+
+:::code-tree{default-value="src/components/checkbox.styleframe.ts"}
+
+```ts [src/components/checkbox.styleframe.ts]
+import { styleframe } from 'virtual:styleframe';
+import { useCheckboxRecipe, useCheckboxFieldRecipe } from '@styleframe/theme';
+
+const s = styleframe();
+
+const checkbox = useCheckboxRecipe(s);
+const checkboxField = useCheckboxFieldRecipe(s);
+
+export default s;
+```
+
+```ts [styleframe.config.ts]
+import { styleframe } from 'styleframe';
+import { useDesignTokensPreset, useUtilitiesPreset } from '@styleframe/theme';
+
+const s = styleframe();
+
+useDesignTokensPreset(s);
+useUtilitiesPreset(s);
+
+export default s;
+```
+
+:::
+
+#### Build the component
+
+Put the `checkbox` wrapper on the `<label>` and the `checkboxField` box on the native `<input type="checkbox">`. The `indeterminate` state is a DOM property (not an HTML attribute), so set it on the element via a ref:
+
+::framework-switcher
+
+#vue
+
+```vue [src/components/Checkbox.vue]
+<script setup lang="ts">
+import { onMounted, ref, watch } from "vue";
+import { checkbox, checkboxField } from "virtual:styleframe";
+
+const {
+	color = "neutral",
+	size = "md",
+	checked = false,
+	indeterminate = false,
+	disabled = false,
+	label,
+} = defineProps<{
+	color?: "light" | "dark" | "neutral";
+	size?: "sm" | "md" | "lg";
+	checked?: boolean;
+	indeterminate?: boolean;
+	disabled?: boolean;
+	label?: string;
+}>();
+
+const field = ref<HTMLInputElement | null>(null);
+const syncIndeterminate = () => {
+	if (field.value) field.value.indeterminate = indeterminate;
+};
+onMounted(syncIndeterminate);
+watch(() => indeterminate, syncIndeterminate);
+</script>
+
+<template>
+	<label :class="checkbox({ size })">
+		<input
+			ref="field"
+			type="checkbox"
+			:class="checkboxField({ color, size })"
+			:checked="checked"
+			:disabled="disabled"
+		/>
+		<span>{{ label }}</span>
+	</label>
+</template>
+```
+
+#react
+
+```ts [src/components/Checkbox.tsx]
+import { useEffect, useRef } from "react";
+import { checkbox, checkboxField } from "virtual:styleframe";
+
+interface CheckboxProps {
+	color?: "light" | "dark" | "neutral";
+	size?: "sm" | "md" | "lg";
+	checked?: boolean;
+	indeterminate?: boolean;
+	disabled?: boolean;
+	label?: string;
+}
+
+export function Checkbox({
+	color = "neutral",
+	size = "md",
+	checked = false,
+	indeterminate = false,
+	disabled = false,
+	label,
+}: CheckboxProps) {
+	const field = useRef<HTMLInputElement>(null);
+
+	useEffect(() => {
+		if (field.current) field.current.indeterminate = indeterminate;
+	}, [indeterminate]);
+
+	return (
+		<label className={checkbox({ size })}>
+			<input
+				ref={field}
+				type="checkbox"
+				className={checkboxField({ color, size })}
+				checked={checked}
+				disabled={disabled}
+				readOnly
+			/>
+			<span>{label}</span>
+		</label>
+	);
+}
+```
+
+#other
+
+The `checkbox()` and `checkboxField()` runtimes each return a class string. Apply them however your framework binds classes:
+
+```ts [src/components/checkbox.ts]
+import { checkbox, checkboxField } from "virtual:styleframe";
+
+const wrapperClasses = checkbox({ size: "md" });
+// → "checkbox _display:inline-flex _align-items:center ..."
+
+const fieldClasses = checkboxField({ color: "neutral", size: "md" });
+// → "checkbox-field _appearance:none _border-width:thin ..."
+```
+
+```html [src/components/checkbox.html]
+<label class="checkbox _display:inline-flex _align-items:center ...">
+	<input type="checkbox" class="checkbox-field _appearance:none ..." />
+	<span>Accept terms and conditions</span>
+</label>
+```
+
+::
+
+#### See it in action
+
+:::story-preview
+---
+story: theme-recipes-forms-checkbox--default
+panel: true
+---
+:::
+
+::
+
+## Colors
+
+The Checkbox field includes 3 color variants: `light`, `dark`, and `neutral`. Like the [Input](/docs/components/forms/input) and Card recipes, these are neutral-spectrum surface colors rather than status colors &mdash; the color sets the *unchecked* box background and border, while the checked and indeterminate fill is always `@color.primary`.
+
+The `neutral` color adapts automatically: a light surface in light mode and a dark surface in dark mode, making it the safest default for general-purpose forms.
+
+::story-preview
+---
+story: theme-recipes-forms-checkbox--neutral
+panel: true
+---
+::
+
+### Color Reference
+
+::story-preview
+---
+story: theme-recipes-forms-checkbox--all-states
+height: 420
+---
+::
+
+| Color | Token | Use Case |
+|-------|-------|----------|
+| `light` | `@color.white` / `@color.gray-300` | Light surfaces, stays light in dark mode |
+| `dark` | `@color.gray-900` / `@color.gray-600` | Dark surfaces, stays dark in light mode |
+| `neutral` | Adaptive (light &harr; dark) | Default color, adapts to the current color scheme |
+
+::tip
+**Pro tip:** Use `neutral` as your default checkbox color. It adapts to the user's color scheme automatically, so you don't need to manage light and dark surfaces separately.
+::
+
+## Sizes
+
+Three size variants from `sm` to `lg` control the box dimensions and border radius. The checkmark is a white SVG `background-image` sized with `background-size: contain`, so it stays crisp and scales with the box.
+
+::story-preview
+---
+story: theme-recipes-forms-checkbox--all-sizes
+height: 320
+---
+::
+
+### Size Reference
+
+| Size | Box Size | Border Radius |
+|------|----------|---------------|
+| `sm` | `14px` | `@border-radius.sm` |
+| `md` | `16px` | `@border-radius.sm` |
+| `lg` | `20px` | `@border-radius.md` |
+
+::note
+**Good to know:** Pass the same `size` to the `checkbox` wrapper and the `checkboxField` box so the label typography, gap, and box scale together.
+::
+
+## States
+
+The field's states ride on native pseudo-classes, so they reflect the real `<input>` without extra wiring.
+
+### Checked
+
+`:checked` fills the box with `@color.primary` and reveals the white SVG checkmark. Bind the native `checked` attribute (or `v-model` / controlled value) as usual.
+
+::story-preview
+---
+story: theme-recipes-forms-checkbox--checked
+panel: true
+---
+::
+
+### Indeterminate
+
+`:indeterminate` fills the box with `@color.primary` and shows a horizontal dash instead of the checkmark &mdash; use it for a "select all" control whose children are partially selected. Indeterminate is a DOM property only, so set `el.indeterminate = true` on the input via a ref (see [Build the component](#build-the-component)).
+
+::story-preview
+---
+story: theme-recipes-forms-checkbox--indeterminate
+panel: true
+---
+::
+
+### Disabled
+
+`:disabled` dims the box to `0.5` opacity and switches the cursor to `not-allowed`; the wrapper dims its label to match via `:has()`. Mirror it with the native `disabled` attribute so the input is also removed from the tab order.
+
+::story-preview
+---
+story: theme-recipes-forms-checkbox--disabled
+panel: true
+---
+::
+
+## Anatomy
+
+The Checkbox is composed of two independent recipes: a label wrapper and the native input box.
+
+| Part | Recipe | Role |
+|------|--------|------|
+| **Wrapper** | `useCheckboxRecipe()` | The `.checkbox` `<label>` &mdash; owns inline layout (gap, alignment), label typography, and disabled-label dimming |
+| **Field** | `useCheckboxFieldRecipe()` | The `.checkbox-field` native `<input type="checkbox">` &mdash; owns the box, checkmark, color surface, and checked / indeterminate / disabled / focus states |
+
+```html
+<label class="checkbox(...)">
+	<input type="checkbox" class="checkboxField(...)" />
+	<span>Accept terms and conditions</span>
+</label>
+```
+
+The wrapper dims its own label when it contains a disabled field, using `:has(.checkbox-field:disabled)`, so a disabled checkbox and its text fade together without extra props.
+
+## Accessibility
+
+- **Label every checkbox.** Wrap the input and its text in the `<label>` (as the wrapper does) or associate a separate `<label for="...">`. The recipe styles the control but does not provide a name.
+- **Keep the native input.** Styling the real `<input type="checkbox">` with `appearance: none` preserves keyboard operation (Space toggles), focus order, and form submission for free.
+- **Set `indeterminate` on the element.** Indeterminate is a visual + accessibility state exposed only as a DOM property; set `el.indeterminate = true` so assistive technology reports "mixed".
+- **Mirror `disabled` on the input.** Set the real `disabled` attribute in addition to the recipe state so the field leaves the tab order.
+- **Don't rely on color alone.** The checked state is conveyed by the checkmark, not just the fill color, satisfying [WCAG 1.4.1](https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html). Keep the adjacent label text descriptive.
+- **Verify contrast.** The checkmark is `@color.white` on a `@color.primary` fill. Default tokens meet WCAG AA; if you override the primary color, verify with the [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/).
+
+## Customization
+
+### Overriding Defaults
+
+Each checkbox composable accepts an optional second argument to override any part of the recipe configuration. Overrides are deep-merged with the defaults, so you only need to specify the properties you want to change:
+
+```ts [src/components/checkbox.styleframe.ts]
+import { styleframe } from 'virtual:styleframe';
+import { useCheckboxFieldRecipe } from '@styleframe/theme';
+
+const s = styleframe();
+
+const checkboxField = useCheckboxFieldRecipe(s, {
+    base: {
+        borderRadius: '@border-radius.md',
+    },
+    defaultVariants: {
+        color: 'neutral',
+        size: 'lg',
+    },
+});
+
+export default s;
+```
+
+### Filtering Variants
+
+If you only need a subset of the available variants, use the `filter` option to limit which values are generated. This reduces the output CSS and keeps your component API focused:
+
+```ts [src/components/checkbox.styleframe.ts]
+import { styleframe } from 'virtual:styleframe';
+import { useCheckboxFieldRecipe } from '@styleframe/theme';
+
+const s = styleframe();
+
+// Only generate the neutral color
+const checkboxField = useCheckboxFieldRecipe(s, {
+    filter: {
+        color: ['neutral'],
+    },
+});
+
+export default s;
+```
+
+::note
+**Good to know:** Filtering also removes compound variants and adjusts default variants that reference filtered-out values, so your recipe stays consistent.
+::
+
+## API Reference
+
+### `useCheckboxRecipe(s, options?)`
+
+Creates the checkbox wrapper recipe &mdash; the `.checkbox` `<label>` that lays out the box and label and dims the label when the nested field is disabled.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `s` | `Styleframe` | The Styleframe instance |
+| `options` | `DeepPartial<RecipeConfig>` | Optional overrides for the recipe configuration |
+| `options.base` | `VariantDeclarationsBlock` | Custom base styles for the wrapper |
+| `options.variants` | `Variants` | Custom variant definitions for the recipe |
+| `options.defaultVariants` | `Record<keyof Variants, string>` | Default variant values for the recipe |
+| `options.filter` | `Record<string, string[]>` | Limit which variant values are generated |
+
+**Variants:**
+
+| Variant | Options | Default |
+|---------|---------|---------|
+| `size` | `sm`, `md`, `lg` | `md` |
+
+### `useCheckboxFieldRecipe(s, options?)`
+
+Creates the checkbox field recipe &mdash; the `.checkbox-field` native `<input type="checkbox">` that owns the box, SVG checkmark, surface color, and native states. Accepts the same parameters as `useCheckboxRecipe`.
+
+**Variants:**
+
+| Variant | Options | Default |
+|---------|---------|---------|
+| `color` | `light`, `dark`, `neutral` | `neutral` |
+| `size` | `sm`, `md`, `lg` | `md` |
+
+[Learn more about recipes &rarr;](/docs/api/recipes)
+
+## Best Practices
+
+- **Pass `size` to both parts**: Spread the same `size` to the wrapper and the field so the label and box scale together.
+- **Use `neutral` for general forms**: The neutral color adapts to light and dark mode automatically, making it the safest default.
+- **Mirror state on the native input**: Set the real `disabled` attribute and the `indeterminate` DOM property in addition to styling.
+- **Group related checkboxes**: Use the [Checkbox Group](/docs/components/forms/checkbox-group) recipe to lay out a set with consistent spacing.
+- **Filter what you don't need**: If your forms use only the neutral color, pass a `filter` option to reduce generated CSS.
+
+## FAQ
+
+::accordion
+
+:::accordion-item{label="Why style the native input instead of a custom element?" icon="i-lucide-circle-help"}
+Applying the recipe to the real `<input type="checkbox">` with `appearance: none` keeps the control fully native: Space toggles it, it participates in form submission, and `:checked` / `:indeterminate` / `:disabled` / `:focus-visible` drive the styling with zero runtime JavaScript. A custom `<div>` would need ARIA roles and keyboard handlers to match.
+:::
+
+:::accordion-item{label="How do I set the indeterminate state?" icon="i-lucide-circle-help"}
+`indeterminate` is a DOM property, not an HTML attribute, so you can't set it declaratively in markup. Grab the input via a ref and assign `el.indeterminate = true` (see [Build the component](#build-the-component)). The recipe's `:indeterminate` styles then render a horizontal dash in the primary-filled box.
+:::
+
+:::accordion-item{label="Why is the color light/dark/neutral instead of primary/success/error?" icon="i-lucide-circle-help"}
+The `color` axis controls the *unchecked* box surface, which reflects the form's surface rather than a status. The checked and indeterminate fill is always `@color.primary`, the conventional accent for a selected control. This mirrors the [Input](/docs/components/forms/input) recipe's color model.
+:::
+
+:::accordion-item{label="How does the checked fill stay correct in dark mode?" icon="i-lucide-circle-help"}
+The `neutral` color sets a dark unchecked surface under `&:dark`, which gains attribute-selector specificity when you toggle a `[data-theme="dark"]` theme. To keep the checked box `@color.primary` in that case, the recipe re-asserts the fill under `&:dark:checked` and `&:dark:indeterminate`, so the accent always wins over the dark surface.
+:::
+
+:::accordion-item{label="How does filtering affect the recipe?" icon="i-lucide-circle-help"}
+When you use the `filter` option, compound variants that reference filtered-out colors are automatically removed, and default variants are adjusted if they reference a removed value &mdash; so the recipe stays consistent and only emits the CSS you use.
+:::
+
+::

--- a/apps/docs/content/docs/05.components/05.forms/01.checkbox.md
+++ b/apps/docs/content/docs/05.components/05.forms/01.checkbox.md
@@ -9,12 +9,14 @@ navigation:
 
 The **Checkbox** is a binary form control that lets users toggle an option on or off. It is composed of two recipe parts:
 
-- **`useCheckboxRecipe()`** &mdash; the `<label>` wrapper that owns the inline layout (gap, alignment), label typography, and dims itself when the field is disabled.
-- **`useCheckboxFieldRecipe()`** &mdash; the native `<input type="checkbox">` styled with `appearance: none`, a white SVG checkmark/dash painted as a `background-image`, and the checked, indeterminate, focus, and disabled states.
+- **`useCheckboxRecipe()`** &mdash; the label wrapper that owns the inline layout (gap, alignment), label typography, and dims itself when the field is disabled.
+- **`useCheckboxFieldRecipe()`** &mdash; the native styled input, a white SVG checkmark/dash painted as a background image, and the checked, indeterminate, focus, and disabled states.
 
-The field is the real native input, so every state is driven by the browser: `:checked` and `:indeterminate` fill the box with `@color.primary`, `:focus-visible` shows a focus ring, and `:disabled` dims it. The `color` axis sets the *unchecked* surface (`light`, `dark`, `neutral`); the checked fill stays `@color.primary` across all three. To lay several checkboxes out as a set, see the [Checkbox Group](/docs/components/forms/checkbox-group) recipe.
+The field is the real native input, so every state is driven by the browser: `:checked` and `:indeterminate` fill the box with `@color.primary`, `:focus-visible` shows a focus ring, and `:disabled` dims it. The `color` axis sets the *unchecked* surface (`light`, `dark`, `neutral`) and the checked fill stays `@color.primary` across all three. 
 
 The Checkbox recipes integrate directly with the default [design tokens preset](/docs/theme/design-tokens/presets) and generate type-safe utility classes at build time with zero runtime CSS.
+
+To lay several checkboxes out as a set, see the [Checkbox Group](/docs/components/forms/checkbox-group) recipe.
 
 ## Why use the Checkbox recipe?
 

--- a/apps/docs/content/docs/05.components/05.forms/02.checkbox-group.md
+++ b/apps/docs/content/docs/05.components/05.forms/02.checkbox-group.md
@@ -1,0 +1,304 @@
+---
+title: Checkbox Group
+description: A layout component for arranging a set of checkboxes with shared orientation and spacing. Supports vertical and horizontal layouts and three gap sizes through the recipe system.
+navigation:
+    icon: false
+---
+
+## Overview
+
+The **Checkbox Group** is a layout component that arranges related [checkboxes](/docs/components/forms/checkbox) into a single, consistently spaced set. The `useCheckboxGroupRecipe()` composable creates a fully configured [recipe](/docs/api/recipes) with orientation and size options &mdash; a flex container that stacks checkboxes vertically or lays them out in a wrapping row.
+
+The Checkbox Group recipe integrates directly with the [Checkbox recipe](/docs/components/forms/checkbox) and generates type-safe utility classes at build time with zero runtime CSS.
+
+## Why use the Checkbox Group recipe?
+
+The Checkbox Group recipe helps you:
+
+- **Lay out sets consistently**: Stack checkboxes vertically or wrap them in a row with a single orientation prop.
+- **Control spacing with one axis**: The size variant sets the gap between items, so a whole group scales together.
+- **Compose, don't couple**: The group only handles layout; each child checkbox keeps its own color, size, and state.
+- **Stay type-safe**: Full TypeScript support means your editor catches invalid orientation or size values at compile time.
+
+## Usage
+
+::steps{level="4"}
+
+#### Register the recipe
+
+Add the Checkbox Group recipe to a local Styleframe instance alongside the checkbox recipes. The global `styleframe.config.ts` provides design tokens and utilities, while the component-level file registers the recipes themselves:
+
+:::code-tree{default-value="src/components/checkbox-group.styleframe.ts"}
+
+```ts [src/components/checkbox-group.styleframe.ts]
+import { styleframe } from 'virtual:styleframe';
+import {
+    useCheckboxRecipe,
+    useCheckboxFieldRecipe,
+    useCheckboxGroupRecipe,
+} from '@styleframe/theme';
+
+const s = styleframe();
+
+const checkbox = useCheckboxRecipe(s);
+const checkboxField = useCheckboxFieldRecipe(s);
+const checkboxGroup = useCheckboxGroupRecipe(s);
+
+export default s;
+```
+
+```ts [styleframe.config.ts]
+import { styleframe } from 'styleframe';
+import { useDesignTokensPreset, useUtilitiesPreset } from '@styleframe/theme';
+
+const s = styleframe();
+
+useDesignTokensPreset(s);
+useUtilitiesPreset(s);
+
+export default s;
+```
+
+:::
+
+#### Build the component
+
+Import the `checkboxGroup` runtime function from the virtual module and wrap your checkboxes in the container:
+
+::framework-switcher
+
+#vue
+
+```vue [src/components/CheckboxGroup.vue]
+<script setup lang="ts">
+import { checkboxGroup } from "virtual:styleframe";
+
+const { orientation = "vertical", size = "md" } = defineProps<{
+	orientation?: "vertical" | "horizontal";
+	size?: "sm" | "md" | "lg";
+}>();
+</script>
+
+<template>
+	<div :class="checkboxGroup({ orientation, size })" role="group">
+		<slot />
+	</div>
+</template>
+```
+
+#react
+
+```ts [src/components/CheckboxGroup.tsx]
+import { checkboxGroup } from "virtual:styleframe";
+
+interface CheckboxGroupProps {
+	orientation?: "vertical" | "horizontal";
+	size?: "sm" | "md" | "lg";
+	children?: React.ReactNode;
+}
+
+export function CheckboxGroup({
+	orientation = "vertical",
+	size = "md",
+	children,
+}: CheckboxGroupProps) {
+	const classes = checkboxGroup({ orientation, size });
+
+	return (
+		<div className={classes} role="group">
+			{children}
+		</div>
+	);
+}
+```
+
+#other
+
+The `checkboxGroup()` runtime returns a class string. Apply it however your framework binds classes:
+
+```ts [src/components/checkbox-group.ts]
+import { checkboxGroup } from "virtual:styleframe";
+
+const classes = checkboxGroup({ orientation: "vertical", size: "md" });
+// → "checkbox-group _display:flex _flex-direction:column _gap:0.75 ..."
+```
+
+```html [src/components/checkbox-group.html]
+<div class="checkbox-group _display:flex _flex-direction:column ..." role="group">
+	<label class="checkbox ..."><input type="checkbox" class="checkbox-field ..." /><span>Email</span></label>
+	<label class="checkbox ..."><input type="checkbox" class="checkbox-field ..." /><span>SMS</span></label>
+</div>
+```
+
+::
+
+#### See it in action
+
+:::story-preview
+---
+story: theme-recipes-forms-checkbox-group--default
+panel: true
+---
+:::
+
+::
+
+## Orientation
+
+The Checkbox Group supports two orientation variants that control the layout direction.
+
+### Vertical
+
+The default orientation. Checkboxes are stacked top-to-bottom in a column &mdash; the most common layout for option lists.
+
+::story-preview
+---
+story: theme-recipes-forms-checkbox-group--vertical
+panel: true
+---
+::
+
+### Horizontal
+
+Checkboxes are laid out left-to-right in a wrapping row, aligned to the center. Useful for short option sets that fit inline.
+
+::story-preview
+---
+story: theme-recipes-forms-checkbox-group--horizontal
+panel: true
+---
+::
+
+### Orientation Reference
+
+::story-preview
+---
+story: theme-recipes-forms-checkbox-group--all-orientations
+---
+::
+
+| Orientation | Direction | Notes |
+|-------------|-----------|-------|
+| `vertical` | Top to bottom (`column`) | Default; one option per line |
+| `horizontal` | Left to right (`row`, wraps) | Center-aligned, wraps to the next line when out of space |
+
+## Sizes
+
+Three size variants control the gap between checkboxes, letting you tighten or loosen a group to match its surroundings. Set the same `size` on each child checkbox so the controls and the spacing scale together.
+
+| Size | Gap |
+|------|-----|
+| `sm` | `@0.5` |
+| `md` | `@0.75` |
+| `lg` | `@1` |
+
+::note
+**Good to know:** The group's `size` controls only the gap between items. Pass the same `size` to each child `<Checkbox>` so the boxes and the spacing scale as a set.
+::
+
+## Accessibility
+
+- **Group related options.** Wrap the checkboxes in an element with `role="group"` and an `aria-label` (or `aria-labelledby`) describing the set, so assistive technology announces the context.
+- **Prefer a fieldset for forms.** When the group is part of a form, a native `<fieldset>` with a `<legend>` is the most robust grouping &mdash; apply the recipe class to the fieldset.
+- **Keep each checkbox labelled.** The group provides layout only; every child still needs its own label (see the [Checkbox](/docs/components/forms/checkbox) recipe).
+
+## Customization
+
+### Overriding Defaults
+
+The `useCheckboxGroupRecipe()` composable accepts an optional second argument to override any part of the recipe configuration. Overrides are deep-merged with the defaults, so you only need to specify the properties you want to change:
+
+```ts [src/components/checkbox-group.styleframe.ts]
+import { styleframe } from 'virtual:styleframe';
+import { useCheckboxGroupRecipe } from '@styleframe/theme';
+
+const s = styleframe();
+
+const checkboxGroup = useCheckboxGroupRecipe(s, {
+    defaultVariants: {
+        orientation: 'horizontal',
+        size: 'lg',
+    },
+});
+
+export default s;
+```
+
+### Filtering Variants
+
+If you only need a subset of the available variants, use the `filter` option to limit which values are generated. This reduces the output CSS and keeps your component API focused:
+
+```ts [src/components/checkbox-group.styleframe.ts]
+import { styleframe } from 'virtual:styleframe';
+import { useCheckboxGroupRecipe } from '@styleframe/theme';
+
+const s = styleframe();
+
+// Only generate the vertical orientation
+const checkboxGroup = useCheckboxGroupRecipe(s, {
+    filter: {
+        orientation: ['vertical'],
+    },
+});
+
+export default s;
+```
+
+::note
+**Good to know:** Filtering also removes compound variants and adjusts default variants that reference filtered-out values, so your recipe stays consistent.
+::
+
+## API Reference
+
+### `useCheckboxGroupRecipe(s, options?)`
+
+Creates a checkbox group recipe &mdash; a flex container with orientation and size (gap) variants.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `s` | `Styleframe` | The Styleframe instance |
+| `options` | `DeepPartial<RecipeConfig>` | Optional overrides for the recipe configuration |
+| `options.base` | `VariantDeclarationsBlock` | Custom base styles for the group |
+| `options.variants` | `Variants` | Custom variant definitions for the recipe |
+| `options.defaultVariants` | `Record<keyof Variants, string>` | Default variant values for the recipe |
+| `options.filter` | `Record<string, string[]>` | Limit which variant values are generated |
+
+**Variants:**
+
+| Variant | Options | Default |
+|---------|---------|---------|
+| `orientation` | `vertical`, `horizontal` | `vertical` |
+| `size` | `sm`, `md`, `lg` | `md` |
+
+[Learn more about recipes &rarr;](/docs/api/recipes)
+
+## Best Practices
+
+- **Pair with the Checkbox recipe**: The group handles layout; each child should use the [Checkbox](/docs/components/forms/checkbox) recipe for consistent controls.
+- **Match sizes**: Use the same `size` on the group and its child checkboxes so spacing and boxes scale together.
+- **Keep groups scannable**: Prefer vertical layout for longer option lists; reserve horizontal for two or three short options.
+- **Label the set**: Always describe the group's purpose with `aria-label` or a `<legend>` so screen readers communicate the relationship between options.
+
+## FAQ
+
+::accordion
+
+:::accordion-item{label="Does the group propagate color or size to its checkboxes?" icon="i-lucide-circle-help"}
+No. The group is a pure layout container &mdash; it sets the flex direction and the gap between items. Each child checkbox keeps its own `color` and `size`. Pass the same `size` to the group and its children if you want the spacing and the boxes to scale together.
+:::
+
+:::accordion-item{label="When should I use horizontal orientation?" icon="i-lucide-circle-help"}
+Use `horizontal` for short sets of two or three options that read well inline. It lays the checkboxes out in a centered, wrapping row. For longer option lists, the default `vertical` orientation is easier to scan.
+:::
+
+:::accordion-item{label="Can I use a fieldset instead of a div?" icon="i-lucide-circle-help"}
+Yes, and it's recommended inside forms. Apply the `checkboxGroup()` class to a native `<fieldset>` and add a `<legend>` for the group name. The recipe only sets layout properties, so it works on any block-level element.
+:::
+
+:::accordion-item{label="How does filtering affect the recipe?" icon="i-lucide-circle-help"}
+When you use the `filter` option, variant values you exclude are not generated, and default variants are adjusted if they reference a removed value &mdash; so the recipe stays consistent and only emits the CSS you use.
+:::
+
+::

--- a/apps/storybook/src/components/components/checkbox/Checkbox.vue
+++ b/apps/storybook/src/components/components/checkbox/Checkbox.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from "vue";
+import { checkbox, checkboxField } from "virtual:styleframe";
+
+const props = withDefaults(
+	defineProps<{
+		color?: "light" | "dark" | "neutral";
+		size?: "sm" | "md" | "lg";
+		checked?: boolean;
+		indeterminate?: boolean;
+		disabled?: boolean;
+		label?: string;
+	}>(),
+	{
+		size: "md",
+	},
+);
+
+const fieldRef = ref<HTMLInputElement | null>(null);
+
+const wrapperClasses = computed(() => checkbox({ size: props.size }));
+const fieldClasses = computed(() =>
+	checkboxField({ color: props.color, size: props.size }),
+);
+
+function syncIndeterminate() {
+	if (fieldRef.value) {
+		fieldRef.value.indeterminate = Boolean(props.indeterminate);
+	}
+}
+
+onMounted(syncIndeterminate);
+watch(() => props.indeterminate, syncIndeterminate);
+</script>
+
+<template>
+	<label :class="wrapperClasses">
+		<input
+			ref="fieldRef"
+			type="checkbox"
+			:class="fieldClasses"
+			:checked="checked"
+			:disabled="disabled"
+		/>
+		<span v-if="$slots.default || label"><slot>{{ label }}</slot></span>
+	</label>
+</template>

--- a/apps/storybook/src/components/components/checkbox/CheckboxGroup.vue
+++ b/apps/storybook/src/components/components/checkbox/CheckboxGroup.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { checkboxGroup } from "virtual:styleframe";
+
+const props = withDefaults(
+	defineProps<{
+		orientation?: "vertical" | "horizontal";
+		size?: "sm" | "md" | "lg";
+	}>(),
+	{},
+);
+
+const classes = computed(() =>
+	checkboxGroup({
+		orientation: props.orientation,
+		size: props.size,
+	}),
+);
+</script>
+
+<template>
+	<div :class="classes">
+		<slot />
+	</div>
+</template>

--- a/apps/storybook/src/components/components/checkbox/preview/CheckboxGrid.vue
+++ b/apps/storybook/src/components/components/checkbox/preview/CheckboxGrid.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import Checkbox from "../Checkbox.vue";
+
+const colors = ["neutral", "light", "dark"] as const;
+const states = [
+	{ label: "unchecked", checked: false, indeterminate: false, disabled: false },
+	{ label: "checked", checked: true, indeterminate: false, disabled: false },
+	{ label: "indeterminate", checked: false, indeterminate: true, disabled: false },
+	{ label: "disabled", checked: false, indeterminate: false, disabled: true },
+	{
+		label: "disabled checked",
+		checked: true,
+		indeterminate: false,
+		disabled: true,
+	},
+] as const;
+</script>
+
+<template>
+	<div class="checkbox-section">
+		<div v-for="state in states" :key="state.label">
+			<div class="checkbox-label">{{ state.label }}</div>
+			<div class="checkbox-row">
+				<Checkbox
+					v-for="color in colors"
+					:key="`${state.label}-${color}`"
+					:color="color"
+					:checked="state.checked"
+					:indeterminate="state.indeterminate"
+					:disabled="state.disabled"
+					:label="color"
+				/>
+			</div>
+		</div>
+	</div>
+</template>

--- a/apps/storybook/src/components/components/checkbox/preview/CheckboxGrid.vue
+++ b/apps/storybook/src/components/components/checkbox/preview/CheckboxGrid.vue
@@ -5,7 +5,12 @@ const colors = ["neutral", "light", "dark"] as const;
 const states = [
 	{ label: "unchecked", checked: false, indeterminate: false, disabled: false },
 	{ label: "checked", checked: true, indeterminate: false, disabled: false },
-	{ label: "indeterminate", checked: false, indeterminate: true, disabled: false },
+	{
+		label: "indeterminate",
+		checked: false,
+		indeterminate: true,
+		disabled: false,
+	},
 	{ label: "disabled", checked: false, indeterminate: false, disabled: true },
 	{
 		label: "disabled checked",

--- a/apps/storybook/src/components/components/checkbox/preview/CheckboxGroupGrid.vue
+++ b/apps/storybook/src/components/components/checkbox/preview/CheckboxGroupGrid.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import CheckboxGroup from "../CheckboxGroup.vue";
+import Checkbox from "../Checkbox.vue";
+
+const orientations = ["vertical", "horizontal"] as const;
+</script>
+
+<template>
+	<div class="checkbox-section">
+		<div v-for="orientation in orientations" :key="orientation">
+			<div class="checkbox-label">{{ orientation }}</div>
+			<CheckboxGroup :orientation="orientation">
+				<Checkbox checked label="Email" />
+				<Checkbox label="SMS" />
+				<Checkbox label="Push notifications" />
+			</CheckboxGroup>
+		</div>
+	</div>
+</template>

--- a/apps/storybook/src/components/components/checkbox/preview/CheckboxSizeGrid.vue
+++ b/apps/storybook/src/components/components/checkbox/preview/CheckboxSizeGrid.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import Checkbox from "../Checkbox.vue";
+
+const sizes = ["sm", "md", "lg"] as const;
+const sizeTitles: Record<string, string> = {
+	sm: "Small",
+	md: "Medium",
+	lg: "Large",
+};
+</script>
+
+<template>
+	<div class="checkbox-section">
+		<div v-for="size in sizes" :key="size">
+			<div class="checkbox-label">{{ size }}</div>
+			<div class="checkbox-row">
+				<Checkbox :size="size" :label="sizeTitles[size]" />
+				<Checkbox :size="size" checked label="Checked" />
+				<Checkbox :size="size" indeterminate label="Indeterminate" />
+			</div>
+		</div>
+	</div>
+</template>

--- a/apps/storybook/stories/components/checkbox-group.stories.ts
+++ b/apps/storybook/stories/components/checkbox-group.stories.ts
@@ -1,0 +1,99 @@
+import type { Meta, StoryObj } from "@storybook/vue3-vite";
+
+import CheckboxGroup from "@/components/components/checkbox/CheckboxGroup.vue";
+import Checkbox from "@/components/components/checkbox/Checkbox.vue";
+import CheckboxGroupGrid from "@/components/components/checkbox/preview/CheckboxGroupGrid.vue";
+
+const orientations = ["vertical", "horizontal"] as const;
+const sizes = ["sm", "md", "lg"] as const;
+
+const meta = {
+	title: "Theme/Recipes/Forms/Checkbox Group",
+	component: CheckboxGroup,
+	tags: ["autodocs"],
+	parameters: {
+		layout: "padded",
+	},
+	argTypes: {
+		orientation: {
+			control: "select",
+			options: orientations,
+			description: "The layout direction of the group",
+		},
+		size: {
+			control: "select",
+			options: sizes,
+			description: "The gap between checkboxes",
+		},
+	},
+} satisfies Meta<typeof CheckboxGroup>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	render: (args) => ({
+		components: { CheckboxGroup, Checkbox },
+		setup() {
+			return { args };
+		},
+		template: `
+			<CheckboxGroup v-bind="args">
+				<Checkbox checked label="Email" />
+				<Checkbox label="SMS" />
+				<Checkbox label="Push notifications" />
+			</CheckboxGroup>
+		`,
+	}),
+	args: {
+		orientation: "vertical",
+		size: "md",
+	},
+};
+
+export const AllOrientations: StoryObj = {
+	render: () => ({
+		components: { CheckboxGroupGrid },
+		template: "<CheckboxGroupGrid />",
+	}),
+};
+
+export const Vertical: Story = {
+	render: (args) => ({
+		components: { CheckboxGroup, Checkbox },
+		setup() {
+			return { args };
+		},
+		template: `
+			<CheckboxGroup v-bind="args">
+				<Checkbox checked label="Email" />
+				<Checkbox label="SMS" />
+				<Checkbox label="Push notifications" />
+			</CheckboxGroup>
+		`,
+	}),
+	args: {
+		orientation: "vertical",
+		size: "md",
+	},
+};
+
+export const Horizontal: Story = {
+	render: (args) => ({
+		components: { CheckboxGroup, Checkbox },
+		setup() {
+			return { args };
+		},
+		template: `
+			<CheckboxGroup v-bind="args">
+				<Checkbox checked label="Email" />
+				<Checkbox label="SMS" />
+				<Checkbox label="Push" />
+			</CheckboxGroup>
+		`,
+	}),
+	args: {
+		orientation: "horizontal",
+		size: "md",
+	},
+};

--- a/apps/storybook/stories/components/checkbox.stories.ts
+++ b/apps/storybook/stories/components/checkbox.stories.ts
@@ -1,0 +1,118 @@
+import type { Meta, StoryObj } from "@storybook/vue3-vite";
+
+import Checkbox from "@/components/components/checkbox/Checkbox.vue";
+import CheckboxGrid from "@/components/components/checkbox/preview/CheckboxGrid.vue";
+import CheckboxSizeGrid from "@/components/components/checkbox/preview/CheckboxSizeGrid.vue";
+
+const colors = ["neutral", "light", "dark"] as const;
+const sizes = ["sm", "md", "lg"] as const;
+
+const meta = {
+	title: "Theme/Recipes/Forms/Checkbox",
+	component: Checkbox,
+	tags: ["autodocs"],
+	parameters: {
+		layout: "padded",
+	},
+	argTypes: {
+		color: {
+			control: "select",
+			options: colors,
+			description: "The color of the checkbox surface",
+		},
+		size: {
+			control: "select",
+			options: sizes,
+			description: "The size of the checkbox",
+		},
+		checked: {
+			control: "boolean",
+			description: "Whether the checkbox is checked",
+		},
+		indeterminate: {
+			control: "boolean",
+			description: "Whether the checkbox is in an indeterminate state",
+		},
+		disabled: {
+			control: "boolean",
+			description: "Whether the checkbox is disabled",
+		},
+		label: {
+			control: "text",
+			description: "The checkbox label",
+		},
+	},
+} satisfies Meta<typeof Checkbox>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {
+		color: "neutral",
+		size: "md",
+		checked: true,
+		label: "Accept terms and conditions",
+	},
+};
+
+export const AllStates: StoryObj = {
+	render: () => ({
+		components: { CheckboxGrid },
+		template: "<CheckboxGrid />",
+	}),
+};
+
+export const AllSizes: StoryObj = {
+	render: () => ({
+		components: { CheckboxSizeGrid },
+		template: "<CheckboxSizeGrid />",
+	}),
+};
+
+// Colors
+export const Neutral: Story = {
+	args: { color: "neutral", checked: true, label: "Neutral" },
+};
+
+export const Light: Story = {
+	args: { color: "light", checked: true, label: "Light" },
+};
+
+export const Dark: Story = {
+	args: { color: "dark", checked: true, label: "Dark" },
+};
+
+// States
+export const Unchecked: Story = {
+	args: { checked: false, label: "Unchecked" },
+};
+
+export const Checked: Story = {
+	args: { checked: true, label: "Checked" },
+};
+
+export const Indeterminate: Story = {
+	args: { indeterminate: true, label: "Indeterminate" },
+};
+
+export const Disabled: Story = {
+	args: { disabled: true, label: "Disabled" },
+};
+
+export const DisabledChecked: Story = {
+	args: { disabled: true, checked: true, label: "Disabled checked" },
+};
+
+// Sizes
+export const Small: Story = {
+	args: { size: "sm", checked: true, label: "Small" },
+};
+
+export const Medium: Story = {
+	args: { size: "md", checked: true, label: "Medium" },
+};
+
+export const Large: Story = {
+	args: { size: "lg", checked: true, label: "Large" },
+};

--- a/apps/storybook/stories/components/checkbox.stories.ts
+++ b/apps/storybook/stories/components/checkbox.stories.ts
@@ -72,15 +72,15 @@ export const AllSizes: StoryObj = {
 
 // Colors
 export const Neutral: Story = {
-	args: { color: "neutral", checked: true, label: "Neutral" },
+	args: { color: "neutral", label: "Neutral" },
 };
 
 export const Light: Story = {
-	args: { color: "light", checked: true, label: "Light" },
+	args: { color: "light", label: "Light" },
 };
 
 export const Dark: Story = {
-	args: { color: "dark", checked: true, label: "Dark" },
+	args: { color: "dark", label: "Dark" },
 };
 
 // States

--- a/apps/storybook/stories/components/checkbox.styleframe.ts
+++ b/apps/storybook/stories/components/checkbox.styleframe.ts
@@ -1,0 +1,45 @@
+import {
+	useCheckboxRecipe,
+	useCheckboxFieldRecipe,
+	useCheckboxGroupRecipe,
+} from "@styleframe/theme";
+import { styleframe } from "virtual:styleframe";
+
+const s = styleframe();
+const { selector } = s;
+
+// Initialize checkbox recipes
+export const checkbox = useCheckboxRecipe(s);
+export const checkboxField = useCheckboxFieldRecipe(s);
+export const checkboxGroup = useCheckboxGroupRecipe(s);
+
+// Container styles for story layout
+selector(".checkbox-grid", {
+	display: "flex",
+	flexWrap: "wrap",
+	gap: "@spacing.md",
+	padding: "@spacing.md",
+	alignItems: "flex-start",
+});
+
+selector(".checkbox-section", {
+	display: "flex",
+	flexDirection: "column",
+	gap: "@spacing.lg",
+	padding: "@spacing.md",
+});
+
+selector(".checkbox-row", {
+	display: "flex",
+	flexWrap: "wrap",
+	gap: "@spacing.md",
+	alignItems: "center",
+});
+
+selector(".checkbox-label", {
+	fontSize: "@font-size.sm",
+	fontWeight: "@font-weight.semibold",
+	minWidth: "120px",
+});
+
+export default s;

--- a/theme/src/presets/useUtilitiesPreset.ts
+++ b/theme/src/presets/useUtilitiesPreset.ts
@@ -263,6 +263,7 @@ import {
 import {
 	useAccentColorUtility,
 	useAppearanceUtility,
+	useWebkitAppearanceUtility,
 	useCaretColorUtility,
 	useColorSchemeUtility,
 	useCursorUtility,
@@ -546,6 +547,7 @@ export interface UtilitiesPresetConfig {
 
 	// Interactivity
 	appearance?: Record<string, string> | false;
+	webkitAppearance?: Record<string, string> | false;
 	colorScheme?: Record<string, string> | false;
 	cursor?: Record<string, string> | false;
 	pointerEvents?: Record<string, string> | false;
@@ -763,6 +765,10 @@ export function useUtilitiesPreset(
 	const placeSelf = resolveValues(config.placeSelf, placeSelfValues);
 	const gridAutoFlow = resolveValues(config.gridAutoFlow, gridAutoFlowValues);
 	const appearance = resolveValues(config.appearance, appearanceValues);
+	const webkitAppearance = resolveValues(
+		config.webkitAppearance,
+		appearanceValues,
+	);
 	const colorScheme = resolveValues(config.colorScheme, colorSchemeValues);
 	const cursor = resolveValues(config.cursor, cursorValues);
 	const pointerEvents = resolveValues(
@@ -1120,6 +1126,14 @@ export function useUtilitiesPreset(
 		resolveUtilityOptions("appearance"),
 	);
 	if (appearance) createAppearanceUtility(appearance);
+
+	const createWebkitAppearanceUtility = useWebkitAppearanceUtility(
+		s,
+		undefined,
+		undefined,
+		resolveUtilityOptions("-webkit-appearance"),
+	);
+	if (webkitAppearance) createWebkitAppearanceUtility(webkitAppearance);
 
 	const createColorSchemeUtility = useColorSchemeUtility(
 		s,
@@ -2360,6 +2374,7 @@ export function useUtilitiesPreset(
 			resolveUtilityOptions("accent-color"),
 		),
 		createAppearanceUtility,
+		createWebkitAppearanceUtility,
 		createCaretColorUtility: useCaretColorUtility(
 			s,
 			undefined,

--- a/theme/src/recipes/checkbox/index.ts
+++ b/theme/src/recipes/checkbox/index.ts
@@ -1,0 +1,3 @@
+export * from "./useCheckboxRecipe";
+export * from "./useCheckboxFieldRecipe";
+export * from "./useCheckboxGroupRecipe";

--- a/theme/src/recipes/checkbox/useCheckboxFieldRecipe.test.ts
+++ b/theme/src/recipes/checkbox/useCheckboxFieldRecipe.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from "vitest";
+import { styleframe } from "@styleframe/core";
+import { useDarkModifier } from "../../modifiers/useMediaPreferenceModifiers";
+import {
+	useCheckedModifier,
+	useDisabledModifier,
+	useIndeterminateModifier,
+} from "../../modifiers/useFormStateModifiers";
+import { useFocusVisibleModifier } from "../../modifiers/usePseudoStateModifiers";
+import { useDesignTokensPreset } from "../../presets/useDesignTokensPreset";
+import { useUtilitiesPreset } from "../../presets/useUtilitiesPreset";
+import { useModifiersPreset } from "../../presets/useModifiersPreset";
+import { useCheckboxFieldRecipe } from "./useCheckboxFieldRecipe";
+
+function createInstance() {
+	const s = styleframe();
+	for (const name of [
+		"appearance",
+		"WebkitAppearance",
+		"boxSizing",
+		"display",
+		"flexShrink",
+		"borderWidth",
+		"borderStyle",
+		"borderColor",
+		"borderRadius",
+		"backgroundColor",
+		"backgroundImage",
+		"backgroundRepeat",
+		"backgroundPosition",
+		"backgroundSize",
+		"cursor",
+		"transitionProperty",
+		"transitionDuration",
+		"transitionTimingFunction",
+		"width",
+		"height",
+		"opacity",
+		"outlineWidth",
+		"outlineStyle",
+		"outlineColor",
+		"outlineOffset",
+	]) {
+		s.utility(name, ({ value }) => ({ [name]: value }));
+	}
+	useDarkModifier(s);
+	useCheckedModifier(s);
+	useIndeterminateModifier(s);
+	useDisabledModifier(s);
+	useFocusVisibleModifier(s);
+	return s;
+}
+
+describe("useCheckboxFieldRecipe", () => {
+	it("should create a recipe with correct metadata", () => {
+		const s = createInstance();
+		const recipe = useCheckboxFieldRecipe(s);
+
+		expect(recipe.type).toBe("recipe");
+		expect(recipe.name).toBe("checkbox-field");
+	});
+
+	it("should build against the design-tokens, utilities, and modifiers presets", () => {
+		const s = styleframe();
+		useDesignTokensPreset(s);
+		useUtilitiesPreset(s);
+		useModifiersPreset(s);
+
+		// Reproduces the real init environment: every declared property must
+		// resolve to a registered utility (e.g. -webkit-appearance).
+		expect(() => useCheckboxFieldRecipe(s)).not.toThrow();
+	});
+
+	it("should have correct base styles", () => {
+		const s = createInstance();
+		const recipe = useCheckboxFieldRecipe(s);
+
+		expect(recipe.base).toMatchObject({
+			appearance: "none",
+			boxSizing: "border-box",
+			display: "inline-block",
+			borderWidth: "@border-width.thin",
+			borderStyle: "@border-style.solid",
+			cursor: "pointer",
+			backgroundRepeat: "no-repeat",
+			backgroundPosition: "center",
+			backgroundSize: "contain",
+		});
+	});
+
+	it("should fill the box with primary and paint an SVG mark when checked or indeterminate", () => {
+		const s = createInstance();
+		const recipe = useCheckboxFieldRecipe(s);
+
+		const checked = recipe.base?.["&:checked"] as Record<string, string>;
+		expect(checked).toMatchObject({
+			backgroundColor: "@color.primary",
+			borderColor: "@color.primary",
+		});
+		expect(checked.backgroundImage).toContain("data:image/svg+xml");
+		expect(checked.backgroundImage).toContain("M3.5 8.5l3 3 6-6");
+
+		const indeterminate = recipe.base?.["&:indeterminate"] as Record<
+			string,
+			string
+		>;
+		expect(indeterminate).toMatchObject({
+			backgroundColor: "@color.primary",
+			borderColor: "@color.primary",
+		});
+		expect(indeterminate.backgroundImage).toContain("M4 8h8");
+	});
+
+	it("should style focus-visible and disabled states", () => {
+		const s = createInstance();
+		const recipe = useCheckboxFieldRecipe(s);
+
+		expect(recipe.base?.["&:focus-visible"]).toMatchObject({
+			outlineColor: "@color.primary",
+		});
+		expect(recipe.base?.["&:disabled"]).toEqual({
+			opacity: "0.5",
+			cursor: "not-allowed",
+		});
+	});
+
+	describe("variants", () => {
+		it("should have all color variants", () => {
+			const s = createInstance();
+			const recipe = useCheckboxFieldRecipe(s);
+
+			expect(Object.keys(recipe.variants!.color)).toEqual([
+				"light",
+				"dark",
+				"neutral",
+			]);
+		});
+
+		it("should have size variants with correct styles", () => {
+			const s = createInstance();
+			const recipe = useCheckboxFieldRecipe(s);
+
+			expect(Object.keys(recipe.variants!.size)).toEqual(["sm", "md", "lg"]);
+			expect(recipe.variants!.size.md).toEqual({
+				width: "16px",
+				height: "16px",
+				borderRadius: "@border-radius.sm",
+			});
+		});
+	});
+
+	it("should have correct default variants", () => {
+		const s = createInstance();
+		const recipe = useCheckboxFieldRecipe(s);
+
+		expect(recipe.defaultVariants).toEqual({
+			color: "neutral",
+			size: "md",
+		});
+	});
+
+	describe("compound variants", () => {
+		it("should have 3 compound variants", () => {
+			const s = createInstance();
+			const recipe = useCheckboxFieldRecipe(s);
+
+			expect(recipe.compoundVariants).toHaveLength(3);
+		});
+
+		it("should set the neutral unchecked surface and re-assert the checked fill in dark mode", () => {
+			const s = createInstance();
+			const recipe = useCheckboxFieldRecipe(s);
+
+			const cv = recipe.compoundVariants!.find(
+				(v) => v.match.color === "neutral",
+			);
+			expect(cv?.css).toEqual({
+				backgroundColor: "@color.white",
+				borderColor: "@color.gray-300",
+				"&:dark": {
+					backgroundColor: "@color.gray-900",
+					borderColor: "@color.gray-600",
+				},
+				"&:dark:checked": {
+					backgroundColor: "@color.primary",
+					borderColor: "@color.primary",
+				},
+				"&:dark:indeterminate": {
+					backgroundColor: "@color.primary",
+					borderColor: "@color.primary",
+				},
+			});
+		});
+
+		it("should keep fixed light/dark surfaces free of dark overrides", () => {
+			const s = createInstance();
+			const recipe = useCheckboxFieldRecipe(s);
+
+			const light = recipe.compoundVariants!.find(
+				(v) => v.match.color === "light",
+			);
+			expect(light?.css).toEqual({
+				backgroundColor: "@color.white",
+				borderColor: "@color.gray-300",
+			});
+		});
+	});
+
+	describe("config overrides", () => {
+		it("should allow overriding base styles", () => {
+			const s = createInstance();
+			const recipe = useCheckboxFieldRecipe(s, {
+				base: { display: "block" },
+			});
+
+			expect(recipe.base?.display).toBe("block");
+		});
+	});
+
+	describe("filter", () => {
+		it("should filter color variants and prune compound variants", () => {
+			const s = createInstance();
+			const recipe = useCheckboxFieldRecipe(s, {
+				filter: { color: ["neutral"] },
+			});
+
+			expect(Object.keys(recipe.variants!.color)).toEqual(["neutral"]);
+			expect(recipe.compoundVariants).toHaveLength(1);
+		});
+
+		it("should adjust default variants when filtered out", () => {
+			const s = createInstance();
+			const recipe = useCheckboxFieldRecipe(s, {
+				filter: { color: ["light"] },
+			});
+
+			expect(recipe.defaultVariants?.color).toBeUndefined();
+		});
+	});
+});

--- a/theme/src/recipes/checkbox/useCheckboxFieldRecipe.ts
+++ b/theme/src/recipes/checkbox/useCheckboxFieldRecipe.ts
@@ -1,0 +1,134 @@
+import { createUseRecipe } from "../../utils/createUseRecipe";
+
+/**
+ * Checkbox field recipe — sits on the native `<input type="checkbox">`.
+ *
+ * Renders a custom box with no extra markup. The native element drives every
+ * state: `:checked` and `:indeterminate` fill the box with `@color.primary` and
+ * paint a white checkmark / dash as a `background-image` SVG, `:focus-visible`
+ * shows a focus ring, and `:disabled` dims it.
+ *
+ * The mark is an inline SVG `background-image` (the same technique the sanitize
+ * layer uses for the `<select>` arrow) rather than a rotated `::after` border —
+ * it stays crisp and centered at every size via `background-size: contain`.
+ *
+ * The `color` axis only controls the *unchecked* surface (background + border)
+ * and its dark-mode adaptation, mirroring the `input` recipe's
+ * `light` / `dark` / `neutral` colors. The adaptive `neutral` color re-asserts
+ * the checked fill under `&:dark` so it keeps winning against the
+ * attribute-based dark surface (`[data-theme="dark"]`), which would otherwise
+ * out-specify the base `&:checked` rule.
+ */
+const checkmarkImage =
+	"url(\"data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='white' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M3.5 8.5l3 3 6-6'/%3E%3C/svg%3E\")";
+
+const dashImage =
+	"url(\"data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='white' stroke-width='2' stroke-linecap='round'%3E%3Cpath d='M4 8h8'/%3E%3C/svg%3E\")";
+
+export const useCheckboxFieldRecipe = createUseRecipe("checkbox-field", {
+	base: {
+		appearance: "none",
+		WebkitAppearance: "none",
+		boxSizing: "border-box",
+		display: "inline-block",
+		flexShrink: "0",
+		borderWidth: "@border-width.thin",
+		borderStyle: "@border-style.solid",
+		cursor: "pointer",
+		backgroundRepeat: "no-repeat",
+		backgroundPosition: "center",
+		backgroundSize: "contain",
+		transitionProperty: "color, background-color, border-color",
+		transitionDuration: "150ms",
+		transitionTimingFunction: "@easing.ease-in-out",
+		"&:checked": {
+			backgroundColor: "@color.primary",
+			borderColor: "@color.primary",
+			backgroundImage: checkmarkImage,
+		},
+		"&:indeterminate": {
+			backgroundColor: "@color.primary",
+			borderColor: "@color.primary",
+			backgroundImage: dashImage,
+		},
+		"&:focus-visible": {
+			outlineWidth: "2px",
+			outlineStyle: "solid",
+			outlineColor: "@color.primary",
+			outlineOffset: "2px",
+		},
+		"&:disabled": {
+			opacity: "0.5",
+			cursor: "not-allowed",
+		},
+	},
+	variants: {
+		color: {
+			light: {},
+			dark: {},
+			neutral: {},
+		},
+		size: {
+			sm: {
+				width: "14px",
+				height: "14px",
+				borderRadius: "@border-radius.sm",
+			},
+			md: {
+				width: "16px",
+				height: "16px",
+				borderRadius: "@border-radius.sm",
+			},
+			lg: {
+				width: "20px",
+				height: "20px",
+				borderRadius: "@border-radius.md",
+			},
+		},
+	},
+	compoundVariants: [
+		// Light surface — fixed across themes. The base `&:checked` fill
+		// out-specifies this unchecked rule in every mode, so no dark override.
+		{
+			match: { color: "light" as const },
+			css: {
+				backgroundColor: "@color.white",
+				borderColor: "@color.gray-300",
+			},
+		},
+		// Dark surface — fixed across themes.
+		{
+			match: { color: "dark" as const },
+			css: {
+				backgroundColor: "@color.gray-900",
+				borderColor: "@color.gray-600",
+			},
+		},
+		// Neutral surface — adaptive. The `&:dark` unchecked rule gains
+		// attribute-selector specificity, so the checked fill is re-asserted
+		// under `&:dark:checked` / `&:dark:indeterminate` to keep winning.
+		{
+			match: { color: "neutral" as const },
+			css: {
+				backgroundColor: "@color.white",
+				borderColor: "@color.gray-300",
+				"&:dark": {
+					backgroundColor: "@color.gray-900",
+					borderColor: "@color.gray-600",
+				},
+				"&:dark:checked": {
+					backgroundColor: "@color.primary",
+					borderColor: "@color.primary",
+				},
+				"&:dark:indeterminate": {
+					backgroundColor: "@color.primary",
+					borderColor: "@color.primary",
+				},
+			},
+		},
+	],
+	defaultVariants: {
+		color: "neutral",
+		size: "md",
+	},
+});

--- a/theme/src/recipes/checkbox/useCheckboxGroupRecipe.test.ts
+++ b/theme/src/recipes/checkbox/useCheckboxGroupRecipe.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { styleframe } from "@styleframe/core";
+import { useDarkModifier } from "../../modifiers/useMediaPreferenceModifiers";
+import { useCheckboxGroupRecipe } from "./useCheckboxGroupRecipe";
+
+function createInstance() {
+	const s = styleframe();
+	for (const name of [
+		"display",
+		"flexDirection",
+		"flexWrap",
+		"alignItems",
+		"gap",
+	]) {
+		s.utility(name, ({ value }) => ({ [name]: value }));
+	}
+	useDarkModifier(s);
+	return s;
+}
+
+describe("useCheckboxGroupRecipe", () => {
+	it("should create a recipe with correct metadata", () => {
+		const s = createInstance();
+		const recipe = useCheckboxGroupRecipe(s);
+
+		expect(recipe.type).toBe("recipe");
+		expect(recipe.name).toBe("checkbox-group");
+	});
+
+	it("should have correct base styles", () => {
+		const s = createInstance();
+		const recipe = useCheckboxGroupRecipe(s);
+
+		expect(recipe.base).toEqual({ display: "flex" });
+	});
+
+	describe("variants", () => {
+		it("should have all orientation variants", () => {
+			const s = createInstance();
+			const recipe = useCheckboxGroupRecipe(s);
+
+			expect(Object.keys(recipe.variants!.orientation)).toEqual([
+				"vertical",
+				"horizontal",
+			]);
+			expect(recipe.variants!.orientation.vertical).toEqual({
+				flexDirection: "column",
+			});
+			expect(recipe.variants!.orientation.horizontal).toEqual({
+				flexDirection: "row",
+				flexWrap: "wrap",
+				alignItems: "center",
+			});
+		});
+
+		it("should have size variants with correct styles", () => {
+			const s = createInstance();
+			const recipe = useCheckboxGroupRecipe(s);
+
+			expect(Object.keys(recipe.variants!.size)).toEqual(["sm", "md", "lg"]);
+			expect(recipe.variants!.size.md).toEqual({ gap: "@0.75" });
+		});
+	});
+
+	it("should have correct default variants", () => {
+		const s = createInstance();
+		const recipe = useCheckboxGroupRecipe(s);
+
+		expect(recipe.defaultVariants).toEqual({
+			orientation: "vertical",
+			size: "md",
+		});
+	});
+
+	it("should not define compound variants", () => {
+		const s = createInstance();
+		const recipe = useCheckboxGroupRecipe(s);
+
+		expect(recipe.compoundVariants ?? []).toHaveLength(0);
+	});
+
+	describe("config overrides", () => {
+		it("should allow overriding base styles", () => {
+			const s = createInstance();
+			const recipe = useCheckboxGroupRecipe(s, {
+				base: { display: "block" },
+			});
+
+			expect(recipe.base?.display).toBe("block");
+		});
+	});
+
+	describe("filter", () => {
+		it("should filter orientation variants", () => {
+			const s = createInstance();
+			const recipe = useCheckboxGroupRecipe(s, {
+				filter: { orientation: ["horizontal"] },
+			});
+
+			expect(Object.keys(recipe.variants!.orientation)).toEqual(["horizontal"]);
+		});
+
+		it("should adjust default variants when filtered out", () => {
+			const s = createInstance();
+			const recipe = useCheckboxGroupRecipe(s, {
+				filter: { orientation: ["horizontal"] },
+			});
+
+			expect(recipe.defaultVariants?.orientation).toBeUndefined();
+		});
+	});
+});

--- a/theme/src/recipes/checkbox/useCheckboxGroupRecipe.ts
+++ b/theme/src/recipes/checkbox/useCheckboxGroupRecipe.ts
@@ -1,0 +1,39 @@
+import { createUseRecipe } from "../../utils/createUseRecipe";
+
+/**
+ * Checkbox group recipe — a flex container that lays out multiple `.checkbox`
+ * rows. Supports orientation (vertical / horizontal) and a size axis that
+ * controls the gap between items.
+ */
+export const useCheckboxGroupRecipe = createUseRecipe("checkbox-group", {
+	base: {
+		display: "flex",
+	},
+	variants: {
+		orientation: {
+			vertical: {
+				flexDirection: "column",
+			},
+			horizontal: {
+				flexDirection: "row",
+				flexWrap: "wrap",
+				alignItems: "center",
+			},
+		},
+		size: {
+			sm: {
+				gap: "@0.5",
+			},
+			md: {
+				gap: "@0.75",
+			},
+			lg: {
+				gap: "@1",
+			},
+		},
+	},
+	defaultVariants: {
+		orientation: "vertical",
+		size: "md",
+	},
+});

--- a/theme/src/recipes/checkbox/useCheckboxRecipe.test.ts
+++ b/theme/src/recipes/checkbox/useCheckboxRecipe.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { styleframe } from "@styleframe/core";
+import { useDarkModifier } from "../../modifiers/useMediaPreferenceModifiers";
+import { useCheckboxRecipe } from "./useCheckboxRecipe";
+
+function createInstance() {
+	const s = styleframe();
+	for (const name of [
+		"display",
+		"alignItems",
+		"cursor",
+		"userSelect",
+		"color",
+		"lineHeight",
+		"opacity",
+		"gap",
+		"fontSize",
+	]) {
+		s.utility(name, ({ value }) => ({ [name]: value }));
+	}
+	useDarkModifier(s);
+	return s;
+}
+
+describe("useCheckboxRecipe", () => {
+	it("should create a recipe with correct metadata", () => {
+		const s = createInstance();
+		const recipe = useCheckboxRecipe(s);
+
+		expect(recipe.type).toBe("recipe");
+		expect(recipe.name).toBe("checkbox");
+	});
+
+	it("should have correct base styles", () => {
+		const s = createInstance();
+		const recipe = useCheckboxRecipe(s);
+
+		expect(recipe.base).toMatchObject({
+			display: "inline-flex",
+			alignItems: "center",
+			cursor: "pointer",
+			userSelect: "none",
+			color: "@color.text",
+		});
+	});
+
+	describe("variants", () => {
+		it("should have size variants with correct styles", () => {
+			const s = createInstance();
+			const recipe = useCheckboxRecipe(s);
+
+			expect(Object.keys(recipe.variants!.size)).toEqual(["sm", "md", "lg"]);
+			expect(recipe.variants!.size.md).toEqual({
+				gap: "@0.5",
+				fontSize: "@font-size.sm",
+			});
+		});
+	});
+
+	it("should have correct default variants", () => {
+		const s = createInstance();
+		const recipe = useCheckboxRecipe(s);
+
+		expect(recipe.defaultVariants).toEqual({ size: "md" });
+	});
+
+	it("should not define compound variants", () => {
+		const s = createInstance();
+		const recipe = useCheckboxRecipe(s);
+
+		expect(recipe.compoundVariants ?? []).toHaveLength(0);
+	});
+
+	describe("config overrides", () => {
+		it("should allow overriding base styles", () => {
+			const s = createInstance();
+			const recipe = useCheckboxRecipe(s, {
+				base: { display: "flex" },
+			});
+
+			expect(recipe.base?.display).toBe("flex");
+		});
+	});
+
+	describe("filter", () => {
+		it("should filter size variants", () => {
+			const s = createInstance();
+			const recipe = useCheckboxRecipe(s, {
+				filter: { size: ["md"] },
+			});
+
+			expect(Object.keys(recipe.variants!.size)).toEqual(["md"]);
+		});
+
+		it("should adjust default variants when filtered out", () => {
+			const s = createInstance();
+			const recipe = useCheckboxRecipe(s, {
+				filter: { size: ["sm"] },
+			});
+
+			expect(recipe.defaultVariants?.size).toBeUndefined();
+		});
+	});
+});

--- a/theme/src/recipes/checkbox/useCheckboxRecipe.ts
+++ b/theme/src/recipes/checkbox/useCheckboxRecipe.ts
@@ -1,0 +1,52 @@
+import { createUseRecipe } from "../../utils/createUseRecipe";
+
+/**
+ * Checkbox wrapper recipe — sits on the `<label>` that wraps a
+ * `<input class="checkbox-field">` and its text. Owns the inline layout
+ * (gap, alignment), label typography, and dims the label when the nested
+ * field is disabled. The visual box lives on `checkbox-field`.
+ *
+ * The disabled-label dimming uses `:has()`, which is a raw CSS selector rather
+ * than a registered modifier, so it is declared via the `setup` callback.
+ */
+export const useCheckboxRecipe = createUseRecipe(
+	"checkbox",
+	{
+		base: {
+			display: "inline-flex",
+			alignItems: "center",
+			cursor: "pointer",
+			userSelect: "none",
+			color: "@color.text",
+			lineHeight: "@line-height.normal",
+		},
+		variants: {
+			size: {
+				sm: {
+					gap: "@0.375",
+					fontSize: "@font-size.xs",
+				},
+				md: {
+					gap: "@0.5",
+					fontSize: "@font-size.sm",
+				},
+				lg: {
+					gap: "@0.625",
+					fontSize: "@font-size.md",
+				},
+			},
+		},
+		defaultVariants: {
+			size: "md",
+		},
+	},
+	(s) => {
+		const { selector } = s;
+
+		// Dim the label when the nested field is disabled.
+		selector(".checkbox:has(.checkbox-field:disabled)", {
+			opacity: "0.5",
+			cursor: "not-allowed",
+		});
+	},
+);

--- a/theme/src/recipes/index.ts
+++ b/theme/src/recipes/index.ts
@@ -5,6 +5,7 @@ export * from "./button-group";
 export * from "./callout";
 export * from "./card";
 export * from "./chat-message";
+export * from "./checkbox";
 export * from "./chip";
 export * from "./dropdown";
 export * from "./hamburger-menu";

--- a/theme/src/utilities/interactivity/useInteractivityUtility.test.ts
+++ b/theme/src/utilities/interactivity/useInteractivityUtility.test.ts
@@ -4,6 +4,7 @@ import { consumeCSS } from "@styleframe/transpiler";
 import {
 	useAccentColorUtility,
 	useAppearanceUtility,
+	useWebkitAppearanceUtility,
 	useCaretColorUtility,
 	useColorSchemeUtility,
 	useCursorUtility,
@@ -103,6 +104,51 @@ describe("useAppearanceUtility", () => {
 	it("should handle empty values object", () => {
 		const s = styleframe();
 		useAppearanceUtility(s, {});
+
+		expect(s.root.children).toHaveLength(0);
+	});
+});
+
+describe("useWebkitAppearanceUtility", () => {
+	it("should create utility instances with provided values", () => {
+		const s = styleframe();
+		useWebkitAppearanceUtility(s, { none: "none", auto: "auto" });
+
+		const utilities = s.root.children.filter(
+			(u): u is Utility => isUtility(u) && u.name === "-webkit-appearance",
+		);
+		expect(utilities).toHaveLength(2);
+	});
+
+	it("should set correct declarations", () => {
+		const s = styleframe();
+		useWebkitAppearanceUtility(s, { none: "none" });
+
+		const utility = s.root.children[0] as Utility;
+		expect(utility.declarations).toEqual({ "-webkit-appearance": "none" });
+	});
+
+	it("should compile to correct CSS output", () => {
+		const s = styleframe();
+		useWebkitAppearanceUtility(s, { none: "none" });
+
+		const css = consumeCSS(s.root, s.options);
+		expect(css).toContain("-webkit-appearance: none;");
+	});
+
+	it("should use default values when called without arguments", () => {
+		const s = styleframe();
+		useWebkitAppearanceUtility(s);
+
+		const utilities = s.root.children.filter(
+			(u): u is Utility => isUtility(u) && u.name === "-webkit-appearance",
+		);
+		expect(utilities).toHaveLength(Object.keys(appearanceValues).length);
+	});
+
+	it("should handle empty values object", () => {
+		const s = styleframe();
+		useWebkitAppearanceUtility(s, {});
 
 		expect(s.root.children).toHaveLength(0);
 	});

--- a/theme/src/utilities/interactivity/useInteractivityUtility.ts
+++ b/theme/src/utilities/interactivity/useInteractivityUtility.ts
@@ -34,6 +34,24 @@ export const useAppearanceUtility = createUseUtility(
 );
 
 /**
+ * Create -webkit-appearance utility classes.
+ *
+ * The vendor-prefixed counterpart to `appearance`, used to reset native form
+ * control styling in Safari < 15.4. Shares the `appearanceValues` defaults.
+ *
+ * The declaration uses the explicit `-webkit-appearance` key (not the
+ * `WebkitAppearance` camelCase form) because the camelCase-to-kebab transform
+ * drops the leading dash, which would emit the invalid `webkit-appearance`.
+ */
+export const useWebkitAppearanceUtility = createUseUtility(
+	"-webkit-appearance",
+	({ value }) => ({
+		"-webkit-appearance": value,
+	}),
+	{ defaults: appearanceValues },
+);
+
+/**
  * Create caret-color utility classes.
  */
 export const useCaretColorUtility = createUseUtility(


### PR DESCRIPTION
## Summary

- Adds `useCheckboxRecipe`, `useCheckboxFieldRecipe`, and `useCheckboxGroupRecipe` to `@styleframe/theme` — Inkline-style form controls built on the native `<input type="checkbox">` with SVG checkmark/dash marks, native pseudo-class states (`:checked`, `:indeterminate`, `:disabled`, `:focus-visible`), `light`/`dark`/`neutral` surface colors, and `sm`/`md`/`lg` sizes.
- Adds `useWebkitAppearanceUtility` (`-webkit-appearance`) to the utilities preset so recipes can reset native checkbox rendering on legacy Safari.
- Adds Storybook showcase (`Theme/Recipes/Forms/Checkbox` + `Checkbox Group`) with preview grids and per-state/size stories.
- Adds docs pages at `05.components/05.forms/01.checkbox.md` and `02.checkbox-group.md`.
- Includes a `minor` changeset for `@styleframe/theme` and `styleframe`.

## Test plan

- [ ] `pnpm --filter @styleframe/theme test` — 31 new checkbox tests + full suite passes (2628 total)
- [ ] `pnpm typecheck` — clean across all 15 packages
- [ ] Storybook: **Theme/Recipes/Forms/Checkbox** — verify checked (teal box + white tick), indeterminate (dash), disabled (dimmed), all colors, all sizes
- [ ] Storybook: **Theme/Recipes/Forms/Checkbox Group** — verify vertical/horizontal orientations