### PR TITLE
docs: prebundle @vueuse/core, motion-v, and posthog-js in optimizeDeps

### DIFF
--- a/apps/docs/modules/optimizeDeps.ts
+++ b/apps/docs/modules/optimizeDeps.ts
@@ -6,7 +6,12 @@ export default defineNuxtModule({
 		extendViteConfig((config) => {
 			config.optimizeDeps ||= {};
 			config.optimizeDeps.include ||= [];
-			config.optimizeDeps.include.push("@nuxt/content > slugify");
+			config.optimizeDeps.include.push(
+				"@nuxt/content > slugify",
+				"@vueuse/core",
+				"motion-v",
+				"posthog-js",
+			);
 			config.optimizeDeps.include = config.optimizeDeps.include.map(
 				(id: string) =>
 					id.replace(/^@nuxt\/content > /, "docus > @nuxt/content > "),


### PR DESCRIPTION
Adds `@vueuse/core`, `motion-v`, and `posthog-js` to the Vite `optimizeDeps.include` list in the docs site's custom Nuxt module. This ensures these dependencies are pre-bundled by Vite, preventing CJS/ESM interop issues and improving cold-start dev server performance.