### PR TITLE
feat(theme): add OTP recipe with shared field surface abstraction

### DIFF
--- a/.changeset/otp-recipe.md
+++ b/.changeset/otp-recipe.md
@@ -1,0 +1,10 @@
+---
+"@styleframe/theme": minor
+"styleframe": minor
+---
+
+Add OTP recipe with shared field surface abstraction.
+
+Adds `useOtpRecipe` and `useOtpCellRecipe` for styling one-time password inputs. The cell recipe targets a single `<input>` with `:focus-visible` ring and supports the full color × variant × size matrix matching Input/Textarea parity.
+
+Extracts `fieldSurfaceCompoundVariants()` from `createFieldRecipe` so the OTP cell can share the same nine color×variant surface declarations without duplication.

--- a/apps/docs/content/docs/05.components/05.forms/01.otp.md
+++ b/apps/docs/content/docs/05.components/05.forms/01.otp.md
@@ -1,0 +1,466 @@
+---
+title: OTP
+description: A one-time-password / pin input — a row of single-character cells with light, dark, and neutral surface colors, default, soft, and ghost styles, three sizes, and invalid, disabled, and focus states through the recipe system.
+navigation:
+    icon: false
+---
+
+## Overview
+
+The **OTP** input (also called a pin input) is a row of single-character fields for entering a short code &mdash; a one-time password, a 2FA token, or a verification PIN. It is composed of two recipe parts:
+
+- **`useOtpRecipe()`** &mdash; the row container that owns the layout: a horizontal flex row whose `size` axis scales the gap between cells.
+- **`useOtpCellRecipe()`** &mdash; the single-character cell that sits directly on each native `<input>`. It owns the surface (color, style, size), centered text, and the invalid, disabled, and `:focus-visible` states.
+
+Each cell is the real native `<input>`, so focus and the focus ring are driven by the browser: `:focus-visible` shows a ring in `@color.primary`, and the `invalid` state switches that ring and the border to `@color.error`. The cell shares the exact color / style / state surface as the [Input](/docs/components/forms/input) recipe, so an OTP field feels like the rest of your forms.
+
+The OTP recipes integrate directly with the default [design tokens preset](/docs/theme/design-tokens/presets) and generate type-safe utility classes at build time with zero runtime CSS.
+
+::note
+**Styling, not behavior.** These recipes style the cells. Auto-advancing focus, handling paste, and masking are interaction concerns you wire up yourself (or with a headless library) &mdash; the recipe stays framework-agnostic.
+::
+
+## Why use the OTP recipe?
+
+The OTP recipe helps you:
+
+- **Ship faster with sensible defaults**: Get 3 surface colors, 3 styles, and 3 sizes out of the box with a single set of composable calls.
+- **Match the rest of your forms**: The cell reuses the Input recipe's color / style / state surface, so an OTP field shares the same visual language as your text inputs.
+- **Maintain consistency**: The focus ring, invalid border, and dark-mode surfaces follow the same design rules everywhere.
+- **Customize without forking**: Override base styles, default variants, or filter out options you don't need &mdash; all through the options API.
+- **Stay type-safe**: Full TypeScript support means your editor catches invalid color, style, or size values at compile time.
+- **Integrate with your tokens**: Every value references the design tokens preset, so theme changes propagate automatically.
+
+## Usage
+
+::steps{level="4"}
+
+#### Register the recipes
+
+Add the OTP recipes to a local Styleframe instance. The global `styleframe.config.ts` provides design tokens and utilities, while the component-level file registers the recipes themselves:
+
+:::code-tree{default-value="src/components/otp.styleframe.ts"}
+
+```ts [src/components/otp.styleframe.ts]
+import { styleframe } from 'virtual:styleframe';
+import { useOtpRecipe, useOtpCellRecipe } from '@styleframe/theme';
+
+const s = styleframe();
+
+const otp = useOtpRecipe(s);
+const otpCell = useOtpCellRecipe(s);
+
+export default s;
+```
+
+```ts [styleframe.config.ts]
+import { styleframe } from 'styleframe';
+import { useDesignTokensPreset, useUtilitiesPreset } from '@styleframe/theme';
+
+const s = styleframe();
+
+useDesignTokensPreset(s);
+useUtilitiesPreset(s);
+
+export default s;
+```
+
+:::
+
+#### Build the component
+
+Put the `otp` container on the wrapper element and the `otpCell` class on each native `<input>`. Render one input per character, capped at a single character with `maxlength="1"`:
+
+::framework-switcher
+
+#vue
+
+```vue [src/components/Otp.vue]
+<script setup lang="ts">
+import { otp, otpCell } from "virtual:styleframe";
+
+const {
+	color = "neutral",
+	variant = "default",
+	size = "md",
+	length = 6,
+	invalid = false,
+	disabled = false,
+} = defineProps<{
+	color?: "light" | "dark" | "neutral";
+	variant?: "default" | "soft" | "ghost";
+	size?: "sm" | "md" | "lg";
+	length?: number;
+	invalid?: boolean;
+	disabled?: boolean;
+}>();
+</script>
+
+<template>
+	<div :class="otp({ size })" role="group" aria-label="One-time password">
+		<input
+			v-for="i in length"
+			:key="i"
+			:class="otpCell({
+				color,
+				variant,
+				size,
+				invalid: invalid ? 'true' : 'false',
+				disabled: disabled ? 'true' : 'false',
+			})"
+			type="text"
+			inputmode="numeric"
+			autocomplete="one-time-code"
+			maxlength="1"
+			:disabled="disabled"
+		/>
+	</div>
+</template>
+```
+
+#react
+
+```ts [src/components/Otp.tsx]
+import { otp, otpCell } from "virtual:styleframe";
+
+interface OtpProps {
+	color?: "light" | "dark" | "neutral";
+	variant?: "default" | "soft" | "ghost";
+	size?: "sm" | "md" | "lg";
+	length?: number;
+	invalid?: boolean;
+	disabled?: boolean;
+}
+
+export function Otp({
+	color = "neutral",
+	variant = "default",
+	size = "md",
+	length = 6,
+	invalid = false,
+	disabled = false,
+}: OtpProps) {
+	return (
+		<div className={otp({ size })} role="group" aria-label="One-time password">
+			{Array.from({ length }).map((_, i) => (
+				<input
+					key={i}
+					className={otpCell({
+						color,
+						variant,
+						size,
+						invalid: invalid ? "true" : "false",
+						disabled: disabled ? "true" : "false",
+					})}
+					type="text"
+					inputMode="numeric"
+					autoComplete="one-time-code"
+					maxLength={1}
+					disabled={disabled}
+				/>
+			))}
+		</div>
+	);
+}
+```
+
+#other
+
+The `otp()` and `otpCell()` runtimes each return a class string. Apply them however your framework binds classes:
+
+```ts [src/components/otp.ts]
+import { otp, otpCell } from "virtual:styleframe";
+
+const containerClasses = otp({ size: "md" });
+// → "otp _display:inline-flex _align-items:center ..."
+
+const cellClasses = otpCell({ color: "neutral", variant: "default", size: "md" });
+// → "otp-cell _box-sizing:border-box _text-align:center ..."
+```
+
+```html [src/components/otp.html]
+<div class="otp _display:inline-flex ..." role="group" aria-label="One-time password">
+	<input class="otp-cell _text-align:center ..." type="text" inputmode="numeric" maxlength="1" />
+	<input class="otp-cell _text-align:center ..." type="text" inputmode="numeric" maxlength="1" />
+	<!-- one input per character -->
+</div>
+```
+
+::
+
+#### See it in action
+
+:::story-preview
+---
+story: theme-recipes-forms-otp--default
+panel: true
+---
+:::
+
+::
+
+## Colors
+
+The OTP cell includes 3 color variants: `light`, `dark`, and `neutral`. Like the [Input](/docs/components/forms/input) and [Checkbox](/docs/components/forms/checkbox) recipes, these are neutral-spectrum surface colors rather than status colors &mdash; the color sets the cell background and border, while the `:focus-visible` ring stays `@color.primary`.
+
+The `neutral` color adapts automatically: a light surface in light mode and a dark surface in dark mode, making it the safest default for general-purpose forms.
+
+::story-preview
+---
+story: theme-recipes-forms-otp--neutral
+panel: true
+---
+::
+
+### Color Reference
+
+::story-preview
+---
+story: theme-recipes-forms-otp--all-variants
+height: 420
+---
+::
+
+| Color | Token | Use Case |
+|-------|-------|----------|
+| `light` | `@color.white` / `@color.gray-200` | Light surfaces, stays light in dark mode |
+| `dark` | `@color.gray-900` / `@color.gray-700` | Dark surfaces, stays dark in light mode |
+| `neutral` | Adaptive (light &harr; dark) | Default color, adapts to the current color scheme |
+
+::tip
+**Pro tip:** Use `neutral` as your default OTP color. It adapts to the user's color scheme automatically, so you don't need to manage light and dark surfaces separately.
+::
+
+## Variants
+
+Three visual styles control how much surface each cell shows. All three share the same `:focus-visible` ring and invalid border &mdash; they differ only in their resting background and border.
+
+### Default
+
+`default` draws a bordered cell on a solid surface &mdash; the most legible option and the right default for verification flows.
+
+::story-preview
+---
+story: theme-recipes-forms-otp--default
+panel: true
+---
+::
+
+### Soft
+
+`soft` fills the cell with a subtle tinted background and a matching border, for a gentler look that still reads as an input.
+
+::story-preview
+---
+story: theme-recipes-forms-otp--soft
+panel: true
+---
+::
+
+### Ghost
+
+`ghost` is transparent until focused, for dense or low-chrome layouts. Pair it with a clear label so the field stays discoverable.
+
+::story-preview
+---
+story: theme-recipes-forms-otp--ghost
+panel: true
+---
+::
+
+## Sizes
+
+Three size variants from `sm` to `lg` control the square cell dimensions, font size, and border radius. Cells are square so digits stay centered both ways.
+
+::story-preview
+---
+story: theme-recipes-forms-otp--all-sizes
+height: 360
+---
+::
+
+### Size Reference
+
+| Size | Cell Size | Font Size | Border Radius |
+|------|-----------|-----------|---------------|
+| `sm` | `40px` | `@font-size.sm` | `@border-radius.sm` |
+| `md` | `48px` | `@font-size.md` | `@border-radius.md` |
+| `lg` | `56px` | `@font-size.lg` | `@border-radius.md` |
+
+::note
+**Good to know:** Pass the same `size` to the `otp` container and the `otpCell` cells so the gap between cells scales with the cell size.
+::
+
+## States
+
+### Invalid
+
+Set the `invalid` state when the entered code is wrong or expired. The cell border and the `:focus-visible` ring switch to `@color.error`, layered over whatever color and style the cell already uses.
+
+::story-preview
+---
+story: theme-recipes-forms-otp--invalid
+panel: true
+---
+::
+
+### Disabled
+
+The `disabled` state dims the cells to `0.5` opacity, switches the cursor to `not-allowed`, and blocks pointer interaction. Mirror it with the native `disabled` attribute so the inputs also leave the tab order.
+
+::story-preview
+---
+story: theme-recipes-forms-otp--disabled
+panel: true
+---
+::
+
+## Anatomy
+
+The OTP input is composed of two independent recipes: a row container and the repeated cell.
+
+| Part | Recipe | Role |
+|------|--------|------|
+| **Container** | `useOtpRecipe()` | The `.otp` wrapper &mdash; owns the horizontal row layout and scales the gap between cells with `size` |
+| **Cell** | `useOtpCellRecipe()` | The `.otp-cell` native `<input>` &mdash; owns the surface color, style, square size, centered text, and the invalid / disabled / focus states |
+
+```html
+<div class="otp(...)" role="group" aria-label="One-time password">
+	<input class="otpCell(...)" type="text" maxlength="1" />
+	<!-- one input per character -->
+</div>
+```
+
+The container carries no color or style axis; all surface styling lives on the cell, so every cell in a row stays visually identical.
+
+## Accessibility
+
+- **Group and label the cells.** Wrap the inputs in an element with `role="group"` and an `aria-label` (e.g. "One-time password") so assistive technology announces them as one control rather than several unrelated fields.
+- **Keep native inputs.** Styling real `<input>` elements preserves keyboard operation, focus order, and form submission for free.
+- **Hint the input type.** Set `inputmode="numeric"` for digit codes and `autocomplete="one-time-code"` so mobile keyboards and OS-level SMS autofill work.
+- **Don't rely on color alone.** The `invalid` state changes the border and ring color; pair it with a visible error message so the failure isn't conveyed by color only, satisfying [WCAG 1.4.1](https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html).
+- **Mirror `disabled` on the input.** Set the real `disabled` attribute in addition to the recipe state so the cells leave the tab order.
+- **Verify contrast.** The `:focus-visible` ring is `@color.primary`. Default tokens meet WCAG AA; if you override the primary color, verify with the [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/).
+
+## Customization
+
+### Overriding Defaults
+
+Each OTP composable accepts an optional second argument to override any part of the recipe configuration. Overrides are deep-merged with the defaults, so you only need to specify the properties you want to change:
+
+```ts [src/components/otp.styleframe.ts]
+import { styleframe } from 'virtual:styleframe';
+import { useOtpCellRecipe } from '@styleframe/theme';
+
+const s = styleframe();
+
+const otpCell = useOtpCellRecipe(s, {
+    base: {
+        fontWeight: '@font-weight.semibold',
+    },
+    defaultVariants: {
+        color: 'neutral',
+        size: 'lg',
+    },
+});
+
+export default s;
+```
+
+### Filtering Variants
+
+If you only need a subset of the available variants, use the `filter` option to limit which values are generated. This reduces the output CSS and keeps your component API focused:
+
+```ts [src/components/otp.styleframe.ts]
+import { styleframe } from 'virtual:styleframe';
+import { useOtpCellRecipe } from '@styleframe/theme';
+
+const s = styleframe();
+
+// Only generate the neutral color and the default style
+const otpCell = useOtpCellRecipe(s, {
+    filter: {
+        color: ['neutral'],
+        variant: ['default'],
+    },
+});
+
+export default s;
+```
+
+::note
+**Good to know:** Filtering also removes compound variants and adjusts default variants that reference filtered-out values, so your recipe stays consistent.
+::
+
+## API Reference
+
+### `useOtpRecipe(s, options?)`
+
+Creates the OTP container recipe &mdash; the `.otp` row that lays out the cells and scales the gap between them with `size`.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `s` | `Styleframe` | The Styleframe instance |
+| `options` | `DeepPartial<RecipeConfig>` | Optional overrides for the recipe configuration |
+| `options.base` | `VariantDeclarationsBlock` | Custom base styles for the container |
+| `options.variants` | `Variants` | Custom variant definitions for the recipe |
+| `options.defaultVariants` | `Record<keyof Variants, string>` | Default variant values for the recipe |
+| `options.filter` | `Record<string, string[]>` | Limit which variant values are generated |
+
+**Variants:**
+
+| Variant | Options | Default |
+|---------|---------|---------|
+| `size` | `sm`, `md`, `lg` | `md` |
+
+### `useOtpCellRecipe(s, options?)`
+
+Creates the OTP cell recipe &mdash; the `.otp-cell` native `<input>` that owns the surface color, style, square size, centered text, and the invalid / disabled / focus states. Accepts the same parameters as `useOtpRecipe`.
+
+**Variants:**
+
+| Variant | Options | Default |
+|---------|---------|---------|
+| `color` | `light`, `dark`, `neutral` | `neutral` |
+| `variant` | `default`, `soft`, `ghost` | `default` |
+| `size` | `sm`, `md`, `lg` | `md` |
+| `invalid` | `true`, `false` | `false` |
+| `disabled` | `true`, `false` | `false` |
+
+[Learn more about recipes &rarr;](/docs/api/recipes)
+
+## Best Practices
+
+- **Pass `size` to both parts**: Spread the same `size` to the container and the cells so the gap scales with the cell size.
+- **Use `neutral` for general forms**: The neutral color adapts to light and dark mode automatically, making it the safest default.
+- **Cap each cell at one character**: Set `maxlength="1"` and wire up auto-advance so focus moves to the next cell as the user types.
+- **Group and label the row**: Use `role="group"` and an `aria-label` so the cells are announced as a single control.
+- **Filter what you don't need**: If your forms use only the neutral color and default style, pass a `filter` option to reduce generated CSS.
+
+## FAQ
+
+::accordion
+
+:::accordion-item{label="Does this recipe handle focus advancing and paste?" icon="i-lucide-circle-help"}
+No &mdash; the recipe only styles the cells. Moving focus to the next cell as the user types, handling a pasted code across cells, and masking are interaction concerns you implement yourself or delegate to a headless component. Keeping behavior out of the recipe keeps it framework-agnostic and zero-runtime.
+:::
+
+:::accordion-item{label="Why is the color light/dark/neutral instead of primary/success/error?" icon="i-lucide-circle-help"}
+The `color` axis controls the cell surface, which reflects the form's surface rather than a status. This mirrors the [Input](/docs/components/forms/input) recipe's color model. For an error state, use the `invalid` state, which switches the border and focus ring to `@color.error`.
+:::
+
+:::accordion-item{label="How is the OTP cell related to the Input recipe?" icon="i-lucide-circle-help"}
+The cell shares the Input recipe's color / style / state surface through an internal helper, so the two stay visually consistent. The difference is structural: an Input wraps a transparent field and uses a `:focus-within` ring, while each OTP cell *is* the focusable `<input>` and uses a `:focus-visible` ring.
+:::
+
+:::accordion-item{label="How do I render a fixed number of cells?" icon="i-lucide-circle-help"}
+Render one `<input>` per character &mdash; iterate over a `length` (e.g. `v-for="i in length"` in Vue or `Array.from({ length })` in React) and apply the `otpCell()` class to each. The `otp()` container handles the row layout and spacing.
+:::
+
+:::accordion-item{label="How does filtering affect the recipe?" icon="i-lucide-circle-help"}
+When you use the `filter` option, compound variants that reference filtered-out colors or styles are automatically removed, and default variants are adjusted if they reference a removed value &mdash; so the recipe stays consistent and only emits the CSS you use.
+:::
+
+::

--- a/apps/storybook/src/components/components/otp/Otp.vue
+++ b/apps/storybook/src/components/components/otp/Otp.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { otp, otpCell } from "virtual:styleframe";
+
+const props = withDefaults(
+	defineProps<{
+		color?: "light" | "dark" | "neutral";
+		variant?: "default" | "soft" | "ghost";
+		size?: "sm" | "md" | "lg";
+		invalid?: boolean;
+		disabled?: boolean;
+		length?: number;
+		value?: string;
+		placeholder?: string;
+	}>(),
+	{
+		variant: "default",
+		size: "md",
+		length: 6,
+		value: "",
+		placeholder: "",
+	},
+);
+
+const containerClasses = computed(() => otp({ size: props.size }));
+
+const cellClasses = computed(() =>
+	otpCell({
+		color: props.color,
+		variant: props.variant,
+		size: props.size,
+		invalid: props.invalid ? "true" : "false",
+		disabled: props.disabled ? "true" : "false",
+	}),
+);
+
+const characters = computed(() =>
+	Array.from({ length: props.length }, (_, index) => props.value[index] ?? ""),
+);
+</script>
+
+<template>
+	<div :class="containerClasses" role="group" aria-label="One-time password">
+		<input
+			v-for="(char, index) in characters"
+			:key="index"
+			:class="cellClasses"
+			type="text"
+			inputmode="numeric"
+			autocomplete="one-time-code"
+			maxlength="1"
+			:value="char"
+			:placeholder="placeholder"
+			:disabled="disabled"
+			:aria-invalid="invalid || undefined"
+		/>
+	</div>
+</template>

--- a/apps/storybook/src/components/components/otp/preview/OtpGrid.vue
+++ b/apps/storybook/src/components/components/otp/preview/OtpGrid.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import Otp from "../Otp.vue";
+
+const variants = ["default", "soft", "ghost"] as const;
+const colors = ["neutral", "light", "dark"] as const;
+</script>
+
+<template>
+	<div class="otp-section">
+		<div v-for="variant in variants" :key="variant">
+			<div class="otp-label">{{ variant }}</div>
+			<div class="otp-row">
+				<div v-for="color in colors" :key="`${variant}-${color}`">
+					<div class="otp-caption">{{ color }}</div>
+					<Otp
+						:color="color"
+						:variant="variant"
+						:length="4"
+						value="12"
+					/>
+				</div>
+			</div>
+		</div>
+	</div>
+</template>

--- a/apps/storybook/src/components/components/otp/preview/OtpSizeGrid.vue
+++ b/apps/storybook/src/components/components/otp/preview/OtpSizeGrid.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+import Otp from "../Otp.vue";
+
+const sizes = ["sm", "md", "lg"] as const;
+const sizeTitles: Record<string, string> = {
+	sm: "Small",
+	md: "Medium",
+	lg: "Large",
+};
+</script>
+
+<template>
+	<div class="otp-section">
+		<div v-for="size in sizes" :key="size">
+			<div class="otp-label">{{ sizeTitles[size] }}</div>
+			<div class="otp-row">
+				<Otp :size="size" :length="4" value="12" />
+			</div>
+		</div>
+	</div>
+</template>

--- a/apps/storybook/stories/components/otp.stories.ts
+++ b/apps/storybook/stories/components/otp.stories.ts
@@ -1,0 +1,126 @@
+import type { Meta, StoryObj } from "@storybook/vue3-vite";
+
+import Otp from "@/components/components/otp/Otp.vue";
+import OtpGrid from "@/components/components/otp/preview/OtpGrid.vue";
+import OtpSizeGrid from "@/components/components/otp/preview/OtpSizeGrid.vue";
+
+const colors = ["neutral", "light", "dark"] as const;
+const variants = ["default", "soft", "ghost"] as const;
+const sizes = ["sm", "md", "lg"] as const;
+
+const meta = {
+	title: "Theme/Recipes/Forms/Otp",
+	component: Otp,
+	tags: ["autodocs"],
+	parameters: {
+		layout: "padded",
+	},
+	argTypes: {
+		color: {
+			control: "select",
+			options: colors,
+			description: "The color of the cell surface",
+		},
+		variant: {
+			control: "select",
+			options: variants,
+			description: "The visual style of the cells",
+		},
+		size: {
+			control: "select",
+			options: sizes,
+			description: "The size of the cells",
+		},
+		invalid: {
+			control: "boolean",
+			description: "Whether the input is in an invalid state",
+		},
+		disabled: {
+			control: "boolean",
+			description: "Whether the input is disabled",
+		},
+		length: {
+			control: "number",
+			description: "The number of cells",
+		},
+		value: {
+			control: "text",
+			description: "The current value (one character per cell)",
+		},
+	},
+} satisfies Meta<typeof Otp>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {
+		color: "neutral",
+		variant: "default",
+		size: "md",
+		length: 6,
+		value: "",
+	},
+};
+
+export const AllVariants: StoryObj = {
+	render: () => ({
+		components: { OtpGrid },
+		template: "<OtpGrid />",
+	}),
+};
+
+export const AllSizes: StoryObj = {
+	render: () => ({
+		components: { OtpSizeGrid },
+		template: "<OtpSizeGrid />",
+	}),
+};
+
+// Colors
+export const Neutral: Story = {
+	args: { color: "neutral", length: 4, value: "12" },
+};
+
+export const Light: Story = {
+	args: { color: "light", length: 4, value: "12" },
+};
+
+export const Dark: Story = {
+	args: { color: "dark", length: 4, value: "12" },
+};
+
+// Variants
+export const Soft: Story = {
+	args: { variant: "soft", length: 4, value: "12" },
+};
+
+export const Ghost: Story = {
+	args: { variant: "ghost", length: 4, value: "12" },
+};
+
+// States
+export const Filled: Story = {
+	args: { length: 6, value: "123456" },
+};
+
+export const Invalid: Story = {
+	args: { invalid: true, length: 4, value: "12" },
+};
+
+export const Disabled: Story = {
+	args: { disabled: true, length: 4, value: "12" },
+};
+
+// Sizes
+export const Small: Story = {
+	args: { size: "sm", length: 4, value: "12" },
+};
+
+export const Medium: Story = {
+	args: { size: "md", length: 4, value: "12" },
+};
+
+export const Large: Story = {
+	args: { size: "lg", length: 4, value: "12" },
+};

--- a/apps/storybook/stories/components/otp.styleframe.ts
+++ b/apps/storybook/stories/components/otp.styleframe.ts
@@ -1,0 +1,47 @@
+import { useOtpRecipe, useOtpCellRecipe } from "@styleframe/theme";
+import { styleframe } from "virtual:styleframe";
+
+const s = styleframe();
+const { selector } = s;
+
+// Initialize otp recipes
+export const otp = useOtpRecipe(s);
+export const otpCell = useOtpCellRecipe(s);
+
+// Container styles for story layout
+selector(".otp-grid", {
+	display: "flex",
+	flexWrap: "wrap",
+	gap: "@spacing.md",
+	padding: "@spacing.md",
+	alignItems: "flex-start",
+});
+
+selector(".otp-section", {
+	display: "flex",
+	flexDirection: "column",
+	gap: "@spacing.lg",
+	padding: "@spacing.md",
+});
+
+selector(".otp-row", {
+	display: "flex",
+	flexWrap: "wrap",
+	gap: "@spacing.lg",
+	alignItems: "flex-start",
+});
+
+selector(".otp-label", {
+	fontSize: "@font-size.sm",
+	fontWeight: "@font-weight.semibold",
+	marginBottom: "@spacing.sm",
+});
+
+selector(".otp-caption", {
+	fontSize: "@font-size.xs",
+	fontWeight: "@font-weight.normal",
+	color: "@color.text-weak",
+	marginBottom: "@spacing.sm",
+});
+
+export default s;

--- a/theme/src/recipes/index.ts
+++ b/theme/src/recipes/index.ts
@@ -14,6 +14,7 @@ export * from "./media";
 export * from "./spinner";
 export * from "./modal";
 export * from "./nav";
+export * from "./otp";
 export * from "./page-hero";
 export * from "./pagination";
 export * from "./placeholder";

--- a/theme/src/recipes/input/createFieldRecipe.ts
+++ b/theme/src/recipes/input/createFieldRecipe.ts
@@ -5,6 +5,235 @@ import {
 } from "../../utils/createUseRecipe";
 
 /**
+ * The shared field surface as a compound-variant array: the nine color×variant
+ * combinations plus the `invalid` and `disabled` state overrides, and
+ * optionally the `readonly` state. Extracted so sibling recipes can paint the
+ * exact same surface without re-declaring it — the Input/Textarea wrappers
+ * consume it with the `:focus-within` ring and the read-only state, while the
+ * OTP cell consumes it directly on the `<input>` with a `:focus-visible` ring
+ * and no read-only state.
+ *
+ * Order matters: `invalid` precedes `readonly`/`disabled` so its error border
+ * wins over the color/variant rules but can still be dimmed by the disabled
+ * state. Like the builders below, it is intentionally not re-exported from the
+ * package barrel — it is internal to the field recipes family.
+ */
+export function fieldSurfaceCompoundVariants({
+	focusModifier = "focus-within",
+	includeReadonly = true,
+}: {
+	focusModifier?: "focus-within" | "focus-visible";
+	includeReadonly?: boolean;
+} = {}): NonNullable<RecipeConfig["compoundVariants"]> {
+	return [
+		// Light color (fixed across themes)
+		{
+			match: { color: "light", variant: "default" },
+			css: {
+				background: "@color.white",
+				borderColor: "@color.gray-200",
+				color: "@color.text",
+				"&:hover": {
+					borderColor: "@color.gray-300",
+				},
+				"&:dark": {
+					background: "@color.white",
+					borderColor: "@color.gray-200",
+					color: "@color.text-inverted",
+				},
+				"&:dark:hover": {
+					borderColor: "@color.gray-300",
+				},
+			},
+		},
+		{
+			match: { color: "light", variant: "soft" },
+			css: {
+				background: "@color.gray-100",
+				borderColor: "@color.gray-200",
+				color: "@color.text",
+				"&:hover": {
+					borderColor: "@color.gray-300",
+				},
+				"&:dark": {
+					background: "@color.gray-100",
+					borderColor: "@color.gray-200",
+					color: "@color.text-inverted",
+				},
+				"&:dark:hover": {
+					borderColor: "@color.gray-300",
+				},
+			},
+		},
+		{
+			match: { color: "light", variant: "ghost" },
+			css: {
+				background: "transparent",
+				borderColor: "transparent",
+				color: "@color.text",
+				"&:dark": {
+					background: "transparent",
+					borderColor: "transparent",
+					color: "@color.text-inverted",
+				},
+			},
+		},
+
+		// Dark color (fixed across themes)
+		{
+			match: { color: "dark", variant: "default" },
+			css: {
+				background: "@color.gray-900",
+				borderColor: "@color.gray-700",
+				color: "@color.white",
+				"&:hover": {
+					borderColor: "@color.gray-600",
+				},
+				"&:dark": {
+					background: "@color.gray-900",
+					borderColor: "@color.gray-700",
+					color: "@color.white",
+				},
+				"&:dark:hover": {
+					borderColor: "@color.gray-600",
+				},
+			},
+		},
+		{
+			match: { color: "dark", variant: "soft" },
+			css: {
+				background: "@color.gray-800",
+				borderColor: "@color.gray-700",
+				color: "@color.gray-300",
+				"&:hover": {
+					borderColor: "@color.gray-600",
+				},
+				"&:dark": {
+					background: "@color.gray-800",
+					borderColor: "@color.gray-700",
+					color: "@color.gray-300",
+				},
+				"&:dark:hover": {
+					borderColor: "@color.gray-600",
+				},
+			},
+		},
+		{
+			match: { color: "dark", variant: "ghost" },
+			css: {
+				background: "transparent",
+				borderColor: "transparent",
+				color: "@color.gray-300",
+				"&:dark": {
+					background: "transparent",
+					borderColor: "transparent",
+					color: "@color.gray-300",
+				},
+			},
+		},
+
+		// Neutral color (adaptive: light in light mode, dark in dark mode)
+		{
+			match: { color: "neutral", variant: "default" },
+			css: {
+				background: "@color.white",
+				borderColor: "@color.gray-200",
+				color: "@color.text",
+				"&:hover": {
+					borderColor: "@color.gray-300",
+				},
+				"&:dark": {
+					background: "@color.gray-900",
+					borderColor: "@color.gray-700",
+					color: "@color.white",
+				},
+				"&:dark:hover": {
+					borderColor: "@color.gray-600",
+				},
+			},
+		},
+		{
+			match: { color: "neutral", variant: "soft" },
+			css: {
+				background: "@color.gray-100",
+				borderColor: "@color.gray-200",
+				color: "@color.text",
+				"&:hover": {
+					borderColor: "@color.gray-300",
+				},
+				"&:dark": {
+					background: "@color.gray-800",
+					borderColor: "@color.gray-700",
+					color: "@color.gray-300",
+				},
+				"&:dark:hover": {
+					borderColor: "@color.gray-600",
+				},
+			},
+		},
+		{
+			match: { color: "neutral", variant: "ghost" },
+			css: {
+				background: "transparent",
+				borderColor: "transparent",
+				color: "@color.text",
+				"&:dark": {
+					background: "transparent",
+					borderColor: "transparent",
+					color: "@color.white",
+				},
+			},
+		},
+
+		// Invalid state — overrides border and focus ring to error color.
+		{
+			match: { invalid: "true" },
+			css: {
+				borderColor: "@color.error",
+				"&:hover": {
+					borderColor: "@color.error",
+				},
+				[`&:${focusModifier}`]: {
+					outlineColor: "@color.error",
+				},
+				"&:dark": {
+					borderColor: "@color.error",
+				},
+				"&:dark:hover": {
+					borderColor: "@color.error",
+				},
+			},
+		},
+
+		// Read-only state — subtle background shift, default cursor.
+		...(includeReadonly
+			? [
+					{
+						match: { readonly: "true" },
+						css: {
+							background: "@color.gray-50",
+							cursor: "default",
+							"&:dark": {
+								background: "@color.gray-800",
+							},
+						},
+					},
+				]
+			: []),
+
+		// Disabled state — dim, not-allowed cursor, block interaction.
+		{
+			match: { disabled: "true" },
+			css: {
+				opacity: "0.5",
+				cursor: "not-allowed",
+				pointerEvents: "none",
+			},
+		},
+	];
+}
+
+/**
  * Builds a field-wrapper recipe (`.input` / `.textarea`). Merges the shared
  * field surface with per-field `extras` (e.g. the `display`/`alignItems` base
  * deltas, or textarea's `resize` axis) and registers the transparent nested
@@ -129,211 +358,11 @@ export function createFieldRecipe<
 			} as typeof fieldRecipeVariants & ExtraVariants,
 			/**
 			 * The 12 compound variants: 9 color×variant combinations plus the invalid,
-			 * read-only, and disabled state overrides. Order matters &mdash; invalid is
-			 * placed before read-only and disabled so its error border wins over the
-			 * color/variant rules but can still be dimmed by the disabled state.
+			 * read-only, and disabled state overrides, from the shared field surface
+			 * (`:focus-within` ring, read-only included), then any per-field extras.
 			 */
 			compoundVariants: [
-				// Light color (fixed across themes)
-				{
-					match: { color: "light", variant: "default" },
-					css: {
-						background: "@color.white",
-						borderColor: "@color.gray-200",
-						color: "@color.text",
-						"&:hover": {
-							borderColor: "@color.gray-300",
-						},
-						"&:dark": {
-							background: "@color.white",
-							borderColor: "@color.gray-200",
-							color: "@color.text-inverted",
-						},
-						"&:dark:hover": {
-							borderColor: "@color.gray-300",
-						},
-					},
-				},
-				{
-					match: { color: "light", variant: "soft" },
-					css: {
-						background: "@color.gray-100",
-						borderColor: "@color.gray-200",
-						color: "@color.text",
-						"&:hover": {
-							borderColor: "@color.gray-300",
-						},
-						"&:dark": {
-							background: "@color.gray-100",
-							borderColor: "@color.gray-200",
-							color: "@color.text-inverted",
-						},
-						"&:dark:hover": {
-							borderColor: "@color.gray-300",
-						},
-					},
-				},
-				{
-					match: { color: "light", variant: "ghost" },
-					css: {
-						background: "transparent",
-						borderColor: "transparent",
-						color: "@color.text",
-						"&:dark": {
-							background: "transparent",
-							borderColor: "transparent",
-							color: "@color.text-inverted",
-						},
-					},
-				},
-
-				// Dark color (fixed across themes)
-				{
-					match: { color: "dark", variant: "default" },
-					css: {
-						background: "@color.gray-900",
-						borderColor: "@color.gray-700",
-						color: "@color.white",
-						"&:hover": {
-							borderColor: "@color.gray-600",
-						},
-						"&:dark": {
-							background: "@color.gray-900",
-							borderColor: "@color.gray-700",
-							color: "@color.white",
-						},
-						"&:dark:hover": {
-							borderColor: "@color.gray-600",
-						},
-					},
-				},
-				{
-					match: { color: "dark", variant: "soft" },
-					css: {
-						background: "@color.gray-800",
-						borderColor: "@color.gray-700",
-						color: "@color.gray-300",
-						"&:hover": {
-							borderColor: "@color.gray-600",
-						},
-						"&:dark": {
-							background: "@color.gray-800",
-							borderColor: "@color.gray-700",
-							color: "@color.gray-300",
-						},
-						"&:dark:hover": {
-							borderColor: "@color.gray-600",
-						},
-					},
-				},
-				{
-					match: { color: "dark", variant: "ghost" },
-					css: {
-						background: "transparent",
-						borderColor: "transparent",
-						color: "@color.gray-300",
-						"&:dark": {
-							background: "transparent",
-							borderColor: "transparent",
-							color: "@color.gray-300",
-						},
-					},
-				},
-
-				// Neutral color (adaptive: light in light mode, dark in dark mode)
-				{
-					match: { color: "neutral", variant: "default" },
-					css: {
-						background: "@color.white",
-						borderColor: "@color.gray-200",
-						color: "@color.text",
-						"&:hover": {
-							borderColor: "@color.gray-300",
-						},
-						"&:dark": {
-							background: "@color.gray-900",
-							borderColor: "@color.gray-700",
-							color: "@color.white",
-						},
-						"&:dark:hover": {
-							borderColor: "@color.gray-600",
-						},
-					},
-				},
-				{
-					match: { color: "neutral", variant: "soft" },
-					css: {
-						background: "@color.gray-100",
-						borderColor: "@color.gray-200",
-						color: "@color.text",
-						"&:hover": {
-							borderColor: "@color.gray-300",
-						},
-						"&:dark": {
-							background: "@color.gray-800",
-							borderColor: "@color.gray-700",
-							color: "@color.gray-300",
-						},
-						"&:dark:hover": {
-							borderColor: "@color.gray-600",
-						},
-					},
-				},
-				{
-					match: { color: "neutral", variant: "ghost" },
-					css: {
-						background: "transparent",
-						borderColor: "transparent",
-						color: "@color.text",
-						"&:dark": {
-							background: "transparent",
-							borderColor: "transparent",
-							color: "@color.white",
-						},
-					},
-				},
-
-				// Invalid state — overrides border and focus ring to error color.
-				{
-					match: { invalid: "true" },
-					css: {
-						borderColor: "@color.error",
-						"&:hover": {
-							borderColor: "@color.error",
-						},
-						"&:focus-within": {
-							outlineColor: "@color.error",
-						},
-						"&:dark": {
-							borderColor: "@color.error",
-						},
-						"&:dark:hover": {
-							borderColor: "@color.error",
-						},
-					},
-				},
-
-				// Read-only state — subtle background shift, default cursor.
-				{
-					match: { readonly: "true" },
-					css: {
-						background: "@color.gray-50",
-						cursor: "default",
-						"&:dark": {
-							background: "@color.gray-800",
-						},
-					},
-				},
-
-				// Disabled state — dim, not-allowed cursor, block interaction.
-				{
-					match: { disabled: "true" },
-					css: {
-						opacity: "0.5",
-						cursor: "not-allowed",
-						pointerEvents: "none",
-					},
-				},
+				...fieldSurfaceCompoundVariants(),
 				...(extras.compoundVariants ?? []),
 			],
 			/** Shared default selections (everything except textarea's `resize`). */

--- a/theme/src/recipes/otp/index.ts
+++ b/theme/src/recipes/otp/index.ts
@@ -1,0 +1,2 @@
+export * from "./useOtpRecipe";
+export * from "./useOtpCellRecipe";

--- a/theme/src/recipes/otp/useOtpCellRecipe.test.ts
+++ b/theme/src/recipes/otp/useOtpCellRecipe.test.ts
@@ -1,0 +1,305 @@
+import { styleframe } from "@styleframe/core";
+import { useDarkModifier } from "../../modifiers/useMediaPreferenceModifiers";
+import {
+	useFocusVisibleModifier,
+	useHoverModifier,
+} from "../../modifiers/usePseudoStateModifiers";
+import { useOtpCellRecipe } from "./useOtpCellRecipe";
+
+function createInstance() {
+	const s = styleframe();
+	for (const name of [
+		"boxSizing",
+		"textAlign",
+		"padding",
+		"fontFamily",
+		"fontWeight",
+		"lineHeight",
+		"borderWidth",
+		"borderStyle",
+		"borderColor",
+		"borderRadius",
+		"width",
+		"height",
+		"fontSize",
+		"background",
+		"color",
+		"outline",
+		"outlineWidth",
+		"outlineStyle",
+		"outlineColor",
+		"outlineOffset",
+		"cursor",
+		"opacity",
+		"pointerEvents",
+		"transitionProperty",
+		"transitionTimingFunction",
+		"transitionDuration",
+	]) {
+		s.utility(name, ({ value }) => ({ [name]: value }));
+	}
+	useDarkModifier(s);
+	useHoverModifier(s);
+	useFocusVisibleModifier(s);
+	return s;
+}
+
+describe("useOtpCellRecipe", () => {
+	it("should create a recipe with correct metadata", () => {
+		const s = createInstance();
+		const recipe = useOtpCellRecipe(s);
+
+		expect(recipe.type).toBe("recipe");
+		expect(recipe.name).toBe("otp-cell");
+	});
+
+	it("should have correct base styles with centered text and a focus-visible ring", () => {
+		const s = createInstance();
+		const recipe = useOtpCellRecipe(s);
+
+		expect(recipe.base).toEqual({
+			boxSizing: "border-box",
+			textAlign: "center",
+			padding: "0",
+			fontFamily: "inherit",
+			fontWeight: "@font-weight.medium",
+			lineHeight: "@line-height.normal",
+			borderWidth: "@border-width.thin",
+			borderStyle: "@border-style.solid",
+			borderColor: "transparent",
+			background: "transparent",
+			color: "@color.text",
+			outline: "none",
+			transitionProperty: "color, background-color, border-color",
+			transitionTimingFunction: "@easing.ease-in-out",
+			transitionDuration: "150ms",
+			"&:focus-visible": {
+				outlineWidth: "2px",
+				outlineStyle: "solid",
+				outlineColor: "@color.primary",
+				outlineOffset: "2px",
+			},
+		});
+	});
+
+	describe("variants", () => {
+		it("should have all color variants", () => {
+			const s = createInstance();
+			const recipe = useOtpCellRecipe(s);
+
+			expect(Object.keys(recipe.variants!.color)).toEqual([
+				"light",
+				"dark",
+				"neutral",
+			]);
+		});
+
+		it("should have all style variants", () => {
+			const s = createInstance();
+			const recipe = useOtpCellRecipe(s);
+
+			expect(Object.keys(recipe.variants!.variant)).toEqual([
+				"default",
+				"soft",
+				"ghost",
+			]);
+		});
+
+		it("should have square size variants with scaled font and radius", () => {
+			const s = createInstance();
+			const recipe = useOtpCellRecipe(s);
+
+			expect(recipe.variants!.size).toEqual({
+				sm: {
+					width: "40px",
+					height: "40px",
+					fontSize: "@font-size.sm",
+					borderRadius: "@border-radius.sm",
+				},
+				md: {
+					width: "48px",
+					height: "48px",
+					fontSize: "@font-size.md",
+					borderRadius: "@border-radius.md",
+				},
+				lg: {
+					width: "56px",
+					height: "56px",
+					fontSize: "@font-size.lg",
+					borderRadius: "@border-radius.md",
+				},
+			});
+		});
+
+		it("should have invalid boolean variants", () => {
+			const s = createInstance();
+			const recipe = useOtpCellRecipe(s);
+
+			expect(recipe.variants!.invalid).toEqual({
+				true: {},
+				false: {},
+			});
+		});
+
+		it("should have disabled boolean variants", () => {
+			const s = createInstance();
+			const recipe = useOtpCellRecipe(s);
+
+			expect(recipe.variants!.disabled).toEqual({
+				true: {},
+				false: {},
+			});
+		});
+
+		it("should not declare a readonly axis", () => {
+			const s = createInstance();
+			const recipe = useOtpCellRecipe(s);
+
+			expect(recipe.variants).not.toHaveProperty("readonly");
+		});
+	});
+
+	it("should have correct default variants", () => {
+		const s = createInstance();
+		const recipe = useOtpCellRecipe(s);
+
+		expect(recipe.defaultVariants).toEqual({
+			color: "neutral",
+			variant: "default",
+			size: "md",
+			invalid: "false",
+			disabled: "false",
+		});
+	});
+
+	describe("compound variants", () => {
+		it("should have 11 compound variants total (9 color×variant + invalid + disabled)", () => {
+			const s = createInstance();
+			const recipe = useOtpCellRecipe(s);
+
+			expect(recipe.compoundVariants).toHaveLength(11);
+		});
+
+		it("should share the neutral default surface with the input recipe", () => {
+			const s = createInstance();
+			const recipe = useOtpCellRecipe(s);
+
+			const cv = recipe.compoundVariants!.find(
+				(v) => v.match.color === "neutral" && v.match.variant === "default",
+			);
+
+			expect(cv).toEqual({
+				match: { color: "neutral", variant: "default" },
+				css: {
+					background: "@color.white",
+					borderColor: "@color.gray-200",
+					color: "@color.text",
+					"&:hover": {
+						borderColor: "@color.gray-300",
+					},
+					"&:dark": {
+						background: "@color.gray-900",
+						borderColor: "@color.gray-700",
+						color: "@color.white",
+					},
+					"&:dark:hover": {
+						borderColor: "@color.gray-600",
+					},
+				},
+			});
+		});
+
+		it("should override the focus-visible ring (not focus-within) when invalid", () => {
+			const s = createInstance();
+			const recipe = useOtpCellRecipe(s);
+
+			const cv = recipe.compoundVariants!.find(
+				(v) => v.match.invalid === "true",
+			);
+
+			expect(cv).toEqual({
+				match: { invalid: "true" },
+				css: {
+					borderColor: "@color.error",
+					"&:hover": {
+						borderColor: "@color.error",
+					},
+					"&:focus-visible": {
+						outlineColor: "@color.error",
+					},
+					"&:dark": {
+						borderColor: "@color.error",
+					},
+					"&:dark:hover": {
+						borderColor: "@color.error",
+					},
+				},
+			});
+		});
+
+		it("should not include a readonly compound variant", () => {
+			const s = createInstance();
+			const recipe = useOtpCellRecipe(s);
+
+			const cv = recipe.compoundVariants!.find(
+				(v) => (v.match as Record<string, unknown>).readonly === "true",
+			);
+
+			expect(cv).toBeUndefined();
+		});
+
+		it("should dim and block interaction when disabled", () => {
+			const s = createInstance();
+			const recipe = useOtpCellRecipe(s);
+
+			const cv = recipe.compoundVariants!.find(
+				(v) => v.match.disabled === "true",
+			);
+
+			expect(cv).toEqual({
+				match: { disabled: "true" },
+				css: {
+					opacity: "0.5",
+					cursor: "not-allowed",
+					pointerEvents: "none",
+				},
+			});
+		});
+	});
+
+	describe("config overrides", () => {
+		it("should allow overriding base styles", () => {
+			const s = createInstance();
+			const recipe = useOtpCellRecipe(s, {
+				base: { textAlign: "left" },
+			});
+
+			expect(recipe.base!.textAlign).toBe("left");
+		});
+	});
+
+	describe("filter", () => {
+		it("should filter color variants", () => {
+			const s = createInstance();
+			const recipe = useOtpCellRecipe(s, {
+				filter: { color: ["neutral"] },
+			});
+
+			expect(Object.keys(recipe.variants!.color)).toEqual(["neutral"]);
+		});
+
+		it("should prune color-scoped compound variants when filtering colors", () => {
+			const s = createInstance();
+			const recipe = useOtpCellRecipe(s, {
+				filter: { color: ["neutral"] },
+			});
+
+			expect(
+				recipe.compoundVariants!.every(
+					(cv) => cv.match.color === undefined || cv.match.color === "neutral",
+				),
+			).toBe(true);
+			expect(recipe.compoundVariants!.length).toBeLessThan(11);
+		});
+	});
+});

--- a/theme/src/recipes/otp/useOtpCellRecipe.ts
+++ b/theme/src/recipes/otp/useOtpCellRecipe.ts
@@ -1,0 +1,94 @@
+import { createUseRecipe } from "../../utils/createUseRecipe";
+import { fieldSurfaceCompoundVariants } from "../input/createFieldRecipe";
+
+/**
+ * OTP / pin-input cell recipe. The `.otp-cell` class sits directly on each
+ * native single-character `<input>` (like `checkbox-field`, and unlike the
+ * `input` wrapper which nests a transparent control). The input *is* the styled
+ * cell: a fixed square with centered text and a `:focus-visible` ring.
+ *
+ * Shares the exact color/variant/state surface as the `input` recipe via
+ * `fieldSurfaceCompoundVariants` — colors `light` / `dark` / `neutral`, variants
+ * `default` / `soft` / `ghost`, and the `invalid` / `disabled` states. Because
+ * the cell is the focusable element itself, the surface is consumed with a
+ * `:focus-visible` ring (not `:focus-within`) and no read-only state.
+ *
+ * Focus advancing, paste handling, and masking are behavior owned by the
+ * consumer; this recipe only supplies the visual styling for each cell.
+ */
+export const useOtpCellRecipe = createUseRecipe("otp-cell", {
+	base: {
+		boxSizing: "border-box",
+		textAlign: "center",
+		padding: "0",
+		fontFamily: "inherit",
+		fontWeight: "@font-weight.medium",
+		lineHeight: "@line-height.normal",
+		borderWidth: "@border-width.thin",
+		borderStyle: "@border-style.solid",
+		borderColor: "transparent",
+		background: "transparent",
+		color: "@color.text",
+		outline: "none",
+		transitionProperty: "color, background-color, border-color",
+		transitionTimingFunction: "@easing.ease-in-out",
+		transitionDuration: "150ms",
+		"&:focus-visible": {
+			outlineWidth: "2px",
+			outlineStyle: "solid",
+			outlineColor: "@color.primary",
+			outlineOffset: "2px",
+		},
+	},
+	variants: {
+		color: {
+			light: {},
+			dark: {},
+			neutral: {},
+		},
+		variant: {
+			default: {},
+			soft: {},
+			ghost: {},
+		},
+		size: {
+			sm: {
+				width: "40px",
+				height: "40px",
+				fontSize: "@font-size.sm",
+				borderRadius: "@border-radius.sm",
+			},
+			md: {
+				width: "48px",
+				height: "48px",
+				fontSize: "@font-size.md",
+				borderRadius: "@border-radius.md",
+			},
+			lg: {
+				width: "56px",
+				height: "56px",
+				fontSize: "@font-size.lg",
+				borderRadius: "@border-radius.md",
+			},
+		},
+		invalid: {
+			true: {},
+			false: {},
+		},
+		disabled: {
+			true: {},
+			false: {},
+		},
+	},
+	compoundVariants: fieldSurfaceCompoundVariants({
+		focusModifier: "focus-visible",
+		includeReadonly: false,
+	}),
+	defaultVariants: {
+		color: "neutral",
+		variant: "default",
+		size: "md",
+		invalid: "false",
+		disabled: "false",
+	},
+});

--- a/theme/src/recipes/otp/useOtpRecipe.test.ts
+++ b/theme/src/recipes/otp/useOtpRecipe.test.ts
@@ -1,0 +1,80 @@
+import { styleframe } from "@styleframe/core";
+import { useOtpRecipe } from "./useOtpRecipe";
+
+function createInstance() {
+	const s = styleframe();
+	for (const name of ["display", "alignItems", "gap"]) {
+		s.utility(name, ({ value }) => ({ [name]: value }));
+	}
+	return s;
+}
+
+describe("useOtpRecipe", () => {
+	it("should create a recipe with correct metadata", () => {
+		const s = createInstance();
+		const recipe = useOtpRecipe(s);
+
+		expect(recipe.type).toBe("recipe");
+		expect(recipe.name).toBe("otp");
+	});
+
+	it("should have correct base styles", () => {
+		const s = createInstance();
+		const recipe = useOtpRecipe(s);
+
+		expect(recipe.base).toEqual({
+			display: "inline-flex",
+			alignItems: "center",
+		});
+	});
+
+	it("should have size variants that scale the gap", () => {
+		const s = createInstance();
+		const recipe = useOtpRecipe(s);
+
+		expect(recipe.variants!.size).toEqual({
+			sm: { gap: "@0.5" },
+			md: { gap: "@0.75" },
+			lg: { gap: "@1" },
+		});
+	});
+
+	it("should have correct default variants", () => {
+		const s = createInstance();
+		const recipe = useOtpRecipe(s);
+
+		expect(recipe.defaultVariants).toEqual({
+			size: "md",
+		});
+	});
+
+	it("should not declare a color or variant axis", () => {
+		const s = createInstance();
+		const recipe = useOtpRecipe(s);
+
+		expect(recipe.variants).not.toHaveProperty("color");
+		expect(recipe.variants).not.toHaveProperty("variant");
+	});
+
+	describe("config overrides", () => {
+		it("should allow overriding base styles", () => {
+			const s = createInstance();
+			const recipe = useOtpRecipe(s, {
+				base: { display: "flex" },
+			});
+
+			expect(recipe.base!.display).toBe("flex");
+		});
+	});
+
+	describe("filter", () => {
+		it("should filter size variants", () => {
+			const s = createInstance();
+			const recipe = useOtpRecipe(s, {
+				filter: { size: ["md"] },
+			});
+
+			expect(Object.keys(recipe.variants!.size)).toEqual(["md"]);
+		});
+	});
+});

--- a/theme/src/recipes/otp/useOtpRecipe.ts
+++ b/theme/src/recipes/otp/useOtpRecipe.ts
@@ -1,0 +1,33 @@
+import { createUseRecipe } from "../../utils/createUseRecipe";
+
+/**
+ * OTP / pin-input container recipe. The `.otp` class sits on the wrapper that
+ * lays out the row of single-character `.otp-cell` inputs. It owns only the
+ * layout — a horizontal flex row whose `size` axis scales the gap between
+ * cells so it tracks the cell size — mirroring `useCheckboxGroupRecipe`.
+ *
+ * All surface styling (color, variant, state) lives on the cell
+ * (`useOtpCellRecipe`); this recipe carries no color or variant axis.
+ */
+export const useOtpRecipe = createUseRecipe("otp", {
+	base: {
+		display: "inline-flex",
+		alignItems: "center",
+	},
+	variants: {
+		size: {
+			sm: {
+				gap: "@0.5",
+			},
+			md: {
+				gap: "@0.75",
+			},
+			lg: {
+				gap: "@1",
+			},
+		},
+	},
+	defaultVariants: {
+		size: "md",
+	},
+});


### PR DESCRIPTION
## Summary

- Adds `useOtpRecipe` and `useOtpCellRecipe` for one-time password input components, with full color × variant × size axes matching Input/Textarea parity
- Extracts `fieldSurfaceCompoundVariants()` from `createFieldRecipe` so OTP cells share the exact same color×variant surface without duplicating ~200 lines
- Adds Storybook showcase (grid + size grid previews) and full docs page at `05.components/05.forms/01.otp.md`

## Test plan

- [ ] `useOtpCellRecipe` and `useOtpRecipe` unit tests pass (`pnpm test` in `theme/`)
- [ ] Storybook shows OTP stories with all color/variant/size combinations
- [ ] Docs page renders correctly in the docs site