### PR TITLE
feat(theme): add fullscreen variant to modal recipes

### DIFF
--- a/.changeset/modal-fullscreen-variant.md
+++ b/.changeset/modal-fullscreen-variant.md
@@ -1,0 +1,8 @@
+---
+"@styleframe/theme": minor
+"styleframe": minor
+---
+
+Add fullscreen variant to modal and modal-body recipes.
+
+Adds a `fullscreen` boolean variant to `useModalRecipe` (fills the viewport with `width: 100%`, `height: 100%`, `max-width: none`, and `border-radius: 0`) and a matching variant to `useModalBodyRecipe` (`flex-grow: 1`) so the footer stays pinned to the bottom. Pass `fullscreen="true"` to both the container and the body to opt in.

--- a/apps/docs/content/docs/05.components/06.overlays/00.modal.md
+++ b/apps/docs/content/docs/05.components/06.overlays/00.modal.md
@@ -314,6 +314,21 @@ story: theme-recipes-overlays-modal--all-sizes
 **Good to know:** The `size` prop must be passed to each sub-recipe individually. The modal container controls the border radius, while the header, body, and footer control their own padding and gap.
 ::
 
+## Fullscreen
+
+Set the `fullscreen` prop to make the modal fill the entire viewport and square its corners &mdash; ideal for immersive content and full-screen workflows on smaller screens. It is independent of the `size` axis, so the header, body, and footer keep their usual padding.
+
+::story-preview
+---
+story: theme-recipes-overlays-modal--fullscreen
+panel: true
+---
+::
+
+::note
+**Good to know:** Pass `fullscreen` to both the container (`modal`) and the body (`modalBody`). The container fills the viewport and squares the corners, while the body grows to fill the available space so the footer stays pinned to the bottom.
+::
+
 ## Anatomy
 
 The Modal recipe is composed of five independent recipes that work together to form a dialog layout:
@@ -482,6 +497,7 @@ Creates the modal container recipe with background, border, border radius, and s
 | `color` | `light`, `dark`, `neutral` | `neutral` |
 | `variant` | `solid`, `soft`, `subtle` | `solid` |
 | `size` | `sm`, `md`, `lg` | `md` |
+| `fullscreen` | `true`, `false` | `false` |
 
 ### `useModalHeaderRecipe(s, options?)`
 
@@ -506,6 +522,7 @@ Creates the modal body recipe for the main content area. Accepts the same parame
 | `color` | `light`, `dark`, `neutral` | `neutral` |
 | `variant` | `solid`, `soft`, `subtle` | `solid` |
 | `size` | `sm`, `md`, `lg` | `md` |
+| `fullscreen` | `true`, `false` | `false` |
 
 ### `useModalFooterRecipe(s, options?)`
 

--- a/apps/storybook/src/components/components/modal/Modal.vue
+++ b/apps/storybook/src/components/components/modal/Modal.vue
@@ -7,6 +7,7 @@ const props = withDefaults(
 		color?: "light" | "dark" | "neutral";
 		variant?: "solid" | "soft" | "subtle";
 		size?: "sm" | "md" | "lg";
+		fullscreen?: boolean;
 	}>(),
 	{},
 );
@@ -16,6 +17,7 @@ const classes = computed(() =>
 		color: props.color,
 		variant: props.variant,
 		size: props.size,
+		fullscreen: props.fullscreen ? "true" : "false",
 	}),
 );
 </script>

--- a/apps/storybook/src/components/components/modal/ModalBody.vue
+++ b/apps/storybook/src/components/components/modal/ModalBody.vue
@@ -7,6 +7,7 @@ const props = withDefaults(
 		color?: "light" | "dark" | "neutral";
 		variant?: "solid" | "soft" | "subtle";
 		size?: "sm" | "md" | "lg";
+		fullscreen?: boolean;
 	}>(),
 	{},
 );
@@ -16,6 +17,7 @@ const classes = computed(() =>
 		color: props.color,
 		variant: props.variant,
 		size: props.size,
+		fullscreen: props.fullscreen ? "true" : "false",
 	}),
 );
 </script>

--- a/apps/storybook/stories/components/modal.stories.ts
+++ b/apps/storybook/stories/components/modal.stories.ts
@@ -39,6 +39,10 @@ const meta = {
 			options: sizes,
 			description: "The size of the modal",
 		},
+		fullscreen: {
+			control: "boolean",
+			description: "Fill the viewport and square the corners",
+		},
 	},
 	render: (args) => ({
 		components: {
@@ -176,11 +180,11 @@ export const Fullscreen: Story = {
 		template: `
 			<Button label="Open Fullscreen Modal" @click="isOpen = true" />
 			<ModalOverlay v-show="isOpen">
-				<Modal v-bind="args" style="width: 100vw; height: 100vh; max-width: 100vw; border-radius: 0;">
+				<Modal v-bind="args" :fullscreen="true">
 					<ModalHeader v-bind="args">
 						<ModalTitle>Fullscreen Modal</ModalTitle>
 					</ModalHeader>
-					<ModalBody v-bind="args" style="flex: 1;">
+					<ModalBody v-bind="args" :fullscreen="true">
 						<ModalDescription>This modal takes up the entire viewport.</ModalDescription>
 					</ModalBody>
 					<ModalFooter v-bind="args">

--- a/theme/src/recipes/modal/useModalBodyRecipe.test.ts
+++ b/theme/src/recipes/modal/useModalBodyRecipe.test.ts
@@ -24,6 +24,7 @@ function createInstance() {
 		"paddingLeft",
 		"paddingRight",
 		"gap",
+		"flexGrow",
 		"borderBottomWidth",
 		"borderBottomStyle",
 		"borderBottomColor",
@@ -90,6 +91,23 @@ describe("useModalBodyRecipe", () => {
 		});
 	});
 
+	it("should have fullscreen variant with true and false keys", () => {
+		const s = createInstance();
+		const recipe = useModalBodyRecipe(s);
+
+		expect(Object.keys(recipe.variants!.fullscreen)).toEqual(["true", "false"]);
+	});
+
+	it("should have correct fullscreen variant styles", () => {
+		const s = createInstance();
+		const recipe = useModalBodyRecipe(s);
+
+		expect(recipe.variants!.fullscreen).toEqual({
+			true: { flexGrow: "1" },
+			false: {},
+		});
+	});
+
 	it("should have correct default variants", () => {
 		const s = createInstance();
 		const recipe = useModalBodyRecipe(s);
@@ -98,6 +116,7 @@ describe("useModalBodyRecipe", () => {
 			color: "neutral",
 			variant: "solid",
 			size: "md",
+			fullscreen: "false",
 		});
 	});
 

--- a/theme/src/recipes/modal/useModalBodyRecipe.ts
+++ b/theme/src/recipes/modal/useModalBodyRecipe.ts
@@ -47,10 +47,15 @@ export const useModalBodyRecipe = createUseRecipe("modal-body", {
 				gap: "@0.75",
 			},
 		},
+		fullscreen: {
+			true: { flexGrow: "1" },
+			false: {},
+		},
 	},
 	defaultVariants: {
 		color: "neutral",
 		variant: "solid",
 		size: "md",
+		fullscreen: "false",
 	},
 });

--- a/theme/src/recipes/modal/useModalRecipe.test.ts
+++ b/theme/src/recipes/modal/useModalRecipe.test.ts
@@ -14,6 +14,9 @@ function createInstance() {
 		"borderColor",
 		"borderRadius",
 		"overflow",
+		"width",
+		"height",
+		"maxWidth",
 		"fontSize",
 		"lineHeight",
 		"boxShadow",
@@ -103,6 +106,31 @@ describe("useModalRecipe", () => {
 				},
 			});
 		});
+
+		it("should have fullscreen variant with true and false keys", () => {
+			const s = createInstance();
+			const recipe = useModalRecipe(s);
+
+			expect(Object.keys(recipe.variants!.fullscreen)).toEqual([
+				"true",
+				"false",
+			]);
+		});
+
+		it("should have correct fullscreen variant styles", () => {
+			const s = createInstance();
+			const recipe = useModalRecipe(s);
+
+			expect(recipe.variants!.fullscreen).toEqual({
+				true: {
+					width: "100%",
+					height: "100%",
+					maxWidth: "none",
+					borderRadius: "0",
+				},
+				false: {},
+			});
+		});
 	});
 
 	it("should have correct default variants", () => {
@@ -113,6 +141,7 @@ describe("useModalRecipe", () => {
 			color: "neutral",
 			variant: "solid",
 			size: "md",
+			fullscreen: "false",
 		});
 	});
 

--- a/theme/src/recipes/modal/useModalRecipe.ts
+++ b/theme/src/recipes/modal/useModalRecipe.ts
@@ -39,6 +39,15 @@ export const useModalRecipe = createUseRecipe("modal", {
 				borderRadius: "@border-radius.lg",
 			},
 		},
+		fullscreen: {
+			true: {
+				width: "100%",
+				height: "100%",
+				maxWidth: "none",
+				borderRadius: "0",
+			},
+			false: {},
+		},
 	},
 	compoundVariants: [
 		// Light color (neutral light-mode values, fixed across themes)
@@ -162,5 +171,6 @@ export const useModalRecipe = createUseRecipe("modal", {
 		color: "neutral",
 		variant: "solid",
 		size: "md",
+		fullscreen: "false",
 	},
 });


### PR DESCRIPTION
## Summary

- Adds a `fullscreen` variant to `useModalRecipe` — fills the viewport (`100%` width/height, `max-width: none`, `border-radius: 0`)
- Adds a matching `fullscreen` variant to `useModalBodyRecipe` — sets `flex-grow: 1` so the footer stays pinned to the bottom
- Updates the Storybook `Fullscreen` story to use `:fullscreen="true"` prop instead of inline styles, and exposes a `fullscreen` boolean control
- Documents the `fullscreen` variant in the modal docs page with a story preview and usage note

## Test plan

- [ ] `useModalRecipe` tests: fullscreen variant keys and styles pass
- [ ] `useModalBodyRecipe` tests: fullscreen variant keys, styles, and default variants pass
- [ ] Storybook: `Fullscreen` story renders correctly with the new prop-driven approach