### PR TITLE
feat(theme): add Radio, RadioField, and RadioGroup recipes

### DIFF
--- a/.changeset/radio-recipe.md
+++ b/.changeset/radio-recipe.md
@@ -1,0 +1,8 @@
+---
+"@styleframe/theme": minor
+"styleframe": minor
+---
+
+Add Radio, RadioField, and RadioGroup recipes.
+
+Adds three form-control recipes built on the native `<input type="radio">`. The `useRadioFieldRecipe()` composable styles the radio indicator with `appearance: none` and a filled inner circle driven by a `background-image`; `:checked`, `:disabled`, and `:focus-visible` states are driven by native pseudo-classes. The `useRadioRecipe()` composable wraps the label, and `useRadioGroupRecipe()` lays out a set with `vertical` / `horizontal` orientation. All three support `light`, `dark`, and `neutral` surface colors and `sm` / `md` / `lg` sizes.

--- a/apps/docs/content/docs/05.components/05.forms/03.radio.md
+++ b/apps/docs/content/docs/05.components/05.forms/03.radio.md
@@ -1,0 +1,410 @@
+---
+title: Radio
+description: A custom radio built on the native input, with a CSS dot indicator, checked, disabled, and focus states, light, dark, and neutral surface colors, and three sizes through the recipe system.
+navigation:
+    icon: false
+---
+
+## Overview
+
+The **Radio** is a form control that lets users select a single option from a set. It is composed of two recipe parts:
+
+- **`useRadioRecipe()`** &mdash; the label wrapper that owns the inline layout (gap, alignment), label typography, and dims itself when the field is disabled.
+- **`useRadioFieldRecipe()`** &mdash; the native styled input, a white SVG dot painted as a background image, and the checked, focus, and disabled states.
+
+The field is the real native input, so every state is driven by the browser: `:checked` fills the circle with `@color.primary`, `:focus-visible` shows a focus ring, and `:disabled` dims it. The `color` axis sets the *unchecked* surface (`light`, `dark`, `neutral`) and the checked fill stays `@color.primary` across all three.
+
+Radios become mutually exclusive when they share a `name` attribute &mdash; the browser then allows only one selection per group and wires up arrow-key navigation. The recipe is purely presentational; grouping is native.
+
+The Radio recipes integrate directly with the default [design tokens preset](/docs/theme/design-tokens/presets) and generate type-safe utility classes at build time with zero runtime CSS.
+
+To lay several radios out as a set, see the [Radio Group](/docs/components/forms/radio-group) recipe.
+
+## Why use the Radio recipe?
+
+The Radio recipe helps you:
+
+- **Ship faster with sensible defaults**: Get 3 surface colors and 3 sizes out of the box with a single set of composable calls.
+- **Build on the native input**: States ride on native pseudo-classes (`:checked`, `:disabled`, `:focus-visible`), so the control stays keyboard-accessible and form-associated with zero runtime JavaScript.
+- **Maintain consistency**: The checked fill, dot, focus ring, and dark-mode surfaces follow the same design rules everywhere.
+- **Customize without forking**: Override base styles, default variants, or filter out options you don't need &mdash; all through the options API.
+- **Stay type-safe**: Full TypeScript support means your editor catches invalid color or size values at compile time.
+- **Integrate with your tokens**: Every value references the design tokens preset, so theme changes propagate automatically.
+
+## Usage
+
+::steps{level="4"}
+
+#### Register the recipes
+
+Add the Radio recipes to a local Styleframe instance. The global `styleframe.config.ts` provides design tokens and utilities, while the component-level file registers the recipes themselves:
+
+:::code-tree{default-value="src/components/radio.styleframe.ts"}
+
+```ts [src/components/radio.styleframe.ts]
+import { styleframe } from 'virtual:styleframe';
+import { useRadioRecipe, useRadioFieldRecipe } from '@styleframe/theme';
+
+const s = styleframe();
+
+const radio = useRadioRecipe(s);
+const radioField = useRadioFieldRecipe(s);
+
+export default s;
+```
+
+```ts [styleframe.config.ts]
+import { styleframe } from 'styleframe';
+import { useDesignTokensPreset, useUtilitiesPreset } from '@styleframe/theme';
+
+const s = styleframe();
+
+useDesignTokensPreset(s);
+useUtilitiesPreset(s);
+
+export default s;
+```
+
+:::
+
+#### Build the component
+
+Put the `radio` wrapper on the `<label>` and the `radioField` circle on the native `<input type="radio">`. Give every radio in the same set the same `name` so the browser keeps the selection mutually exclusive:
+
+::framework-switcher
+
+#vue
+
+```vue [src/components/Radio.vue]
+<script setup lang="ts">
+import { radio, radioField } from "virtual:styleframe";
+
+const {
+	color = "neutral",
+	size = "md",
+	checked = false,
+	disabled = false,
+	name,
+	label,
+} = defineProps<{
+	color?: "light" | "dark" | "neutral";
+	size?: "sm" | "md" | "lg";
+	checked?: boolean;
+	disabled?: boolean;
+	name?: string;
+	label?: string;
+}>();
+</script>
+
+<template>
+	<label :class="radio({ size })">
+		<input
+			type="radio"
+			:class="radioField({ color, size })"
+			:name="name"
+			:checked="checked"
+			:disabled="disabled"
+		/>
+		<span>{{ label }}</span>
+	</label>
+</template>
+```
+
+#react
+
+```ts [src/components/Radio.tsx]
+import { radio, radioField } from "virtual:styleframe";
+
+interface RadioProps {
+	color?: "light" | "dark" | "neutral";
+	size?: "sm" | "md" | "lg";
+	checked?: boolean;
+	disabled?: boolean;
+	name?: string;
+	label?: string;
+}
+
+export function Radio({
+	color = "neutral",
+	size = "md",
+	checked = false,
+	disabled = false,
+	name,
+	label,
+}: RadioProps) {
+	return (
+		<label className={radio({ size })}>
+			<input
+				type="radio"
+				className={radioField({ color, size })}
+				name={name}
+				checked={checked}
+				disabled={disabled}
+				readOnly
+			/>
+			<span>{label}</span>
+		</label>
+	);
+}
+```
+
+#other
+
+The `radio()` and `radioField()` runtimes each return a class string. Apply them however your framework binds classes:
+
+```ts [src/components/radio.ts]
+import { radio, radioField } from "virtual:styleframe";
+
+const wrapperClasses = radio({ size: "md" });
+// → "radio _display:inline-flex _align-items:center ..."
+
+const fieldClasses = radioField({ color: "neutral", size: "md" });
+// → "radio-field _appearance:none _border-width:thin ..."
+```
+
+```html [src/components/radio.html]
+<label class="radio _display:inline-flex _align-items:center ...">
+	<input type="radio" name="plan" class="radio-field _appearance:none ..." />
+	<span>Free plan</span>
+</label>
+```
+
+::
+
+#### See it in action
+
+:::story-preview
+---
+story: theme-recipes-forms-radio--default
+panel: true
+---
+:::
+
+::
+
+## Colors
+
+The Radio field includes 3 color variants: `light`, `dark`, and `neutral`. Like the [Input](/docs/components/forms/input) and Card recipes, these are neutral-spectrum surface colors rather than status colors &mdash; the color sets the *unchecked* circle background and border, while the checked fill is always `@color.primary`.
+
+The `neutral` color adapts automatically: a light surface in light mode and a dark surface in dark mode, making it the safest default for general-purpose forms.
+
+::story-preview
+---
+story: theme-recipes-forms-radio--neutral
+panel: true
+---
+::
+
+### Color Reference
+
+::story-preview
+---
+story: theme-recipes-forms-radio--all-states
+height: 360
+---
+::
+
+| Color | Token | Use Case |
+|-------|-------|----------|
+| `light` | `@color.white` / `@color.gray-300` | Light surfaces, stays light in dark mode |
+| `dark` | `@color.gray-900` / `@color.gray-600` | Dark surfaces, stays dark in light mode |
+| `neutral` | Adaptive (light &harr; dark) | Default color, adapts to the current color scheme |
+
+::tip
+**Pro tip:** Use `neutral` as your default radio color. It adapts to the user's color scheme automatically, so you don't need to manage light and dark surfaces separately.
+::
+
+## Sizes
+
+Three size variants from `sm` to `lg` control the circle dimensions. The dot is a white SVG `background-image` sized with `background-size: contain`, so it stays crisp and scales with the circle. Every size uses a fully rounded border radius (`@border-radius.full`) so the control renders as a circle.
+
+::story-preview
+---
+story: theme-recipes-forms-radio--all-sizes
+height: 320
+---
+::
+
+### Size Reference
+
+| Size | Circle Size | Border Radius |
+|------|-------------|---------------|
+| `sm` | `14px` | `@border-radius.full` |
+| `md` | `16px` | `@border-radius.full` |
+| `lg` | `20px` | `@border-radius.full` |
+
+::note
+**Good to know:** Pass the same `size` to the `radio` wrapper and the `radioField` circle so the label typography, gap, and circle scale together.
+::
+
+## States
+
+The field's states ride on native pseudo-classes, so they reflect the real `<input>` without extra wiring.
+
+### Checked
+
+`:checked` fills the circle with `@color.primary` and reveals the white SVG dot. Bind the native `checked` attribute (or `v-model` / controlled value) as usual, and give radios in the same set a shared `name` so only one stays selected.
+
+::story-preview
+---
+story: theme-recipes-forms-radio--checked
+panel: true
+---
+::
+
+### Disabled
+
+`:disabled` dims the circle to `0.5` opacity and switches the cursor to `not-allowed`; the wrapper dims its label to match via `:has()`. Mirror it with the native `disabled` attribute so the input is also removed from the tab order.
+
+::story-preview
+---
+story: theme-recipes-forms-radio--disabled
+panel: true
+---
+::
+
+## Anatomy
+
+The Radio is composed of two independent recipes: a label wrapper and the native input circle.
+
+| Part | Recipe | Role |
+|------|--------|------|
+| **Wrapper** | `useRadioRecipe()` | The `.radio` `<label>` &mdash; owns inline layout (gap, alignment), label typography, and disabled-label dimming |
+| **Field** | `useRadioFieldRecipe()` | The `.radio-field` native `<input type="radio">` &mdash; owns the circle, dot, color surface, and checked / disabled / focus states |
+
+```html
+<label class="radio(...)">
+	<input type="radio" name="plan" class="radioField(...)" />
+	<span>Free plan</span>
+</label>
+```
+
+The wrapper dims its own label when it contains a disabled field, using `:has(.radio-field:disabled)`, so a disabled radio and its text fade together without extra props.
+
+## Accessibility
+
+- **Label every radio.** Wrap the input and its text in the `<label>` (as the wrapper does) or associate a separate `<label for="...">`. The recipe styles the control but does not provide a name.
+- **Group with a shared `name`.** Radios that share a `name` form one group: the browser enforces single selection and moves focus between them with the arrow keys. Without a shared name, each radio toggles on its own.
+- **Keep the native input.** Styling the real `<input type="radio">` with `appearance: none` preserves keyboard operation (arrow keys move within the group, Space selects), focus order, and form submission for free.
+- **Mirror `disabled` on the input.** Set the real `disabled` attribute in addition to the recipe state so the field leaves the tab order.
+- **Don't rely on color alone.** The selected state is conveyed by the dot, not just the fill color, satisfying [WCAG 1.4.1](https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html). Keep the adjacent label text descriptive.
+- **Verify contrast.** The dot is `@color.white` on a `@color.primary` fill. Default tokens meet WCAG AA; if you override the primary color, verify with the [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/).
+
+## Customization
+
+### Overriding Defaults
+
+Each radio composable accepts an optional second argument to override any part of the recipe configuration. Overrides are deep-merged with the defaults, so you only need to specify the properties you want to change:
+
+```ts [src/components/radio.styleframe.ts]
+import { styleframe } from 'virtual:styleframe';
+import { useRadioFieldRecipe } from '@styleframe/theme';
+
+const s = styleframe();
+
+const radioField = useRadioFieldRecipe(s, {
+    base: {
+        borderWidth: '@border-width.medium',
+    },
+    defaultVariants: {
+        color: 'neutral',
+        size: 'lg',
+    },
+});
+
+export default s;
+```
+
+### Filtering Variants
+
+If you only need a subset of the available variants, use the `filter` option to limit which values are generated. This reduces the output CSS and keeps your component API focused:
+
+```ts [src/components/radio.styleframe.ts]
+import { styleframe } from 'virtual:styleframe';
+import { useRadioFieldRecipe } from '@styleframe/theme';
+
+const s = styleframe();
+
+// Only generate the neutral color
+const radioField = useRadioFieldRecipe(s, {
+    filter: {
+        color: ['neutral'],
+    },
+});
+
+export default s;
+```
+
+::note
+**Good to know:** Filtering also removes compound variants and adjusts default variants that reference filtered-out values, so your recipe stays consistent.
+::
+
+## API Reference
+
+### `useRadioRecipe(s, options?)`
+
+Creates the radio wrapper recipe &mdash; the `.radio` `<label>` that lays out the circle and label and dims the label when the nested field is disabled.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `s` | `Styleframe` | The Styleframe instance |
+| `options` | `DeepPartial<RecipeConfig>` | Optional overrides for the recipe configuration |
+| `options.base` | `VariantDeclarationsBlock` | Custom base styles for the wrapper |
+| `options.variants` | `Variants` | Custom variant definitions for the recipe |
+| `options.defaultVariants` | `Record<keyof Variants, string>` | Default variant values for the recipe |
+| `options.filter` | `Record<string, string[]>` | Limit which variant values are generated |
+
+**Variants:**
+
+| Variant | Options | Default |
+|---------|---------|---------|
+| `size` | `sm`, `md`, `lg` | `md` |
+
+### `useRadioFieldRecipe(s, options?)`
+
+Creates the radio field recipe &mdash; the `.radio-field` native `<input type="radio">` that owns the circle, SVG dot, surface color, and native states. Accepts the same parameters as `useRadioRecipe`.
+
+**Variants:**
+
+| Variant | Options | Default |
+|---------|---------|---------|
+| `color` | `light`, `dark`, `neutral` | `neutral` |
+| `size` | `sm`, `md`, `lg` | `md` |
+
+[Learn more about recipes &rarr;](/docs/api/recipes)
+
+## Best Practices
+
+- **Pass `size` to both parts**: Spread the same `size` to the wrapper and the field so the label and circle scale together.
+- **Use `neutral` for general forms**: The neutral color adapts to light and dark mode automatically, making it the safest default.
+- **Give grouped radios a shared `name`**: Radios only become mutually exclusive when they share a `name` attribute &mdash; set it on every option in a set.
+- **Group related radios**: Use the [Radio Group](/docs/components/forms/radio-group) recipe to lay out a set with consistent spacing.
+- **Filter what you don't need**: If your forms use only the neutral color, pass a `filter` option to reduce generated CSS.
+
+## FAQ
+
+::accordion
+
+:::accordion-item{label="Why style the native input instead of a custom element?" icon="i-lucide-circle-help"}
+Applying the recipe to the real `<input type="radio">` with `appearance: none` keeps the control fully native: arrow keys move between options in the group, Space selects, it participates in form submission, and `:checked` / `:disabled` / `:focus-visible` drive the styling with zero runtime JavaScript. A custom `<div>` would need ARIA roles and keyboard handlers to match.
+:::
+
+:::accordion-item{label="How do I make a set of radios mutually exclusive?" icon="i-lucide-circle-help"}
+Give every radio in the set the same `name` attribute. The browser then allows only one selection per `name` and wires up arrow-key navigation between them. The recipe is presentational &mdash; grouping is the native `name`, not a recipe option.
+:::
+
+:::accordion-item{label="Why is the color light/dark/neutral instead of primary/success/error?" icon="i-lucide-circle-help"}
+The `color` axis controls the *unchecked* circle surface, which reflects the form's surface rather than a status. The checked fill is always `@color.primary`, the conventional accent for a selected control. This mirrors the [Input](/docs/components/forms/input) recipe's color model.
+:::
+
+:::accordion-item{label="How does the checked fill stay correct in dark mode?" icon="i-lucide-circle-help"}
+The `neutral` color sets a dark unchecked surface under `&:dark`, which gains attribute-selector specificity when you toggle a `[data-theme="dark"]` theme. To keep the checked circle `@color.primary` in that case, the recipe re-asserts the fill under `&:dark:checked`, so the accent always wins over the dark surface.
+:::
+
+:::accordion-item{label="How does filtering affect the recipe?" icon="i-lucide-circle-help"}
+When you use the `filter` option, compound variants that reference filtered-out colors are automatically removed, and default variants are adjusted if they reference a removed value &mdash; so the recipe stays consistent and only emits the CSS you use.
+:::
+
+::

--- a/apps/docs/content/docs/05.components/05.forms/04.radio-group.md
+++ b/apps/docs/content/docs/05.components/05.forms/04.radio-group.md
@@ -1,0 +1,308 @@
+---
+title: Radio Group
+description: A layout component for arranging a set of radios with shared orientation and spacing. Supports vertical and horizontal layouts and three gap sizes through the recipe system.
+navigation:
+    icon: false
+---
+
+## Overview
+
+The **Radio Group** is a layout component that arranges related [radios](/docs/components/forms/radio) into a single, consistently spaced set. The `useRadioGroupRecipe()` composable creates a fully configured [recipe](/docs/api/recipes) with orientation and size options &mdash; a flex container that stacks radios vertically or lays them out in a wrapping row.
+
+The group handles layout only. Single selection comes from the native input: give every child radio the same `name`, and the browser enforces one choice per group and wires up arrow-key navigation. Mark the container with `role="radiogroup"` (or use a `<fieldset>`) so assistive technology announces the set.
+
+The Radio Group recipe integrates directly with the [Radio recipe](/docs/components/forms/radio) and generates type-safe utility classes at build time with zero runtime CSS.
+
+## Why use the Radio Group recipe?
+
+The Radio Group recipe helps you:
+
+- **Lay out sets consistently**: Stack radios vertically or wrap them in a row with a single orientation prop.
+- **Control spacing with one axis**: The size variant sets the gap between items, so a whole group scales together.
+- **Compose, don't couple**: The group only handles layout; each child radio keeps its own color, size, and state.
+- **Stay type-safe**: Full TypeScript support means your editor catches invalid orientation or size values at compile time.
+
+## Usage
+
+::steps{level="4"}
+
+#### Register the recipe
+
+Add the Radio Group recipe to a local Styleframe instance alongside the radio recipes. The global `styleframe.config.ts` provides design tokens and utilities, while the component-level file registers the recipes themselves:
+
+:::code-tree{default-value="src/components/radio-group.styleframe.ts"}
+
+```ts [src/components/radio-group.styleframe.ts]
+import { styleframe } from 'virtual:styleframe';
+import {
+    useRadioRecipe,
+    useRadioFieldRecipe,
+    useRadioGroupRecipe,
+} from '@styleframe/theme';
+
+const s = styleframe();
+
+const radio = useRadioRecipe(s);
+const radioField = useRadioFieldRecipe(s);
+const radioGroup = useRadioGroupRecipe(s);
+
+export default s;
+```
+
+```ts [styleframe.config.ts]
+import { styleframe } from 'styleframe';
+import { useDesignTokensPreset, useUtilitiesPreset } from '@styleframe/theme';
+
+const s = styleframe();
+
+useDesignTokensPreset(s);
+useUtilitiesPreset(s);
+
+export default s;
+```
+
+:::
+
+#### Build the component
+
+Import the `radioGroup` runtime function from the virtual module and wrap your radios in the container. Mark it with `role="radiogroup"` and give every child radio the same `name`:
+
+::framework-switcher
+
+#vue
+
+```vue [src/components/RadioGroup.vue]
+<script setup lang="ts">
+import { radioGroup } from "virtual:styleframe";
+
+const { orientation = "vertical", size = "md" } = defineProps<{
+	orientation?: "vertical" | "horizontal";
+	size?: "sm" | "md" | "lg";
+}>();
+</script>
+
+<template>
+	<div :class="radioGroup({ orientation, size })" role="radiogroup">
+		<slot />
+	</div>
+</template>
+```
+
+#react
+
+```ts [src/components/RadioGroup.tsx]
+import { radioGroup } from "virtual:styleframe";
+
+interface RadioGroupProps {
+	orientation?: "vertical" | "horizontal";
+	size?: "sm" | "md" | "lg";
+	children?: React.ReactNode;
+}
+
+export function RadioGroup({
+	orientation = "vertical",
+	size = "md",
+	children,
+}: RadioGroupProps) {
+	const classes = radioGroup({ orientation, size });
+
+	return (
+		<div className={classes} role="radiogroup">
+			{children}
+		</div>
+	);
+}
+```
+
+#other
+
+The `radioGroup()` runtime returns a class string. Apply it however your framework binds classes:
+
+```ts [src/components/radio-group.ts]
+import { radioGroup } from "virtual:styleframe";
+
+const classes = radioGroup({ orientation: "vertical", size: "md" });
+// → "radio-group _display:flex _flex-direction:column _gap:0.75 ..."
+```
+
+```html [src/components/radio-group.html]
+<div class="radio-group _display:flex _flex-direction:column ..." role="radiogroup">
+	<label class="radio ..."><input type="radio" name="plan" class="radio-field ..." /><span>Free</span></label>
+	<label class="radio ..."><input type="radio" name="plan" class="radio-field ..." /><span>Pro</span></label>
+</div>
+```
+
+::
+
+#### See it in action
+
+:::story-preview
+---
+story: theme-recipes-forms-radio-group--default
+panel: true
+---
+:::
+
+::
+
+## Orientation
+
+The Radio Group supports two orientation variants that control the layout direction.
+
+### Vertical
+
+The default orientation. Radios are stacked top-to-bottom in a column &mdash; the most common layout for option lists.
+
+::story-preview
+---
+story: theme-recipes-forms-radio-group--vertical
+panel: true
+---
+::
+
+### Horizontal
+
+Radios are laid out left-to-right in a wrapping row, aligned to the center. Useful for short option sets that fit inline.
+
+::story-preview
+---
+story: theme-recipes-forms-radio-group--horizontal
+panel: true
+---
+::
+
+### Orientation Reference
+
+::story-preview
+---
+story: theme-recipes-forms-radio-group--all-orientations
+---
+::
+
+| Orientation | Direction | Notes |
+|-------------|-----------|-------|
+| `vertical` | Top to bottom (`column`) | Default; one option per line |
+| `horizontal` | Left to right (`row`, wraps) | Center-aligned, wraps to the next line when out of space |
+
+## Sizes
+
+Three size variants control the gap between radios, letting you tighten or loosen a group to match its surroundings. Set the same `size` on each child radio so the controls and the spacing scale together.
+
+| Size | Gap |
+|------|-----|
+| `sm` | `@0.5` |
+| `md` | `@0.75` |
+| `lg` | `@1` |
+
+::note
+**Good to know:** The group's `size` controls only the gap between items. Pass the same `size` to each child `<Radio>` so the circles and the spacing scale as a set.
+::
+
+## Accessibility
+
+- **Mark the group.** Wrap the radios in an element with `role="radiogroup"` and an `aria-label` (or `aria-labelledby`) describing the set, so assistive technology announces the context.
+- **Share a `name` across children.** Single selection and arrow-key navigation come from giving every child radio the same `name`. The group recipe only handles layout.
+- **Prefer a fieldset for forms.** When the group is part of a form, a native `<fieldset>` with a `<legend>` is the most robust grouping &mdash; apply the recipe class to the fieldset.
+- **Keep each radio labelled.** The group provides layout only; every child still needs its own label (see the [Radio](/docs/components/forms/radio) recipe).
+
+## Customization
+
+### Overriding Defaults
+
+The `useRadioGroupRecipe()` composable accepts an optional second argument to override any part of the recipe configuration. Overrides are deep-merged with the defaults, so you only need to specify the properties you want to change:
+
+```ts [src/components/radio-group.styleframe.ts]
+import { styleframe } from 'virtual:styleframe';
+import { useRadioGroupRecipe } from '@styleframe/theme';
+
+const s = styleframe();
+
+const radioGroup = useRadioGroupRecipe(s, {
+    defaultVariants: {
+        orientation: 'horizontal',
+        size: 'lg',
+    },
+});
+
+export default s;
+```
+
+### Filtering Variants
+
+If you only need a subset of the available variants, use the `filter` option to limit which values are generated. This reduces the output CSS and keeps your component API focused:
+
+```ts [src/components/radio-group.styleframe.ts]
+import { styleframe } from 'virtual:styleframe';
+import { useRadioGroupRecipe } from '@styleframe/theme';
+
+const s = styleframe();
+
+// Only generate the vertical orientation
+const radioGroup = useRadioGroupRecipe(s, {
+    filter: {
+        orientation: ['vertical'],
+    },
+});
+
+export default s;
+```
+
+::note
+**Good to know:** Filtering also removes compound variants and adjusts default variants that reference filtered-out values, so your recipe stays consistent.
+::
+
+## API Reference
+
+### `useRadioGroupRecipe(s, options?)`
+
+Creates a radio group recipe &mdash; a flex container with orientation and size (gap) variants.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `s` | `Styleframe` | The Styleframe instance |
+| `options` | `DeepPartial<RecipeConfig>` | Optional overrides for the recipe configuration |
+| `options.base` | `VariantDeclarationsBlock` | Custom base styles for the group |
+| `options.variants` | `Variants` | Custom variant definitions for the recipe |
+| `options.defaultVariants` | `Record<keyof Variants, string>` | Default variant values for the recipe |
+| `options.filter` | `Record<string, string[]>` | Limit which variant values are generated |
+
+**Variants:**
+
+| Variant | Options | Default |
+|---------|---------|---------|
+| `orientation` | `vertical`, `horizontal` | `vertical` |
+| `size` | `sm`, `md`, `lg` | `md` |
+
+[Learn more about recipes &rarr;](/docs/api/recipes)
+
+## Best Practices
+
+- **Pair with the Radio recipe**: The group handles layout; each child should use the [Radio](/docs/components/forms/radio) recipe for consistent controls.
+- **Share a `name`**: Give every child radio the same `name` so the set behaves as one mutually-exclusive group.
+- **Match sizes**: Use the same `size` on the group and its child radios so spacing and circles scale together.
+- **Keep groups scannable**: Prefer vertical layout for longer option lists; reserve horizontal for two or three short options.
+- **Label the set**: Always describe the group's purpose with `aria-label` or a `<legend>` so screen readers communicate the relationship between options.
+
+## FAQ
+
+::accordion
+
+:::accordion-item{label="Does the group make its radios mutually exclusive?" icon="i-lucide-circle-help"}
+No &mdash; the group is a pure layout container that sets the flex direction and the gap between items. Single selection comes from the native input: give every child radio the same `name` and the browser enforces one choice per group. Pass the same `size` to the group and its children if you want the spacing and the circles to scale together.
+:::
+
+:::accordion-item{label="When should I use horizontal orientation?" icon="i-lucide-circle-help"}
+Use `horizontal` for short sets of two or three options that read well inline. It lays the radios out in a centered, wrapping row. For longer option lists, the default `vertical` orientation is easier to scan.
+:::
+
+:::accordion-item{label="Can I use a fieldset instead of a div?" icon="i-lucide-circle-help"}
+Yes, and it's recommended inside forms. Apply the `radioGroup()` class to a native `<fieldset>` and add a `<legend>` for the group name. The recipe only sets layout properties, so it works on any block-level element.
+:::
+
+:::accordion-item{label="How does filtering affect the recipe?" icon="i-lucide-circle-help"}
+When you use the `filter` option, variant values you exclude are not generated, and default variants are adjusted if they reference a removed value &mdash; so the recipe stays consistent and only emits the CSS you use.
+:::
+
+::

--- a/apps/storybook/src/components/components/radio/Radio.vue
+++ b/apps/storybook/src/components/components/radio/Radio.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { radio, radioField } from "virtual:styleframe";
+
+const props = withDefaults(
+	defineProps<{
+		color?: "light" | "dark" | "neutral";
+		size?: "sm" | "md" | "lg";
+		checked?: boolean;
+		disabled?: boolean;
+		name?: string;
+		label?: string;
+	}>(),
+	{
+		size: "md",
+	},
+);
+
+const wrapperClasses = computed(() => radio({ size: props.size }));
+const fieldClasses = computed(() =>
+	radioField({ color: props.color, size: props.size }),
+);
+</script>
+
+<template>
+	<label :class="wrapperClasses">
+		<input
+			type="radio"
+			:class="fieldClasses"
+			:name="name"
+			:checked="checked"
+			:disabled="disabled"
+		/>
+		<span v-if="$slots.default || label"><slot>{{ label }}</slot></span>
+	</label>
+</template>

--- a/apps/storybook/src/components/components/radio/RadioGroup.vue
+++ b/apps/storybook/src/components/components/radio/RadioGroup.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { radioGroup } from "virtual:styleframe";
+
+const props = withDefaults(
+	defineProps<{
+		orientation?: "vertical" | "horizontal";
+		size?: "sm" | "md" | "lg";
+	}>(),
+	{},
+);
+
+const classes = computed(() =>
+	radioGroup({
+		orientation: props.orientation,
+		size: props.size,
+	}),
+);
+</script>
+
+<template>
+	<div :class="classes" role="radiogroup">
+		<slot />
+	</div>
+</template>

--- a/apps/storybook/src/components/components/radio/preview/RadioGrid.vue
+++ b/apps/storybook/src/components/components/radio/preview/RadioGrid.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import Radio from "../Radio.vue";
+
+const colors = ["neutral", "light", "dark"] as const;
+const states = [
+	{ label: "unchecked", checked: false, disabled: false },
+	{ label: "checked", checked: true, disabled: false },
+	{ label: "disabled", checked: false, disabled: true },
+	{ label: "disabled checked", checked: true, disabled: true },
+] as const;
+</script>
+
+<template>
+	<div class="radio-section">
+		<div v-for="state in states" :key="state.label">
+			<div class="radio-label">{{ state.label }}</div>
+			<div class="radio-row">
+				<Radio
+					v-for="color in colors"
+					:key="`${state.label}-${color}`"
+					:color="color"
+					:checked="state.checked"
+					:disabled="state.disabled"
+					:label="color"
+				/>
+			</div>
+		</div>
+	</div>
+</template>

--- a/apps/storybook/src/components/components/radio/preview/RadioGroupGrid.vue
+++ b/apps/storybook/src/components/components/radio/preview/RadioGroupGrid.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import RadioGroup from "../RadioGroup.vue";
+import Radio from "../Radio.vue";
+
+const orientations = ["vertical", "horizontal"] as const;
+</script>
+
+<template>
+	<div class="radio-section">
+		<div v-for="orientation in orientations" :key="orientation">
+			<div class="radio-label">{{ orientation }}</div>
+			<RadioGroup :orientation="orientation">
+				<Radio :name="`rgg-${orientation}`" checked label="Email" />
+				<Radio :name="`rgg-${orientation}`" label="SMS" />
+				<Radio :name="`rgg-${orientation}`" label="Push notifications" />
+			</RadioGroup>
+		</div>
+	</div>
+</template>

--- a/apps/storybook/src/components/components/radio/preview/RadioSizeGrid.vue
+++ b/apps/storybook/src/components/components/radio/preview/RadioSizeGrid.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import Radio from "../Radio.vue";
+
+const sizes = ["sm", "md", "lg"] as const;
+const sizeTitles: Record<string, string> = {
+	sm: "Small",
+	md: "Medium",
+	lg: "Large",
+};
+</script>
+
+<template>
+	<div class="radio-section">
+		<div v-for="size in sizes" :key="size">
+			<div class="radio-label">{{ size }}</div>
+			<div class="radio-row">
+				<Radio :size="size" :label="sizeTitles[size]" />
+				<Radio :size="size" checked label="Checked" />
+				<Radio :size="size" disabled label="Disabled" />
+			</div>
+		</div>
+	</div>
+</template>

--- a/apps/storybook/stories/components/radio-group.stories.ts
+++ b/apps/storybook/stories/components/radio-group.stories.ts
@@ -1,0 +1,99 @@
+import type { Meta, StoryObj } from "@storybook/vue3-vite";
+
+import RadioGroup from "@/components/components/radio/RadioGroup.vue";
+import Radio from "@/components/components/radio/Radio.vue";
+import RadioGroupGrid from "@/components/components/radio/preview/RadioGroupGrid.vue";
+
+const orientations = ["vertical", "horizontal"] as const;
+const sizes = ["sm", "md", "lg"] as const;
+
+const meta = {
+	title: "Theme/Recipes/Forms/Radio Group",
+	component: RadioGroup,
+	tags: ["autodocs"],
+	parameters: {
+		layout: "padded",
+	},
+	argTypes: {
+		orientation: {
+			control: "select",
+			options: orientations,
+			description: "The layout direction of the group",
+		},
+		size: {
+			control: "select",
+			options: sizes,
+			description: "The gap between radios",
+		},
+	},
+} satisfies Meta<typeof RadioGroup>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	render: (args) => ({
+		components: { RadioGroup, Radio },
+		setup() {
+			return { args };
+		},
+		template: `
+			<RadioGroup v-bind="args">
+				<Radio name="rg-default" checked label="Email" />
+				<Radio name="rg-default" label="SMS" />
+				<Radio name="rg-default" label="Push notifications" />
+			</RadioGroup>
+		`,
+	}),
+	args: {
+		orientation: "vertical",
+		size: "md",
+	},
+};
+
+export const AllOrientations: StoryObj = {
+	render: () => ({
+		components: { RadioGroupGrid },
+		template: "<RadioGroupGrid />",
+	}),
+};
+
+export const Vertical: Story = {
+	render: (args) => ({
+		components: { RadioGroup, Radio },
+		setup() {
+			return { args };
+		},
+		template: `
+			<RadioGroup v-bind="args">
+				<Radio name="rg-vertical" checked label="Email" />
+				<Radio name="rg-vertical" label="SMS" />
+				<Radio name="rg-vertical" label="Push notifications" />
+			</RadioGroup>
+		`,
+	}),
+	args: {
+		orientation: "vertical",
+		size: "md",
+	},
+};
+
+export const Horizontal: Story = {
+	render: (args) => ({
+		components: { RadioGroup, Radio },
+		setup() {
+			return { args };
+		},
+		template: `
+			<RadioGroup v-bind="args">
+				<Radio name="rg-horizontal" checked label="Email" />
+				<Radio name="rg-horizontal" label="SMS" />
+				<Radio name="rg-horizontal" label="Push" />
+			</RadioGroup>
+		`,
+	}),
+	args: {
+		orientation: "horizontal",
+		size: "md",
+	},
+};

--- a/apps/storybook/stories/components/radio.stories.ts
+++ b/apps/storybook/stories/components/radio.stories.ts
@@ -1,0 +1,110 @@
+import type { Meta, StoryObj } from "@storybook/vue3-vite";
+
+import Radio from "@/components/components/radio/Radio.vue";
+import RadioGrid from "@/components/components/radio/preview/RadioGrid.vue";
+import RadioSizeGrid from "@/components/components/radio/preview/RadioSizeGrid.vue";
+
+const colors = ["neutral", "light", "dark"] as const;
+const sizes = ["sm", "md", "lg"] as const;
+
+const meta = {
+	title: "Theme/Recipes/Forms/Radio",
+	component: Radio,
+	tags: ["autodocs"],
+	parameters: {
+		layout: "padded",
+	},
+	argTypes: {
+		color: {
+			control: "select",
+			options: colors,
+			description: "The color of the radio surface",
+		},
+		size: {
+			control: "select",
+			options: sizes,
+			description: "The size of the radio",
+		},
+		checked: {
+			control: "boolean",
+			description: "Whether the radio is selected",
+		},
+		disabled: {
+			control: "boolean",
+			description: "Whether the radio is disabled",
+		},
+		label: {
+			control: "text",
+			description: "The radio label",
+		},
+	},
+} satisfies Meta<typeof Radio>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {
+		color: "neutral",
+		size: "md",
+		checked: true,
+		label: "Email notifications",
+	},
+};
+
+export const AllStates: StoryObj = {
+	render: () => ({
+		components: { RadioGrid },
+		template: "<RadioGrid />",
+	}),
+};
+
+export const AllSizes: StoryObj = {
+	render: () => ({
+		components: { RadioSizeGrid },
+		template: "<RadioSizeGrid />",
+	}),
+};
+
+// Colors
+export const Neutral: Story = {
+	args: { color: "neutral", label: "Neutral" },
+};
+
+export const Light: Story = {
+	args: { color: "light", label: "Light" },
+};
+
+export const Dark: Story = {
+	args: { color: "dark", label: "Dark" },
+};
+
+// States
+export const Unchecked: Story = {
+	args: { checked: false, label: "Unselected" },
+};
+
+export const Checked: Story = {
+	args: { checked: true, label: "Selected" },
+};
+
+export const Disabled: Story = {
+	args: { disabled: true, label: "Disabled" },
+};
+
+export const DisabledChecked: Story = {
+	args: { disabled: true, checked: true, label: "Disabled selected" },
+};
+
+// Sizes
+export const Small: Story = {
+	args: { size: "sm", checked: true, label: "Small" },
+};
+
+export const Medium: Story = {
+	args: { size: "md", checked: true, label: "Medium" },
+};
+
+export const Large: Story = {
+	args: { size: "lg", checked: true, label: "Large" },
+};

--- a/apps/storybook/stories/components/radio.styleframe.ts
+++ b/apps/storybook/stories/components/radio.styleframe.ts
@@ -1,0 +1,45 @@
+import {
+	useRadioRecipe,
+	useRadioFieldRecipe,
+	useRadioGroupRecipe,
+} from "@styleframe/theme";
+import { styleframe } from "virtual:styleframe";
+
+const s = styleframe();
+const { selector } = s;
+
+// Initialize radio recipes
+export const radio = useRadioRecipe(s);
+export const radioField = useRadioFieldRecipe(s);
+export const radioGroup = useRadioGroupRecipe(s);
+
+// Container styles for story layout
+selector(".radio-grid", {
+	display: "flex",
+	flexWrap: "wrap",
+	gap: "@spacing.md",
+	padding: "@spacing.md",
+	alignItems: "flex-start",
+});
+
+selector(".radio-section", {
+	display: "flex",
+	flexDirection: "column",
+	gap: "@spacing.lg",
+	padding: "@spacing.md",
+});
+
+selector(".radio-row", {
+	display: "flex",
+	flexWrap: "wrap",
+	gap: "@spacing.md",
+	alignItems: "center",
+});
+
+selector(".radio-label", {
+	fontSize: "@font-size.sm",
+	fontWeight: "@font-weight.semibold",
+	minWidth: "120px",
+});
+
+export default s;

--- a/theme/src/recipes/index.ts
+++ b/theme/src/recipes/index.ts
@@ -19,6 +19,7 @@ export * from "./pagination";
 export * from "./placeholder";
 export * from "./popover";
 export * from "./progress";
+export * from "./radio";
 export * from "./skeleton";
 export * from "./textarea";
 export * from "./tooltip";

--- a/theme/src/recipes/radio/index.ts
+++ b/theme/src/recipes/radio/index.ts
@@ -1,0 +1,3 @@
+export * from "./useRadioRecipe";
+export * from "./useRadioFieldRecipe";
+export * from "./useRadioGroupRecipe";

--- a/theme/src/recipes/radio/useRadioFieldRecipe.test.ts
+++ b/theme/src/recipes/radio/useRadioFieldRecipe.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from "vitest";
+import { styleframe } from "@styleframe/core";
+import { useDarkModifier } from "../../modifiers/useMediaPreferenceModifiers";
+import {
+	useCheckedModifier,
+	useDisabledModifier,
+} from "../../modifiers/useFormStateModifiers";
+import { useFocusVisibleModifier } from "../../modifiers/usePseudoStateModifiers";
+import { useDesignTokensPreset } from "../../presets/useDesignTokensPreset";
+import { useUtilitiesPreset } from "../../presets/useUtilitiesPreset";
+import { useModifiersPreset } from "../../presets/useModifiersPreset";
+import { useRadioFieldRecipe } from "./useRadioFieldRecipe";
+
+function createInstance() {
+	const s = styleframe();
+	for (const name of [
+		"appearance",
+		"WebkitAppearance",
+		"boxSizing",
+		"display",
+		"flexShrink",
+		"borderWidth",
+		"borderStyle",
+		"borderColor",
+		"borderRadius",
+		"backgroundColor",
+		"backgroundImage",
+		"backgroundRepeat",
+		"backgroundPosition",
+		"backgroundSize",
+		"cursor",
+		"transitionProperty",
+		"transitionDuration",
+		"transitionTimingFunction",
+		"width",
+		"height",
+		"opacity",
+		"outlineWidth",
+		"outlineStyle",
+		"outlineColor",
+		"outlineOffset",
+	]) {
+		s.utility(name, ({ value }) => ({ [name]: value }));
+	}
+	useDarkModifier(s);
+	useCheckedModifier(s);
+	useDisabledModifier(s);
+	useFocusVisibleModifier(s);
+	return s;
+}
+
+describe("useRadioFieldRecipe", () => {
+	it("should create a recipe with correct metadata", () => {
+		const s = createInstance();
+		const recipe = useRadioFieldRecipe(s);
+
+		expect(recipe.type).toBe("recipe");
+		expect(recipe.name).toBe("radio-field");
+	});
+
+	it("should build against the design-tokens, utilities, and modifiers presets", () => {
+		const s = styleframe();
+		useDesignTokensPreset(s);
+		useUtilitiesPreset(s);
+		useModifiersPreset(s);
+
+		// Reproduces the real init environment: every declared property must
+		// resolve to a registered utility (e.g. -webkit-appearance).
+		expect(() => useRadioFieldRecipe(s)).not.toThrow();
+	});
+
+	it("should have correct base styles", () => {
+		const s = createInstance();
+		const recipe = useRadioFieldRecipe(s);
+
+		expect(recipe.base).toMatchObject({
+			appearance: "none",
+			boxSizing: "border-box",
+			display: "inline-block",
+			borderWidth: "@border-width.thin",
+			borderStyle: "@border-style.solid",
+			cursor: "pointer",
+			backgroundRepeat: "no-repeat",
+			backgroundPosition: "center",
+			backgroundSize: "contain",
+		});
+	});
+
+	it("should fill the circle with primary and paint an SVG dot when checked", () => {
+		const s = createInstance();
+		const recipe = useRadioFieldRecipe(s);
+
+		const checked = recipe.base?.["&:checked"] as Record<string, string>;
+		expect(checked).toMatchObject({
+			backgroundColor: "@color.primary",
+			borderColor: "@color.primary",
+		});
+		expect(checked.backgroundImage).toContain("data:image/svg+xml");
+		expect(checked.backgroundImage).toContain("circle");
+	});
+
+	it("should not define an indeterminate state", () => {
+		const s = createInstance();
+		const recipe = useRadioFieldRecipe(s);
+
+		expect(recipe.base?.["&:indeterminate"]).toBeUndefined();
+	});
+
+	it("should style focus-visible and disabled states", () => {
+		const s = createInstance();
+		const recipe = useRadioFieldRecipe(s);
+
+		expect(recipe.base?.["&:focus-visible"]).toMatchObject({
+			outlineColor: "@color.primary",
+		});
+		expect(recipe.base?.["&:disabled"]).toEqual({
+			opacity: "0.5",
+			cursor: "not-allowed",
+		});
+	});
+
+	describe("variants", () => {
+		it("should have all color variants", () => {
+			const s = createInstance();
+			const recipe = useRadioFieldRecipe(s);
+
+			expect(Object.keys(recipe.variants!.color)).toEqual([
+				"light",
+				"dark",
+				"neutral",
+			]);
+		});
+
+		it("should have size variants with a circular radius", () => {
+			const s = createInstance();
+			const recipe = useRadioFieldRecipe(s);
+
+			expect(Object.keys(recipe.variants!.size)).toEqual(["sm", "md", "lg"]);
+			expect(recipe.variants!.size.md).toEqual({
+				width: "16px",
+				height: "16px",
+				borderRadius: "@border-radius.full",
+			});
+		});
+	});
+
+	it("should have correct default variants", () => {
+		const s = createInstance();
+		const recipe = useRadioFieldRecipe(s);
+
+		expect(recipe.defaultVariants).toEqual({
+			color: "neutral",
+			size: "md",
+		});
+	});
+
+	describe("compound variants", () => {
+		it("should have 3 compound variants", () => {
+			const s = createInstance();
+			const recipe = useRadioFieldRecipe(s);
+
+			expect(recipe.compoundVariants).toHaveLength(3);
+		});
+
+		it("should set the neutral unchecked surface and re-assert the checked fill in dark mode", () => {
+			const s = createInstance();
+			const recipe = useRadioFieldRecipe(s);
+
+			const cv = recipe.compoundVariants!.find(
+				(v) => v.match.color === "neutral",
+			);
+			expect(cv?.css).toEqual({
+				backgroundColor: "@color.white",
+				borderColor: "@color.gray-300",
+				"&:dark": {
+					backgroundColor: "@color.gray-900",
+					borderColor: "@color.gray-600",
+				},
+				"&:dark:checked": {
+					backgroundColor: "@color.primary",
+					borderColor: "@color.primary",
+				},
+			});
+		});
+
+		it("should keep fixed light/dark surfaces free of dark overrides", () => {
+			const s = createInstance();
+			const recipe = useRadioFieldRecipe(s);
+
+			const light = recipe.compoundVariants!.find(
+				(v) => v.match.color === "light",
+			);
+			expect(light?.css).toEqual({
+				backgroundColor: "@color.white",
+				borderColor: "@color.gray-300",
+			});
+		});
+	});
+
+	describe("config overrides", () => {
+		it("should allow overriding base styles", () => {
+			const s = createInstance();
+			const recipe = useRadioFieldRecipe(s, {
+				base: { display: "block" },
+			});
+
+			expect(recipe.base?.display).toBe("block");
+		});
+	});
+
+	describe("filter", () => {
+		it("should filter color variants and prune compound variants", () => {
+			const s = createInstance();
+			const recipe = useRadioFieldRecipe(s, {
+				filter: { color: ["neutral"] },
+			});
+
+			expect(Object.keys(recipe.variants!.color)).toEqual(["neutral"]);
+			expect(recipe.compoundVariants).toHaveLength(1);
+		});
+
+		it("should adjust default variants when filtered out", () => {
+			const s = createInstance();
+			const recipe = useRadioFieldRecipe(s, {
+				filter: { color: ["light"] },
+			});
+
+			expect(recipe.defaultVariants?.color).toBeUndefined();
+		});
+	});
+});

--- a/theme/src/recipes/radio/useRadioFieldRecipe.ts
+++ b/theme/src/recipes/radio/useRadioFieldRecipe.ts
@@ -1,0 +1,123 @@
+import { createUseRecipe } from "../../utils/createUseRecipe";
+
+/**
+ * Radio field recipe — sits on the native `<input type="radio">`.
+ *
+ * Renders a custom circle with no extra markup. The native element drives every
+ * state: `:checked` fills the circle with `@color.primary` and paints a white
+ * dot as a `background-image` SVG, `:focus-visible` shows a focus ring, and
+ * `:disabled` dims it. Radios have no `:indeterminate` state, so — unlike
+ * `checkbox-field` — there is no dash mark.
+ *
+ * The dot is an inline SVG `background-image` (the same technique the sanitize
+ * layer uses for the `<select>` arrow) rather than a filled `::before` — it
+ * stays crisp and centered at every size via `background-size: contain`.
+ *
+ * The `color` axis only controls the *unchecked* surface (background + border)
+ * and its dark-mode adaptation, mirroring the `input` recipe's
+ * `light` / `dark` / `neutral` colors. The adaptive `neutral` color re-asserts
+ * the checked fill under `&:dark` so it keeps winning against the
+ * attribute-based dark surface (`[data-theme="dark"]`), which would otherwise
+ * out-specify the base `&:checked` rule.
+ */
+const dotImage =
+	"url(\"data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='white'%3E%3Ccircle cx='8' cy='8' r='3'/%3E%3C/svg%3E\")";
+
+export const useRadioFieldRecipe = createUseRecipe("radio-field", {
+	base: {
+		appearance: "none",
+		WebkitAppearance: "none",
+		boxSizing: "border-box",
+		display: "inline-block",
+		flexShrink: "0",
+		borderWidth: "@border-width.thin",
+		borderStyle: "@border-style.solid",
+		cursor: "pointer",
+		backgroundRepeat: "no-repeat",
+		backgroundPosition: "center",
+		backgroundSize: "contain",
+		transitionProperty: "color, background-color, border-color",
+		transitionDuration: "150ms",
+		transitionTimingFunction: "@easing.ease-in-out",
+		"&:checked": {
+			backgroundColor: "@color.primary",
+			borderColor: "@color.primary",
+			backgroundImage: dotImage,
+		},
+		"&:focus-visible": {
+			outlineWidth: "2px",
+			outlineStyle: "solid",
+			outlineColor: "@color.primary",
+			outlineOffset: "2px",
+		},
+		"&:disabled": {
+			opacity: "0.5",
+			cursor: "not-allowed",
+		},
+	},
+	variants: {
+		color: {
+			light: {},
+			dark: {},
+			neutral: {},
+		},
+		size: {
+			sm: {
+				width: "14px",
+				height: "14px",
+				borderRadius: "@border-radius.full",
+			},
+			md: {
+				width: "16px",
+				height: "16px",
+				borderRadius: "@border-radius.full",
+			},
+			lg: {
+				width: "20px",
+				height: "20px",
+				borderRadius: "@border-radius.full",
+			},
+		},
+	},
+	compoundVariants: [
+		// Light surface — fixed across themes. The base `&:checked` fill
+		// out-specifies this unchecked rule in every mode, so no dark override.
+		{
+			match: { color: "light" as const },
+			css: {
+				backgroundColor: "@color.white",
+				borderColor: "@color.gray-300",
+			},
+		},
+		// Dark surface — fixed across themes.
+		{
+			match: { color: "dark" as const },
+			css: {
+				backgroundColor: "@color.gray-900",
+				borderColor: "@color.gray-600",
+			},
+		},
+		// Neutral surface — adaptive. The `&:dark` unchecked rule gains
+		// attribute-selector specificity, so the checked fill is re-asserted
+		// under `&:dark:checked` to keep winning.
+		{
+			match: { color: "neutral" as const },
+			css: {
+				backgroundColor: "@color.white",
+				borderColor: "@color.gray-300",
+				"&:dark": {
+					backgroundColor: "@color.gray-900",
+					borderColor: "@color.gray-600",
+				},
+				"&:dark:checked": {
+					backgroundColor: "@color.primary",
+					borderColor: "@color.primary",
+				},
+			},
+		},
+	],
+	defaultVariants: {
+		color: "neutral",
+		size: "md",
+	},
+});

--- a/theme/src/recipes/radio/useRadioGroupRecipe.test.ts
+++ b/theme/src/recipes/radio/useRadioGroupRecipe.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { styleframe } from "@styleframe/core";
+import { useDarkModifier } from "../../modifiers/useMediaPreferenceModifiers";
+import { useRadioGroupRecipe } from "./useRadioGroupRecipe";
+
+function createInstance() {
+	const s = styleframe();
+	for (const name of [
+		"display",
+		"flexDirection",
+		"flexWrap",
+		"alignItems",
+		"gap",
+	]) {
+		s.utility(name, ({ value }) => ({ [name]: value }));
+	}
+	useDarkModifier(s);
+	return s;
+}
+
+describe("useRadioGroupRecipe", () => {
+	it("should create a recipe with correct metadata", () => {
+		const s = createInstance();
+		const recipe = useRadioGroupRecipe(s);
+
+		expect(recipe.type).toBe("recipe");
+		expect(recipe.name).toBe("radio-group");
+	});
+
+	it("should have correct base styles", () => {
+		const s = createInstance();
+		const recipe = useRadioGroupRecipe(s);
+
+		expect(recipe.base).toEqual({ display: "flex" });
+	});
+
+	describe("variants", () => {
+		it("should have all orientation variants", () => {
+			const s = createInstance();
+			const recipe = useRadioGroupRecipe(s);
+
+			expect(Object.keys(recipe.variants!.orientation)).toEqual([
+				"vertical",
+				"horizontal",
+			]);
+			expect(recipe.variants!.orientation.vertical).toEqual({
+				flexDirection: "column",
+			});
+			expect(recipe.variants!.orientation.horizontal).toEqual({
+				flexDirection: "row",
+				flexWrap: "wrap",
+				alignItems: "center",
+			});
+		});
+
+		it("should have size variants with correct styles", () => {
+			const s = createInstance();
+			const recipe = useRadioGroupRecipe(s);
+
+			expect(Object.keys(recipe.variants!.size)).toEqual(["sm", "md", "lg"]);
+			expect(recipe.variants!.size.md).toEqual({ gap: "@0.75" });
+		});
+	});
+
+	it("should have correct default variants", () => {
+		const s = createInstance();
+		const recipe = useRadioGroupRecipe(s);
+
+		expect(recipe.defaultVariants).toEqual({
+			orientation: "vertical",
+			size: "md",
+		});
+	});
+
+	it("should not define compound variants", () => {
+		const s = createInstance();
+		const recipe = useRadioGroupRecipe(s);
+
+		expect(recipe.compoundVariants ?? []).toHaveLength(0);
+	});
+
+	describe("config overrides", () => {
+		it("should allow overriding base styles", () => {
+			const s = createInstance();
+			const recipe = useRadioGroupRecipe(s, {
+				base: { display: "block" },
+			});
+
+			expect(recipe.base?.display).toBe("block");
+		});
+	});
+
+	describe("filter", () => {
+		it("should filter orientation variants", () => {
+			const s = createInstance();
+			const recipe = useRadioGroupRecipe(s, {
+				filter: { orientation: ["horizontal"] },
+			});
+
+			expect(Object.keys(recipe.variants!.orientation)).toEqual(["horizontal"]);
+		});
+
+		it("should adjust default variants when filtered out", () => {
+			const s = createInstance();
+			const recipe = useRadioGroupRecipe(s, {
+				filter: { orientation: ["horizontal"] },
+			});
+
+			expect(recipe.defaultVariants?.orientation).toBeUndefined();
+		});
+	});
+});

--- a/theme/src/recipes/radio/useRadioGroupRecipe.ts
+++ b/theme/src/recipes/radio/useRadioGroupRecipe.ts
@@ -1,0 +1,39 @@
+import { createUseRecipe } from "../../utils/createUseRecipe";
+
+/**
+ * Radio group recipe — a flex container that lays out multiple `.radio`
+ * rows. Supports orientation (vertical / horizontal) and a size axis that
+ * controls the gap between items.
+ */
+export const useRadioGroupRecipe = createUseRecipe("radio-group", {
+	base: {
+		display: "flex",
+	},
+	variants: {
+		orientation: {
+			vertical: {
+				flexDirection: "column",
+			},
+			horizontal: {
+				flexDirection: "row",
+				flexWrap: "wrap",
+				alignItems: "center",
+			},
+		},
+		size: {
+			sm: {
+				gap: "@0.5",
+			},
+			md: {
+				gap: "@0.75",
+			},
+			lg: {
+				gap: "@1",
+			},
+		},
+	},
+	defaultVariants: {
+		orientation: "vertical",
+		size: "md",
+	},
+});

--- a/theme/src/recipes/radio/useRadioRecipe.test.ts
+++ b/theme/src/recipes/radio/useRadioRecipe.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { styleframe } from "@styleframe/core";
+import { useDarkModifier } from "../../modifiers/useMediaPreferenceModifiers";
+import { useRadioRecipe } from "./useRadioRecipe";
+
+function createInstance() {
+	const s = styleframe();
+	for (const name of [
+		"display",
+		"alignItems",
+		"cursor",
+		"userSelect",
+		"color",
+		"lineHeight",
+		"opacity",
+		"gap",
+		"fontSize",
+	]) {
+		s.utility(name, ({ value }) => ({ [name]: value }));
+	}
+	useDarkModifier(s);
+	return s;
+}
+
+describe("useRadioRecipe", () => {
+	it("should create a recipe with correct metadata", () => {
+		const s = createInstance();
+		const recipe = useRadioRecipe(s);
+
+		expect(recipe.type).toBe("recipe");
+		expect(recipe.name).toBe("radio");
+	});
+
+	it("should have correct base styles", () => {
+		const s = createInstance();
+		const recipe = useRadioRecipe(s);
+
+		expect(recipe.base).toMatchObject({
+			display: "inline-flex",
+			alignItems: "center",
+			cursor: "pointer",
+			userSelect: "none",
+			color: "@color.text",
+		});
+	});
+
+	describe("variants", () => {
+		it("should have size variants with correct styles", () => {
+			const s = createInstance();
+			const recipe = useRadioRecipe(s);
+
+			expect(Object.keys(recipe.variants!.size)).toEqual(["sm", "md", "lg"]);
+			expect(recipe.variants!.size.md).toEqual({
+				gap: "@0.5",
+				fontSize: "@font-size.sm",
+			});
+		});
+	});
+
+	it("should have correct default variants", () => {
+		const s = createInstance();
+		const recipe = useRadioRecipe(s);
+
+		expect(recipe.defaultVariants).toEqual({ size: "md" });
+	});
+
+	it("should not define compound variants", () => {
+		const s = createInstance();
+		const recipe = useRadioRecipe(s);
+
+		expect(recipe.compoundVariants ?? []).toHaveLength(0);
+	});
+
+	describe("config overrides", () => {
+		it("should allow overriding base styles", () => {
+			const s = createInstance();
+			const recipe = useRadioRecipe(s, {
+				base: { display: "flex" },
+			});
+
+			expect(recipe.base?.display).toBe("flex");
+		});
+	});
+
+	describe("filter", () => {
+		it("should filter size variants", () => {
+			const s = createInstance();
+			const recipe = useRadioRecipe(s, {
+				filter: { size: ["md"] },
+			});
+
+			expect(Object.keys(recipe.variants!.size)).toEqual(["md"]);
+		});
+
+		it("should adjust default variants when filtered out", () => {
+			const s = createInstance();
+			const recipe = useRadioRecipe(s, {
+				filter: { size: ["sm"] },
+			});
+
+			expect(recipe.defaultVariants?.size).toBeUndefined();
+		});
+	});
+});

--- a/theme/src/recipes/radio/useRadioRecipe.ts
+++ b/theme/src/recipes/radio/useRadioRecipe.ts
@@ -1,0 +1,52 @@
+import { createUseRecipe } from "../../utils/createUseRecipe";
+
+/**
+ * Radio wrapper recipe — sits on the `<label>` that wraps a
+ * `<input class="radio-field">` and its text. Owns the inline layout
+ * (gap, alignment), label typography, and dims the label when the nested
+ * field is disabled. The visual circle lives on `radio-field`.
+ *
+ * The disabled-label dimming uses `:has()`, which is a raw CSS selector rather
+ * than a registered modifier, so it is declared via the `setup` callback.
+ */
+export const useRadioRecipe = createUseRecipe(
+	"radio",
+	{
+		base: {
+			display: "inline-flex",
+			alignItems: "center",
+			cursor: "pointer",
+			userSelect: "none",
+			color: "@color.text",
+			lineHeight: "@line-height.normal",
+		},
+		variants: {
+			size: {
+				sm: {
+					gap: "@0.375",
+					fontSize: "@font-size.xs",
+				},
+				md: {
+					gap: "@0.5",
+					fontSize: "@font-size.sm",
+				},
+				lg: {
+					gap: "@0.625",
+					fontSize: "@font-size.md",
+				},
+			},
+		},
+		defaultVariants: {
+			size: "md",
+		},
+	},
+	(s) => {
+		const { selector } = s;
+
+		// Dim the label when the nested field is disabled.
+		selector(".radio:has(.radio-field:disabled)", {
+			opacity: "0.5",
+			cursor: "not-allowed",
+		});
+	},
+);


### PR DESCRIPTION
## Summary

- Adds `useRadioRecipe`, `useRadioFieldRecipe`, and `useRadioGroupRecipe` to `@styleframe/theme` with full color/size/variant parity to existing form recipes (Checkbox, Input, Textarea)
- Includes Vitest unit tests colocated at `theme/src/recipes/radio/`
- Adds Storybook showcase components and stories for Radio and RadioGroup
- Adds documentation pages at `apps/docs/content/docs/05.components/05.forms/03.radio.md` and `04.radio-group.md`