### PR TITLE
chore: migrate conductor.json to conductor.toml

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,7 +1,0 @@
-{
-	"scripts": {
-		"setup": "pnpm install && pnpm build",
-		"run": "pnpm run dev:docs",
-		"archive": "pnpm run cleanup"
-	}
-}

--- a/conductor.toml
+++ b/conductor.toml
@@ -1,0 +1,4 @@
+[scripts]
+setup = "pnpm install && pnpm build"
+run = "pnpm run dev:docs"
+archive = "pnpm run cleanup"


### PR DESCRIPTION
Replaces `conductor.json` with `conductor.toml` to adopt the new workspace config format. The `[scripts]` table maps directly from the previous JSON structure — `setup`, `run`, and `archive` entries are unchanged.