### PR TITLE
feat(theme): add Slider recipe with track, range, and thumb parts

### DIFF
--- a/.changeset/slider-recipe.md
+++ b/.changeset/slider-recipe.md
@@ -1,0 +1,8 @@
+---
+"@styleframe/theme": minor
+"styleframe": minor
+---
+
+Add `slider` recipe — a 4-part range input component.
+
+Adds `useSliderRecipe`, `useSliderTrackRecipe`, `useSliderRangeRecipe`, and `useSliderThumbRecipe` to `@styleframe/theme`. The root follows the standard color (light/dark/neutral), size (xs/sm/md/lg/xl), and orientation (horizontal/vertical) axes with disabled and invalid states. The track renders the unfilled groove, the range fills the selected region, and the thumb is the draggable handle with focus-ring, hover, and active states.

--- a/apps/docs/content/docs/05.components/05.forms/03.slider.md
+++ b/apps/docs/content/docs/05.components/05.forms/03.slider.md
@@ -1,0 +1,595 @@
+---
+title: Slider
+description: An input control for selecting a value from a range by dragging a thumb along a track. Composed of a root, track, range, and thumb recipe, with color, size, and orientation options through the recipe system.
+navigation:
+    icon: false
+---
+
+## Overview
+
+The **Slider** is an interactive form control used to select a numeric value from a continuous range. It is composed of four recipe parts: `useSliderRecipe()` for the positioning root, `useSliderTrackRecipe()` for the neutral rail, `useSliderRangeRecipe()` for the colored fill, and `useSliderThumbRecipe()` for the draggable handle. Each composable creates a fully configured [recipe](/docs/api/recipes) &mdash; the colored parts share the full palette, while the track stays neutral, mirroring the [Progress](/docs/components/feedback/progress) recipe with an added handle.
+
+The Slider recipes integrate directly with the default [design tokens preset](/docs/theme/design-tokens/presets) and generate type-safe utility classes at build time with zero runtime CSS.
+
+## Why use the Slider recipe?
+
+The Slider recipe helps you:
+
+- **Ship faster with sensible defaults**: Get 9 range and thumb colors, 5 sizes, and 2 orientations out of the box with four composable calls.
+- **Compose a structured handle**: Four coordinated recipes (root, track, range, thumb) share size and orientation axes, so every part stays internally consistent.
+- **Stay accessible by construction**: The thumb is built to carry `role="slider"` semantics, so keyboard and screen-reader support drops straight in.
+- **Maintain consistency**: Compound variants ensure every color combination follows the same design rules, including dark mode overrides.
+- **Customize without forking**: Override base styles, default variants, or filter out options you don't need &mdash; all through the options API.
+- **Stay type-safe**: Full TypeScript support means your editor catches invalid color, size, or orientation values at compile time.
+- **Integrate with your tokens**: Every value references the design tokens preset, so theme changes propagate automatically.
+- **Support dark mode**: Track, range, and thumb colors adapt automatically between light and dark color schemes.
+
+## Usage
+
+::steps{level="4"}
+
+#### Register the recipes
+
+Add the Slider recipes to a local Styleframe instance. The global `styleframe.config.ts` provides design tokens and utilities, while the component-level file registers the recipes themselves:
+
+:::code-tree{default-value="src/components/slider.styleframe.ts"}
+
+```ts [src/components/slider.styleframe.ts]
+import { styleframe } from 'virtual:styleframe';
+import {
+    useSliderRecipe,
+    useSliderTrackRecipe,
+    useSliderRangeRecipe,
+    useSliderThumbRecipe,
+} from '@styleframe/theme';
+
+const s = styleframe();
+
+const slider = useSliderRecipe(s);
+const sliderTrack = useSliderTrackRecipe(s);
+const sliderRange = useSliderRangeRecipe(s);
+const sliderThumb = useSliderThumbRecipe(s);
+
+export default s;
+```
+
+```ts [styleframe.config.ts]
+import { styleframe } from 'styleframe';
+import { useDesignTokensPreset, useUtilitiesPreset } from '@styleframe/theme';
+
+const s = styleframe();
+
+useDesignTokensPreset(s);
+useUtilitiesPreset(s);
+
+export default s;
+```
+
+:::
+
+#### Build the component
+
+Import the four runtime functions from the virtual module and pass variant props to compute class names. The recipes own the slider's appearance; the current value drives the fill length and thumb offset, which you bind from your model:
+
+::framework-switcher
+
+#vue
+
+```vue [src/components/Slider.vue]
+<script setup lang="ts">
+import { computed } from "vue";
+import {
+    slider,
+    sliderTrack,
+    sliderRange,
+    sliderThumb,
+    type SliderProps,
+    type SliderRangeProps,
+    type SliderThumbProps,
+} from "virtual:styleframe";
+
+const props = withDefaults(
+    defineProps<
+        SliderProps &
+            SliderRangeProps &
+            SliderThumbProps & {
+                modelValue?: number;
+                min?: number;
+                max?: number;
+                disabled?: boolean;
+            }
+    >(),
+    { color: "primary", size: "md", orientation: "horizontal", modelValue: 50, min: 0, max: 100 },
+);
+
+// Percentage of the track the value occupies.
+const fill = computed(() => {
+    const ratio = (props.modelValue - props.min) / (props.max - props.min);
+    return `${Math.min(100, Math.max(0, ratio * 100))}%`;
+});
+
+const rootClasses = computed(() =>
+    slider({ size: props.size, orientation: props.orientation, disabled: props.disabled ? "true" : "false" }),
+);
+const trackClasses = computed(() => sliderTrack({ size: props.size, orientation: props.orientation }));
+const rangeClasses = computed(() => sliderRange({ color: props.color, orientation: props.orientation }));
+const thumbClasses = computed(() => sliderThumb({ color: props.color, size: props.size }));
+
+// The value owns position; the recipe owns appearance.
+const rangeStyle = computed(() =>
+    props.orientation === "vertical" ? { height: fill.value } : { width: fill.value },
+);
+const thumbStyle = computed(() =>
+    props.orientation === "vertical"
+        ? { insetInlineStart: "50%", bottom: fill.value, transform: "translate(-50%, 50%)" }
+        : { top: "50%", insetInlineStart: fill.value, transform: "translate(-50%, -50%)" },
+);
+</script>
+
+<template>
+    <span :class="rootClasses">
+        <span :class="trackClasses">
+            <span :class="rangeClasses" :style="rangeStyle" />
+        </span>
+        <span
+            :class="thumbClasses"
+            :style="thumbStyle"
+            role="slider"
+            tabindex="0"
+            :aria-valuemin="min"
+            :aria-valuemax="max"
+            :aria-valuenow="modelValue"
+            :aria-orientation="orientation"
+            :aria-disabled="disabled || undefined"
+        />
+    </span>
+</template>
+```
+
+#react
+
+```tsx [src/components/Slider.tsx]
+import {
+    slider,
+    sliderTrack,
+    sliderRange,
+    sliderThumb,
+    type SliderProps,
+    type SliderRangeProps,
+    type SliderThumbProps,
+} from "virtual:styleframe";
+
+interface SliderComponentProps extends SliderProps, SliderRangeProps, SliderThumbProps {
+    value?: number;
+    min?: number;
+    max?: number;
+    disabled?: boolean;
+}
+
+export function Slider({
+    color = "primary",
+    size = "md",
+    orientation = "horizontal",
+    value = 50,
+    min = 0,
+    max = 100,
+    disabled = false,
+}: SliderComponentProps) {
+    const ratio = (value - min) / (max - min);
+    const fill = `${Math.min(100, Math.max(0, ratio * 100))}%`;
+    const isVertical = orientation === "vertical";
+
+    return (
+        <span className={slider({ size, orientation, disabled: String(disabled) })}>
+            <span className={sliderTrack({ size, orientation })}>
+                <span
+                    className={sliderRange({ color, orientation })}
+                    style={isVertical ? { height: fill } : { width: fill }}
+                />
+            </span>
+            <span
+                className={sliderThumb({ color, size })}
+                style={
+                    isVertical
+                        ? { insetInlineStart: "50%", bottom: fill, transform: "translate(-50%, 50%)" }
+                        : { top: "50%", insetInlineStart: fill, transform: "translate(-50%, -50%)" }
+                }
+                role="slider"
+                tabIndex={0}
+                aria-valuemin={min}
+                aria-valuemax={max}
+                aria-valuenow={value}
+                aria-orientation={orientation}
+                aria-disabled={disabled || undefined}
+            />
+        </span>
+    );
+}
+```
+
+#other
+
+Each runtime returns a class string. Apply them however your framework binds classes, and set the fill length and thumb offset from the current value:
+
+```ts [src/components/slider.ts]
+import { slider, sliderTrack, sliderRange, sliderThumb } from "virtual:styleframe";
+
+const rootClasses = slider({ size: "md", orientation: "horizontal", disabled: "false" });
+// → "slider _position:relative _display:inline-flex ..."
+const trackClasses = sliderTrack({ size: "md", orientation: "horizontal" });
+// → "slider-track _background:gray-200 _border-radius:full _overflow:hidden ..."
+const rangeClasses = sliderRange({ color: "primary", orientation: "horizontal" });
+// → "slider-range _background:primary _height:full ..."
+const thumbClasses = sliderThumb({ color: "primary", size: "md" });
+// → "slider-thumb _background:primary _border-radius:full ..."
+```
+
+```html [src/components/slider.html]
+<span class="slider _position:relative ...">
+    <span class="slider-track _background:gray-200 ...">
+        <span class="slider-range _background:primary ..." style="width: 50%"></span>
+    </span>
+    <span
+        class="slider-thumb _background:primary ..."
+        style="top: 50%; inset-inline-start: 50%; transform: translate(-50%, -50%)"
+        role="slider"
+        tabindex="0"
+        aria-valuenow="50"
+        aria-valuemin="0"
+        aria-valuemax="100"
+    ></span>
+</span>
+```
+
+::
+
+#### See it in action
+
+:::story-preview
+---
+story: theme-recipes-forms-slider--default
+panel: true
+---
+:::
+
+::
+
+## Colors
+
+The Slider range and thumb recipes include 9 color variants: the 6 semantic colors (`primary`, `secondary`, `success`, `info`, `warning`, `error`) plus 3 neutral-spectrum colors (`light`, `dark`, `neutral`). The track recipe uses only the 3 neutral-spectrum colors (`light`, `dark`, `neutral`) to provide a subtle rail behind the fill.
+
+Each color is applied through compound variants with automatic dark mode overrides. The `neutral` color adapts between light and dark mode automatically.
+
+::story-preview
+---
+story: theme-recipes-forms-slider--primary
+panel: true
+---
+::
+
+### Color Reference
+
+::story-preview
+---
+story: theme-recipes-forms-slider--all-colors
+height: 600
+---
+::
+
+**Range &amp; thumb colors:**
+
+| Color | Token | Use Case |
+|-------|-------|----------|
+| `primary` | `@color.primary` | Default. Primary brand control |
+| `secondary` | `@color.secondary` | Secondary or supporting control |
+| `success` | `@color.success` | Positive ranges, confirmations |
+| `info` | `@color.info` | Informational ranges |
+| `warning` | `@color.warning` | Caution states, approaching limits |
+| `error` | `@color.error` | Error states, destructive ranges |
+| `light` | `@color.gray-400` | Light-themed fill, fixed across color schemes |
+| `dark` | `@color.gray-600` | Dark-themed fill, fixed across color schemes |
+| `neutral` | Adaptive | Light fill in light mode, dark fill in dark mode |
+
+**Track colors:**
+
+| Color | Token | Use Case |
+|-------|-------|----------|
+| `light` | `@color.gray-200` | Light rail, fixed across color schemes |
+| `dark` | `@color.gray-800` | Dark rail, fixed across color schemes |
+| `neutral` | Adaptive | Default. Light rail in light mode, dark rail in dark mode |
+
+::tip
+**Pro tip:** Keep the track `neutral` and let the range and thumb carry the semantic color. The rail is a background; the fill communicates the value's meaning.
+::
+
+## Sizes
+
+Five size variants from `xs` to `xl` control the rail thickness (height, or width in vertical orientation) and the thumb diameter. Pass the same `size` to the root, track, and thumb so the handle and rail stay proportional.
+
+::story-preview
+---
+story: theme-recipes-forms-slider--medium
+panel: true
+---
+::
+
+### Size Reference
+
+::story-preview
+---
+story: theme-recipes-forms-slider--all-sizes
+height: 400
+---
+::
+
+| Size | Rail Thickness | Thumb Diameter | Use Case |
+|------|---------------|----------------|----------|
+| `xs` | `@0.25` | `@0.75` | Thin, compact controls |
+| `sm` | `@0.375` | `@1` | Dense forms |
+| `md` | `@0.5` | `@1.25` | Default. Standard controls |
+| `lg` | `@0.75` | `@1.5` | Prominent controls |
+| `xl` | `@1` | `@2` | Large, touch-friendly controls |
+
+::note
+**Good to know:** The thumb diameter sets the root's cross-axis clearance, so the handle is never clipped by adjacent content.
+::
+
+## Orientation
+
+The `orientation` variant controls the layout direction of the slider. Two options are available: `horizontal` (default) and `vertical`.
+
+### Horizontal
+
+The range fills from the start of the track. The root stretches to `width: 100%` of its container.
+
+::story-preview
+---
+story: theme-recipes-forms-slider--default
+panel: true
+---
+::
+
+### Vertical
+
+The range fills from the bottom of the track. The root stretches to `height: 100%`, so the parent container must have an explicit height for a vertical slider to be visible.
+
+::story-preview
+---
+story: theme-recipes-forms-slider--vertical
+height: 300
+---
+::
+
+| Orientation | Fill Direction | Root Sizing | Use Case |
+|-------------|--------------|-------------|----------|
+| `horizontal` | Start to end | `width: 100%` | Default. Standard sliders |
+| `vertical` | Bottom to top | `height: 100%` | Volume, brightness, level controls |
+
+## Disabled
+
+The root recipe exposes a `disabled` variant. When set, it dims the whole control and sets `pointer-events: none`, which cascades to the track, range, and thumb &mdash; you only set it in one place.
+
+::story-preview
+---
+story: theme-recipes-forms-slider--disabled
+panel: true
+---
+::
+
+```ts
+slider({ disabled: "true" });
+// → "slider ... _opacity:0.5 _cursor:not-allowed _pointer-events:none"
+```
+
+::note
+**Good to know:** Mirror the disabled state to `aria-disabled` on the thumb so assistive technology announces it, in addition to the recipe's visual treatment.
+::
+
+## Anatomy
+
+The Slider recipe is composed of four recipes that work together:
+
+| Part | Recipe | Role |
+|------|--------|------|
+| **Root** | `useSliderRecipe()` | Positioning wrapper. Owns orientation, thumb clearance, and the disabled state |
+| **Track** | `useSliderTrackRecipe()` | Neutral rail with `overflow: hidden`. Holds the range |
+| **Range** | `useSliderRangeRecipe()` | Colored fill from the start of the track to the thumb |
+| **Thumb** | `useSliderThumbRecipe()` | Draggable handle with focus, hover, and active states |
+
+The thumb is a **sibling** of the track, not a child: the track clips its content with `overflow: hidden`, which would crop the larger handle. The root is `position: relative` so the thumb can be positioned absolutely along the track.
+
+```html
+<!-- All four parts working together -->
+<span class="slider(...)">
+    <span class="sliderTrack(...)">
+        <span class="sliderRange(...)" style="width: 50%"></span>
+    </span>
+    <span class="sliderThumb(...)" style="inset-inline-start: 50%" role="slider"></span>
+</span>
+```
+
+::tip
+**Pro tip:** The range and thumb share the same `color` so the active value reads as one coloured unit. Drive their position from the value with an inline style (or a CSS custom property) &mdash; the recipes intentionally leave layout to the data.
+::
+
+## Accessibility
+
+- **Use the `slider` role.** Apply `role="slider"` to the thumb element. This tells assistive technology that the element represents an adjustable value.
+
+```html
+<span class="sliderThumb(...)" role="slider" tabindex="0" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100"></span>
+```
+
+- **Set `aria-valuenow`, `aria-valuemin`, and `aria-valuemax`.** These attributes communicate the current value and its bounds to screen readers.
+
+- **Make the thumb focusable and keyboard-operable.** Give the thumb `tabindex="0"` and handle arrow keys (increment/decrement by step), plus `Home`/`End` to jump to the minimum and maximum. The recipe's `:focus-visible` ring makes keyboard focus visible.
+
+```html
+<span role="slider" tabindex="0" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" aria-orientation="horizontal"></span>
+```
+
+- **Set `aria-orientation` for vertical sliders.** This tells assistive technology the orientation of the control.
+
+- **Reflect the disabled state.** Add `aria-disabled="true"` to the thumb when the slider is disabled, alongside the recipe's `disabled` variant.
+
+- **Add a label.** Use `aria-label` or `aria-labelledby` to give the slider a descriptive name, especially when several sliders appear together.
+
+```html
+<label id="volume-label">Volume</label>
+<span class="slider(...)">
+    <span class="sliderTrack(...)"><span class="sliderRange(...)" style="width: 50%"></span></span>
+    <span role="slider" tabindex="0" aria-labelledby="volume-label" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100"></span>
+</span>
+```
+
+## Customization
+
+### Overriding Defaults
+
+Each slider composable accepts an optional second argument to override any part of the recipe configuration. Overrides are deep-merged with the defaults, so you only specify what you want to change:
+
+```ts [src/components/slider.styleframe.ts]
+import { styleframe } from 'virtual:styleframe';
+import { useSliderThumbRecipe } from '@styleframe/theme';
+
+const s = styleframe();
+
+const sliderThumb = useSliderThumbRecipe(s, {
+    base: {
+        boxShadow: '@box-shadow.md',
+    },
+    defaultVariants: {
+        color: 'neutral',
+        size: 'lg',
+    },
+});
+
+export default s;
+```
+
+### Filtering Variants
+
+If you only need a subset of the available variants, use the `filter` option to limit which values are generated. This reduces the output CSS and keeps your component API focused:
+
+```ts [src/components/slider.styleframe.ts]
+import { styleframe } from 'virtual:styleframe';
+import { useSliderRangeRecipe, useSliderThumbRecipe } from '@styleframe/theme';
+
+const s = styleframe();
+
+// Only generate primary and success colors
+const sliderRange = useSliderRangeRecipe(s, { filter: { color: ['primary', 'success'] } });
+const sliderThumb = useSliderThumbRecipe(s, { filter: { color: ['primary', 'success'] } });
+
+export default s;
+```
+
+::note
+**Good to know:** Filtering also removes compound variants and adjusts default variants that reference filtered-out values, so your recipe stays consistent.
+::
+
+## API Reference
+
+### `useSliderRecipe(s, options?)`
+
+Creates the slider root recipe &mdash; the positioning wrapper that lays out the track and thumb and owns the disabled state.
+
+**Variants:**
+
+| Variant | Options | Default |
+|---------|---------|---------|
+| `orientation` | `horizontal`, `vertical` | `horizontal` |
+| `size` | `xs`, `sm`, `md`, `lg`, `xl` | `md` |
+| `disabled` | `true`, `false` | `false` |
+
+### `useSliderTrackRecipe(s, options?)`
+
+Creates the neutral rail recipe with background color, pill radius, and orientation support.
+
+**Variants:**
+
+| Variant | Options | Default |
+|---------|---------|---------|
+| `color` | `light`, `dark`, `neutral` | `neutral` |
+| `orientation` | `horizontal`, `vertical` | `horizontal` |
+| `size` | `xs`, `sm`, `md`, `lg`, `xl` | `md` |
+
+### `useSliderRangeRecipe(s, options?)`
+
+Creates the colored fill recipe. Its length is data-driven, so set the fill dimension from the value rather than a variant.
+
+**Variants:**
+
+| Variant | Options | Default |
+|---------|---------|---------|
+| `color` | `primary`, `secondary`, `success`, `info`, `warning`, `error`, `light`, `dark`, `neutral` | `primary` |
+| `orientation` | `horizontal`, `vertical` | `horizontal` |
+
+### `useSliderThumbRecipe(s, options?)`
+
+Creates the draggable handle recipe with full color support and interactive focus, hover, and active states.
+
+**Variants:**
+
+| Variant | Options | Default |
+|---------|---------|---------|
+| `color` | `primary`, `secondary`, `success`, `info`, `warning`, `error`, `light`, `dark`, `neutral` | `primary` |
+| `size` | `xs`, `sm`, `md`, `lg`, `xl` | `md` |
+
+**Common parameters (all four recipes):**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `s` | `Styleframe` | The Styleframe instance |
+| `options` | `DeepPartial<RecipeConfig>` | Optional overrides for the recipe configuration |
+| `options.base` | `VariantDeclarationsBlock` | Custom base styles |
+| `options.variants` | `Variants` | Custom variant definitions |
+| `options.defaultVariants` | `Record<keyof Variants, string>` | Default variant values |
+| `options.compoundVariants` | `CompoundVariant[]` | Custom compound variant definitions |
+| `options.filter` | `Record<string, string[]>` | Limit which variant values are generated |
+
+[Learn more about recipes &rarr;](/docs/api/recipes)
+
+## Best Practices
+
+- **Pass `size` to the root, track, and thumb**: All three share the `size` axis so the rail thickness and handle diameter stay proportional.
+- **Keep the track `neutral`**: The rail is a background. Save color for the range and thumb where it communicates the value's meaning.
+- **Use the same `color` for the range and thumb**: This makes the filled portion and handle read as a single coloured unit.
+- **Drive position from the value**: The recipes own appearance, but the range length and thumb offset must be set from the current value via an inline style or a CSS custom property.
+- **Disable in one place**: Set `disabled` on the root only &mdash; `pointer-events: none` cascades to every part. Mirror it to `aria-disabled` on the thumb.
+- **Provide an explicit height for vertical sliders**: The vertical root uses `height: 100%`, so the parent container must have an explicit height.
+- **Filter what you don't need**: If your component only uses a few colors, pass a `filter` option to reduce generated CSS.
+
+## FAQ
+
+::accordion
+
+:::accordion-item{label="Why are there four separate recipes instead of one?" icon="i-lucide-circle-help"}
+A slider has four distinct visual elements: a positioning root, a neutral rail, a colored fill, and a draggable handle. Each needs independent styling &mdash; the track is neutral with `overflow: hidden`, the range carries semantic color, and the thumb adds interactive focus and hover states. Four recipes give each part its own variants while sharing the `size` and `orientation` axes.
+:::
+
+:::accordion-item{label="Why is the thumb a sibling of the track instead of a child?" icon="i-lucide-circle-help"}
+The track uses `overflow: hidden` so the range fill is clipped to the rail's rounded corners. The thumb is larger than the rail, so placing it inside the track would crop it. Instead, the thumb is a sibling positioned absolutely against the `position: relative` root.
+:::
+
+:::accordion-item{label="How do I set the fill and thumb position?" icon="i-lucide-circle-help"}
+The recipes deliberately leave layout to the data. Compute a percentage from the value, then set the range's `width` (or `height` in vertical) and the thumb's `inset-inline-start` (or `bottom`) from it with an inline style or a CSS custom property. See the Usage example above.
+:::
+
+:::accordion-item{label="What is the difference between light, dark, and neutral colors?" icon="i-lucide-circle-help"}
+`light` always uses the same gray tones regardless of the color scheme. `dark` always uses darker gray tones. `neutral` adapts to the current color scheme: it appears light in light mode and dark in dark mode. Use `neutral` when you want the slider to blend naturally with the surrounding interface.
+:::
+
+:::accordion-item{label="How do I make the slider keyboard accessible?" icon="i-lucide-circle-help"}
+Give the thumb `role="slider"`, `tabindex="0"`, and `aria-valuemin`/`aria-valuemax`/`aria-valuenow`. Handle arrow keys to change the value by your step, and `Home`/`End` to jump to the bounds. The recipe's `:focus-visible` ring makes keyboard focus visible automatically.
+:::
+
+:::accordion-item{label="Why does the disabled variant use string keys instead of a boolean?" icon="i-lucide-circle-help"}
+Recipe variant values are always strings in the configuration object. The `disabled` variant uses `"true"` and `"false"` as string keys internally, but your component can accept a boolean prop and convert it with `String(disabled)` when passing it to the recipe function.
+:::
+
+:::accordion-item{label="Can I use the Slider recipe without the design tokens preset?" icon="i-lucide-circle-help"}
+The Slider recipes reference design tokens like `@color.primary`, `@border-radius.full`, and `@box-shadow.sm` through string refs. These tokens need to be defined in your Styleframe instance for the recipes to generate valid CSS. The easiest way is to use `useDesignTokensPreset(s)`, but you can also define the required tokens manually.
+:::
+
+::

--- a/apps/storybook/src/components/components/slider/Slider.vue
+++ b/apps/storybook/src/components/components/slider/Slider.vue
@@ -1,0 +1,78 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import {
+	slider,
+	sliderRange,
+	sliderThumb,
+	sliderTrack,
+} from "virtual:styleframe";
+
+const props = withDefaults(
+	defineProps<{
+		color?:
+			| "primary"
+			| "secondary"
+			| "success"
+			| "info"
+			| "warning"
+			| "error"
+			| "light"
+			| "dark"
+			| "neutral";
+		size?: "xs" | "sm" | "md" | "lg" | "xl";
+		orientation?: "horizontal" | "vertical";
+		disabled?: boolean;
+		value?: number;
+	}>(),
+	{ orientation: "horizontal", value: 60 },
+);
+
+const rootClasses = computed(() =>
+	slider({
+		size: props.size,
+		orientation: props.orientation,
+		disabled: props.disabled ? "true" : "false",
+	}),
+);
+
+const trackClasses = computed(() =>
+	sliderTrack({
+		size: props.size,
+		orientation: props.orientation,
+	}),
+);
+
+const rangeClasses = computed(() => [
+	sliderRange({
+		color: props.color,
+		orientation: props.orientation,
+	}),
+	`slider-range-demo--${props.orientation}`,
+]);
+
+const thumbClasses = computed(() => [
+	sliderThumb({
+		color: props.color,
+		size: props.size,
+	}),
+	`slider-thumb-demo--${props.orientation}`,
+]);
+</script>
+
+<template>
+	<span :class="rootClasses">
+		<span :class="trackClasses">
+			<span :class="rangeClasses" />
+		</span>
+		<span
+			:class="thumbClasses"
+			role="slider"
+			tabindex="0"
+			:aria-orientation="orientation"
+			:aria-valuemin="0"
+			:aria-valuemax="100"
+			:aria-valuenow="value"
+			:aria-disabled="disabled || undefined"
+		/>
+	</span>
+</template>

--- a/apps/storybook/src/components/components/slider/preview/SliderGrid.vue
+++ b/apps/storybook/src/components/components/slider/preview/SliderGrid.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import Slider from "../Slider.vue";
+
+const colors = [
+	"primary",
+	"secondary",
+	"success",
+	"info",
+	"warning",
+	"error",
+	"light",
+	"dark",
+	"neutral",
+] as const;
+</script>
+
+<template>
+	<div class="slider-section">
+		<div v-for="color in colors" :key="color">
+			<div class="slider-label">{{ color }}</div>
+			<div class="slider-row">
+				<div class="_max-width:[320px]">
+					<Slider :color="color" />
+				</div>
+			</div>
+		</div>
+	</div>
+</template>

--- a/apps/storybook/src/components/components/slider/preview/SliderSizeGrid.vue
+++ b/apps/storybook/src/components/components/slider/preview/SliderSizeGrid.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import Slider from "../Slider.vue";
+
+const sizes = ["xs", "sm", "md", "lg", "xl"] as const;
+</script>
+
+<template>
+	<div class="slider-section">
+		<div v-for="size in sizes" :key="size">
+			<div class="slider-label">{{ size }}</div>
+			<div class="slider-row">
+				<div class="_max-width:[320px]">
+					<Slider :size="size" />
+				</div>
+			</div>
+		</div>
+	</div>
+</template>

--- a/apps/storybook/stories/components/slider.stories.ts
+++ b/apps/storybook/stories/components/slider.stories.ts
@@ -1,0 +1,114 @@
+import type { Meta, StoryObj } from "@storybook/vue3-vite";
+
+import Slider from "../../src/components/components/slider/Slider.vue";
+import SliderGrid from "../../src/components/components/slider/preview/SliderGrid.vue";
+import SliderSizeGrid from "../../src/components/components/slider/preview/SliderSizeGrid.vue";
+
+const colors = [
+	"primary",
+	"secondary",
+	"success",
+	"info",
+	"warning",
+	"error",
+	"light",
+	"dark",
+	"neutral",
+] as const;
+const sizes = ["xs", "sm", "md", "lg", "xl"] as const;
+
+const meta = {
+	title: "Theme/Recipes/Forms/Slider",
+	component: Slider,
+	tags: ["autodocs"],
+	parameters: {
+		layout: "padded",
+	},
+	argTypes: {
+		color: {
+			control: "select",
+			options: colors,
+			description: "The color of the range fill and thumb",
+		},
+		size: {
+			control: "select",
+			options: sizes,
+			description: "The size of the track and thumb",
+		},
+		orientation: {
+			control: "select",
+			options: ["horizontal", "vertical"],
+			description: "The orientation of the slider",
+		},
+		disabled: {
+			control: "boolean",
+			description: "Whether the slider is disabled",
+		},
+	},
+} satisfies Meta<typeof Slider>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {
+		color: "primary",
+		size: "md",
+		orientation: "horizontal",
+		disabled: false,
+	},
+};
+
+export const AllColors: StoryObj = {
+	render: () => ({
+		components: { SliderGrid },
+		template: "<SliderGrid />",
+	}),
+};
+
+export const AllSizes: StoryObj = {
+	render: () => ({
+		components: { SliderSizeGrid },
+		template: "<SliderSizeGrid />",
+	}),
+};
+
+export const Vertical: StoryObj = {
+	render: () => ({
+		components: { Slider },
+		template: `
+			<div class="_display:flex _gap:1.5 _height:[200px]">
+				<Slider orientation="vertical" color="primary" />
+				<Slider orientation="vertical" color="success" />
+				<Slider orientation="vertical" color="warning" />
+				<Slider orientation="vertical" color="error" />
+				<Slider orientation="vertical" color="neutral" />
+			</div>
+		`,
+	}),
+};
+
+export const Disabled: Story = {
+	args: {
+		color: "primary",
+		disabled: true,
+	},
+};
+
+// Individual color stories
+export const Primary: Story = { args: { color: "primary" } };
+export const Secondary: Story = { args: { color: "secondary" } };
+export const Success: Story = { args: { color: "success" } };
+export const Info: Story = { args: { color: "info" } };
+export const Warning: Story = { args: { color: "warning" } };
+export const Error: Story = { args: { color: "error" } };
+export const Light: Story = { args: { color: "light" } };
+export const Dark: Story = { args: { color: "dark" } };
+export const Neutral: Story = { args: { color: "neutral" } };
+
+// Size stories
+export const ExtraSmall: Story = { args: { size: "xs" } };
+export const Small: Story = { args: { size: "sm" } };
+export const Medium: Story = { args: { size: "md" } };
+export const Large: Story = { args: { size: "lg" } };
+export const ExtraLarge: Story = { args: { size: "xl" } };

--- a/apps/storybook/stories/components/slider.styleframe.ts
+++ b/apps/storybook/stories/components/slider.styleframe.ts
@@ -1,0 +1,62 @@
+import {
+	useSliderRangeRecipe,
+	useSliderRecipe,
+	useSliderThumbRecipe,
+	useSliderTrackRecipe,
+} from "@styleframe/theme";
+import { styleframe } from "virtual:styleframe";
+
+const s = styleframe();
+const { selector } = s;
+
+// Initialize slider recipes
+export const slider = useSliderRecipe(s);
+export const sliderTrack = useSliderTrackRecipe(s);
+export const sliderRange = useSliderRangeRecipe(s);
+export const sliderThumb = useSliderThumbRecipe(s);
+
+// Demo positioning — a fixed, representative 60% fill for the static showcase.
+// The fill length and thumb offset are data-driven in real usage, so the
+// recipes deliberately leave them out; the showcase pins them with utility
+// selectors instead of inline styles.
+selector(".slider-range-demo--horizontal", {
+	width: "60%",
+});
+
+selector(".slider-range-demo--vertical", {
+	height: "60%",
+});
+
+selector(".slider-thumb-demo--horizontal", {
+	top: "50%",
+	insetInlineStart: "60%",
+	transform: "translate(-50%, -50%)",
+});
+
+selector(".slider-thumb-demo--vertical", {
+	insetInlineStart: "50%",
+	bottom: "60%",
+	transform: "translate(-50%, 50%)",
+});
+
+// Container styles for story layout
+selector(".slider-section", {
+	display: "flex",
+	flexDirection: "column",
+	gap: "@spacing.lg",
+	padding: "@spacing.md",
+});
+
+selector(".slider-row", {
+	display: "flex",
+	flexDirection: "column",
+	gap: "@spacing.sm",
+});
+
+selector(".slider-label", {
+	fontSize: "@font-size.sm",
+	fontWeight: "@font-weight.semibold",
+	minWidth: "80px",
+});
+
+export default s;

--- a/conductor.json
+++ b/conductor.json
@@ -1,7 +1,0 @@
-{
-	"scripts": {
-		"setup": "pnpm install && pnpm build",
-		"run": "pnpm run dev:docs",
-		"archive": "pnpm run cleanup"
-	}
-}

--- a/conductor.toml
+++ b/conductor.toml
@@ -1,0 +1,4 @@
+[scripts]
+setup = "pnpm install && pnpm build"
+run = "pnpm run dev:docs"
+archive = "pnpm run cleanup"

--- a/theme/src/recipes/index.ts
+++ b/theme/src/recipes/index.ts
@@ -21,5 +21,6 @@ export * from "./popover";
 export * from "./progress";
 export * from "./select";
 export * from "./skeleton";
+export * from "./slider";
 export * from "./textarea";
 export * from "./tooltip";

--- a/theme/src/recipes/slider/index.ts
+++ b/theme/src/recipes/slider/index.ts
@@ -1,0 +1,4 @@
+export * from "./useSliderRecipe";
+export * from "./useSliderTrackRecipe";
+export * from "./useSliderRangeRecipe";
+export * from "./useSliderThumbRecipe";

--- a/theme/src/recipes/slider/useSliderRangeRecipe.test.ts
+++ b/theme/src/recipes/slider/useSliderRangeRecipe.test.ts
@@ -1,0 +1,166 @@
+import { styleframe } from "@styleframe/core";
+import { useDarkModifier } from "../../modifiers/useMediaPreferenceModifiers";
+import { useSliderRangeRecipe } from "./useSliderRangeRecipe";
+
+function createInstance() {
+	const s = styleframe();
+	for (const name of ["borderRadius", "height", "width", "background"]) {
+		s.utility(name, ({ value }) => ({ [name]: value }));
+	}
+	useDarkModifier(s);
+	return s;
+}
+
+describe("useSliderRangeRecipe", () => {
+	it("should create a recipe with correct metadata", () => {
+		const s = createInstance();
+		const recipe = useSliderRangeRecipe(s);
+
+		expect(recipe.type).toBe("recipe");
+		expect(recipe.name).toBe("slider-range");
+	});
+
+	it("should have correct base styles", () => {
+		const s = createInstance();
+		const recipe = useSliderRangeRecipe(s);
+
+		expect(recipe.base).toEqual({
+			borderRadius: "@border-radius.full",
+		});
+	});
+
+	describe("variants", () => {
+		it("should have all color variants", () => {
+			const s = createInstance();
+			const recipe = useSliderRangeRecipe(s);
+
+			expect(Object.keys(recipe.variants!.color)).toEqual([
+				"primary",
+				"secondary",
+				"success",
+				"info",
+				"warning",
+				"error",
+				"light",
+				"dark",
+				"neutral",
+			]);
+		});
+
+		it("should have orientation variants", () => {
+			const s = createInstance();
+			const recipe = useSliderRangeRecipe(s);
+
+			expect(recipe.variants!.orientation).toEqual({
+				horizontal: {
+					height: "100%",
+				},
+				vertical: {
+					width: "100%",
+				},
+			});
+		});
+	});
+
+	it("should have correct default variants", () => {
+		const s = createInstance();
+		const recipe = useSliderRangeRecipe(s);
+
+		expect(recipe.defaultVariants).toEqual({
+			color: "primary",
+			orientation: "horizontal",
+		});
+	});
+
+	describe("compound variants", () => {
+		it("should have 9 compound variants total", () => {
+			const s = createInstance();
+			const recipe = useSliderRangeRecipe(s);
+
+			// 6 semantic colors + 3 non-semantic (light/dark/neutral) = 9
+			expect(recipe.compoundVariants).toHaveLength(9);
+		});
+
+		it("should have correct compound variant for semantic colors", () => {
+			const s = createInstance();
+			const recipe = useSliderRangeRecipe(s);
+
+			const primary = recipe.compoundVariants!.find(
+				(cv) => cv.match.color === "primary",
+			);
+
+			expect(primary).toEqual({
+				match: { color: "primary" },
+				css: {
+					background: "@color.primary",
+				},
+			});
+		});
+
+		it("should have correct neutral color compound variant with adaptive dark mode", () => {
+			const s = createInstance();
+			const recipe = useSliderRangeRecipe(s);
+
+			const neutral = recipe.compoundVariants!.find(
+				(cv) => cv.match.color === "neutral",
+			);
+
+			expect(neutral).toEqual({
+				match: { color: "neutral" },
+				css: {
+					background: "@color.gray-400",
+					"&:dark": {
+						background: "@color.gray-600",
+					},
+				},
+			});
+		});
+	});
+
+	describe("config overrides", () => {
+		it("should allow overriding base styles", () => {
+			const s = createInstance();
+			const recipe = useSliderRangeRecipe(s, {
+				base: { borderRadius: "@border-radius.sm" },
+			});
+
+			expect(recipe.base!.borderRadius).toBe("@border-radius.sm");
+		});
+	});
+
+	describe("filter", () => {
+		it("should filter color variants", () => {
+			const s = createInstance();
+			const recipe = useSliderRangeRecipe(s, {
+				filter: { color: ["primary", "success"] },
+			});
+
+			expect(Object.keys(recipe.variants!.color)).toEqual([
+				"primary",
+				"success",
+			]);
+		});
+
+		it("should prune compound variants when filtering colors", () => {
+			const s = createInstance();
+			const recipe = useSliderRangeRecipe(s, {
+				filter: { color: ["primary"] },
+			});
+
+			expect(recipe.compoundVariants).toHaveLength(1);
+			expect(
+				recipe.compoundVariants!.every((cv) => cv.match.color === "primary"),
+			).toBe(true);
+		});
+
+		it("should adjust default variants when filtered out", () => {
+			const s = createInstance();
+			const recipe = useSliderRangeRecipe(s, {
+				filter: { color: ["neutral"] },
+			});
+
+			expect(recipe.defaultVariants?.color).toBeUndefined();
+			expect(recipe.defaultVariants?.orientation).toBe("horizontal");
+		});
+	});
+});

--- a/theme/src/recipes/slider/useSliderRangeRecipe.ts
+++ b/theme/src/recipes/slider/useSliderRangeRecipe.ts
@@ -1,0 +1,91 @@
+import { createUseRecipe } from "../../utils/createUseRecipe";
+
+const colors = [
+	"primary",
+	"secondary",
+	"success",
+	"info",
+	"warning",
+	"error",
+] as const;
+
+/**
+ * Slider range recipe.
+ * The colored fill between the start of the track and the thumb. Full palette,
+ * mirroring the thumb so the active value reads as a single coloured unit. The
+ * fill length is data-driven, so it is set by the consumer, not by this recipe.
+ */
+export const useSliderRangeRecipe = createUseRecipe("slider-range", {
+	base: {
+		borderRadius: "@border-radius.full",
+	},
+	variants: {
+		color: {
+			primary: {},
+			secondary: {},
+			success: {},
+			info: {},
+			warning: {},
+			error: {},
+			light: {},
+			dark: {},
+			neutral: {},
+		},
+		orientation: {
+			horizontal: {
+				height: "100%",
+			},
+			vertical: {
+				width: "100%",
+			},
+		},
+	},
+	compoundVariants: [
+		// Semantic colors (dynamic).
+		...colors.flatMap((color) => [
+			{
+				match: { color },
+				css: {
+					background: `@color.${color}`,
+				},
+			},
+		]),
+
+		// Light — fixed across themes.
+		{
+			match: { color: "light" as const },
+			css: {
+				background: "@color.gray-400",
+				"&:dark": {
+					background: "@color.gray-400",
+				},
+			},
+		},
+
+		// Dark — fixed across themes.
+		{
+			match: { color: "dark" as const },
+			css: {
+				background: "@color.gray-600",
+				"&:dark": {
+					background: "@color.gray-600",
+				},
+			},
+		},
+
+		// Neutral — adaptive (different light/dark values).
+		{
+			match: { color: "neutral" as const },
+			css: {
+				background: "@color.gray-400",
+				"&:dark": {
+					background: "@color.gray-600",
+				},
+			},
+		},
+	],
+	defaultVariants: {
+		color: "primary",
+		orientation: "horizontal",
+	},
+});

--- a/theme/src/recipes/slider/useSliderRecipe.test.ts
+++ b/theme/src/recipes/slider/useSliderRecipe.test.ts
@@ -1,0 +1,191 @@
+import { styleframe } from "@styleframe/core";
+import { useSliderRecipe } from "./useSliderRecipe";
+
+function createInstance() {
+	const s = styleframe();
+	for (const name of [
+		"position",
+		"display",
+		"alignItems",
+		"justifyContent",
+		"userSelect",
+		"touchAction",
+		"flexDirection",
+		"width",
+		"height",
+		"minHeight",
+		"minWidth",
+		"opacity",
+		"cursor",
+		"pointerEvents",
+	]) {
+		s.utility(name, ({ value }) => ({ [name]: value }));
+	}
+	return s;
+}
+
+describe("useSliderRecipe", () => {
+	it("should create a recipe with correct metadata", () => {
+		const s = createInstance();
+		const recipe = useSliderRecipe(s);
+
+		expect(recipe.type).toBe("recipe");
+		expect(recipe.name).toBe("slider");
+	});
+
+	it("should have correct base styles", () => {
+		const s = createInstance();
+		const recipe = useSliderRecipe(s);
+
+		expect(recipe.base).toEqual({
+			position: "relative",
+			display: "inline-flex",
+			alignItems: "center",
+			justifyContent: "center",
+			userSelect: "none",
+			touchAction: "none",
+		});
+	});
+
+	describe("variants", () => {
+		it("should have orientation variants", () => {
+			const s = createInstance();
+			const recipe = useSliderRecipe(s);
+
+			expect(recipe.variants!.orientation).toEqual({
+				horizontal: {
+					flexDirection: "row",
+					width: "100%",
+				},
+				vertical: {
+					flexDirection: "column",
+					height: "100%",
+				},
+			});
+		});
+
+		it("should have size variants with correct styles", () => {
+			const s = createInstance();
+			const recipe = useSliderRecipe(s);
+
+			expect(recipe.variants!.size).toEqual({
+				xs: { minHeight: "@0.75" },
+				sm: { minHeight: "@1" },
+				md: { minHeight: "@1.25" },
+				lg: { minHeight: "@1.5" },
+				xl: { minHeight: "@2" },
+			});
+		});
+
+		it("should have disabled variants", () => {
+			const s = createInstance();
+			const recipe = useSliderRecipe(s);
+
+			expect(recipe.variants!.disabled).toEqual({
+				true: {},
+				false: {},
+			});
+		});
+	});
+
+	it("should have correct default variants", () => {
+		const s = createInstance();
+		const recipe = useSliderRecipe(s);
+
+		expect(recipe.defaultVariants).toEqual({
+			orientation: "horizontal",
+			size: "md",
+			disabled: "false",
+		});
+	});
+
+	describe("compound variants", () => {
+		it("should have 6 compound variants total", () => {
+			const s = createInstance();
+			const recipe = useSliderRecipe(s);
+
+			// 5 vertical × size overrides + 1 disabled = 6
+			expect(recipe.compoundVariants).toHaveLength(6);
+		});
+
+		it("should have vertical × size compound variants", () => {
+			const s = createInstance();
+			const recipe = useSliderRecipe(s);
+
+			const verticalMd = recipe.compoundVariants!.find(
+				(cv) => cv.match.orientation === "vertical" && cv.match.size === "md",
+			);
+
+			expect(verticalMd).toEqual({
+				match: { orientation: "vertical", size: "md" },
+				css: {
+					minHeight: "0",
+					minWidth: "@1.25",
+				},
+			});
+		});
+
+		it("should have a disabled compound variant", () => {
+			const s = createInstance();
+			const recipe = useSliderRecipe(s);
+
+			const disabled = recipe.compoundVariants!.find(
+				(cv) => cv.match.disabled === "true",
+			);
+
+			expect(disabled).toEqual({
+				match: { disabled: "true" },
+				css: {
+					opacity: "0.5",
+					cursor: "not-allowed",
+					pointerEvents: "none",
+				},
+			});
+		});
+	});
+
+	describe("config overrides", () => {
+		it("should allow overriding base styles", () => {
+			const s = createInstance();
+			const recipe = useSliderRecipe(s, {
+				base: { display: "flex" },
+			});
+
+			expect(recipe.base!.display).toBe("flex");
+		});
+	});
+
+	describe("filter", () => {
+		it("should filter size variants", () => {
+			const s = createInstance();
+			const recipe = useSliderRecipe(s, {
+				filter: { size: ["sm", "md"] },
+			});
+
+			expect(Object.keys(recipe.variants!.size)).toEqual(["sm", "md"]);
+		});
+
+		it("should prune compound variants when filtering sizes", () => {
+			const s = createInstance();
+			const recipe = useSliderRecipe(s, {
+				filter: { size: ["md"] },
+			});
+
+			const verticalCvs = recipe.compoundVariants!.filter(
+				(cv) => cv.match.orientation === "vertical",
+			);
+			expect(verticalCvs).toHaveLength(1);
+			expect(verticalCvs.every((cv) => cv.match.size === "md")).toBe(true);
+		});
+
+		it("should adjust default variants when filtered out", () => {
+			const s = createInstance();
+			const recipe = useSliderRecipe(s, {
+				filter: { size: ["sm"] },
+			});
+
+			expect(recipe.defaultVariants?.size).toBeUndefined();
+			expect(recipe.defaultVariants?.orientation).toBe("horizontal");
+		});
+	});
+});

--- a/theme/src/recipes/slider/useSliderRecipe.ts
+++ b/theme/src/recipes/slider/useSliderRecipe.ts
@@ -1,0 +1,79 @@
+import { createUseRecipe } from "../../utils/createUseRecipe";
+
+const sizes = ["xs", "sm", "md", "lg", "xl"] as const;
+
+const thumbSizeMap: Record<string, string> = {
+	xs: "@0.75",
+	sm: "@1",
+	md: "@1.25",
+	lg: "@1.5",
+	xl: "@2",
+};
+
+/**
+ * Slider root recipe.
+ * Positioning wrapper that lays out the track and the absolutely positioned
+ * thumb. Owns orientation, the cross-axis clearance needed to fit the thumb,
+ * and the disabled state (which cascades to every part).
+ */
+export const useSliderRecipe = createUseRecipe("slider", {
+	base: {
+		position: "relative",
+		display: "inline-flex",
+		alignItems: "center",
+		justifyContent: "center",
+		userSelect: "none",
+		touchAction: "none",
+	},
+	variants: {
+		orientation: {
+			horizontal: {
+				flexDirection: "row",
+				width: "100%",
+			},
+			vertical: {
+				flexDirection: "column",
+				height: "100%",
+			},
+		},
+		size: {
+			xs: { minHeight: "@0.75" },
+			sm: { minHeight: "@1" },
+			md: { minHeight: "@1.25" },
+			lg: { minHeight: "@1.5" },
+			xl: { minHeight: "@2" },
+		},
+		disabled: {
+			true: {},
+			false: {},
+		},
+	},
+	compoundVariants: [
+		// Vertical — move the thumb clearance from the block axis to the inline axis.
+		...sizes.map((size) => ({
+			match: {
+				orientation: "vertical" as const,
+				size: size as (typeof sizes)[number],
+			},
+			css: {
+				minHeight: "0",
+				minWidth: thumbSizeMap[size],
+			},
+		})),
+
+		// Disabled — dim and block interaction for the whole control.
+		{
+			match: { disabled: "true" as const },
+			css: {
+				opacity: "0.5",
+				cursor: "not-allowed",
+				pointerEvents: "none",
+			},
+		},
+	],
+	defaultVariants: {
+		orientation: "horizontal",
+		size: "md",
+		disabled: "false",
+	},
+});

--- a/theme/src/recipes/slider/useSliderThumbRecipe.test.ts
+++ b/theme/src/recipes/slider/useSliderThumbRecipe.test.ts
@@ -1,0 +1,212 @@
+import { styleframe } from "@styleframe/core";
+import { useDarkModifier } from "../../modifiers/useMediaPreferenceModifiers";
+import { usePseudoStateModifiers } from "../../modifiers/usePseudoStateModifiers";
+import { useSliderThumbRecipe } from "./useSliderThumbRecipe";
+
+function createInstance() {
+	const s = styleframe();
+	for (const name of [
+		"position",
+		"boxSizing",
+		"borderWidth",
+		"borderStyle",
+		"borderColor",
+		"borderRadius",
+		"boxShadow",
+		"cursor",
+		"outline",
+		"transitionProperty",
+		"transitionTimingFunction",
+		"transitionDuration",
+		"width",
+		"height",
+		"background",
+		"outlineWidth",
+		"outlineStyle",
+		"outlineColor",
+		"outlineOffset",
+	]) {
+		s.utility(name, ({ value }) => ({ [name]: value }));
+	}
+	usePseudoStateModifiers(s);
+	useDarkModifier(s);
+	return s;
+}
+
+describe("useSliderThumbRecipe", () => {
+	it("should create a recipe with correct metadata", () => {
+		const s = createInstance();
+		const recipe = useSliderThumbRecipe(s);
+
+		expect(recipe.type).toBe("recipe");
+		expect(recipe.name).toBe("slider-thumb");
+	});
+
+	it("should have correct base styles", () => {
+		const s = createInstance();
+		const recipe = useSliderThumbRecipe(s);
+
+		expect(recipe.base).toEqual({
+			position: "absolute",
+			boxSizing: "border-box",
+			borderWidth: "@border-width.medium",
+			borderStyle: "@border-style.solid",
+			borderColor: "@color.white",
+			borderRadius: "@border-radius.full",
+			boxShadow: "@box-shadow.sm",
+			cursor: "grab",
+			outline: "none",
+			transitionProperty: "box-shadow, transform",
+			transitionTimingFunction: "@easing.ease-in-out",
+			transitionDuration: "150ms",
+			"&:hover": {
+				boxShadow: "@box-shadow.md",
+			},
+			"&:focus": {
+				boxShadow: "@box-shadow.md",
+			},
+			"&:focus-visible": {
+				outlineWidth: "2px",
+				outlineStyle: "solid",
+				outlineColor: "@color.primary",
+				outlineOffset: "2px",
+			},
+			"&:active": {
+				cursor: "grabbing",
+			},
+		});
+	});
+
+	describe("variants", () => {
+		it("should have all color variants", () => {
+			const s = createInstance();
+			const recipe = useSliderThumbRecipe(s);
+
+			expect(Object.keys(recipe.variants!.color)).toEqual([
+				"primary",
+				"secondary",
+				"success",
+				"info",
+				"warning",
+				"error",
+				"light",
+				"dark",
+				"neutral",
+			]);
+		});
+
+		it("should have size variants with correct styles", () => {
+			const s = createInstance();
+			const recipe = useSliderThumbRecipe(s);
+
+			expect(recipe.variants!.size).toEqual({
+				xs: { width: "@0.75", height: "@0.75" },
+				sm: { width: "@1", height: "@1" },
+				md: { width: "@1.25", height: "@1.25" },
+				lg: { width: "@1.5", height: "@1.5" },
+				xl: { width: "@2", height: "@2" },
+			});
+		});
+	});
+
+	it("should have correct default variants", () => {
+		const s = createInstance();
+		const recipe = useSliderThumbRecipe(s);
+
+		expect(recipe.defaultVariants).toEqual({
+			color: "primary",
+			size: "md",
+		});
+	});
+
+	describe("compound variants", () => {
+		it("should have 9 compound variants total", () => {
+			const s = createInstance();
+			const recipe = useSliderThumbRecipe(s);
+
+			// 6 semantic colors + 3 non-semantic (light/dark/neutral) = 9
+			expect(recipe.compoundVariants).toHaveLength(9);
+		});
+
+		it("should have correct compound variant for semantic colors", () => {
+			const s = createInstance();
+			const recipe = useSliderThumbRecipe(s);
+
+			const primary = recipe.compoundVariants!.find(
+				(cv) => cv.match.color === "primary",
+			);
+
+			expect(primary).toEqual({
+				match: { color: "primary" },
+				css: {
+					background: "@color.primary",
+				},
+			});
+		});
+
+		it("should have correct neutral color compound variant with adaptive dark mode", () => {
+			const s = createInstance();
+			const recipe = useSliderThumbRecipe(s);
+
+			const neutral = recipe.compoundVariants!.find(
+				(cv) => cv.match.color === "neutral",
+			);
+
+			expect(neutral).toEqual({
+				match: { color: "neutral" },
+				css: {
+					background: "@color.white",
+					borderColor: "@color.gray-300",
+					"&:dark": {
+						background: "@color.gray-700",
+						borderColor: "@color.gray-900",
+					},
+				},
+			});
+		});
+	});
+
+	describe("config overrides", () => {
+		it("should allow overriding base styles", () => {
+			const s = createInstance();
+			const recipe = useSliderThumbRecipe(s, {
+				base: { cursor: "pointer" },
+			});
+
+			expect(recipe.base!.cursor).toBe("pointer");
+		});
+	});
+
+	describe("filter", () => {
+		it("should filter color variants", () => {
+			const s = createInstance();
+			const recipe = useSliderThumbRecipe(s, {
+				filter: { color: ["primary"] },
+			});
+
+			expect(Object.keys(recipe.variants!.color)).toEqual(["primary"]);
+		});
+
+		it("should prune compound variants when filtering colors", () => {
+			const s = createInstance();
+			const recipe = useSliderThumbRecipe(s, {
+				filter: { color: ["primary"] },
+			});
+
+			expect(recipe.compoundVariants).toHaveLength(1);
+			expect(
+				recipe.compoundVariants!.every((cv) => cv.match.color === "primary"),
+			).toBe(true);
+		});
+
+		it("should adjust default variants when filtered out", () => {
+			const s = createInstance();
+			const recipe = useSliderThumbRecipe(s, {
+				filter: { color: ["success"] },
+			});
+
+			expect(recipe.defaultVariants?.color).toBeUndefined();
+			expect(recipe.defaultVariants?.size).toBe("md");
+		});
+	});
+});

--- a/theme/src/recipes/slider/useSliderThumbRecipe.ts
+++ b/theme/src/recipes/slider/useSliderThumbRecipe.ts
@@ -1,0 +1,123 @@
+import { createUseRecipe } from "../../utils/createUseRecipe";
+
+const colors = [
+	"primary",
+	"secondary",
+	"success",
+	"info",
+	"warning",
+	"error",
+] as const;
+
+/**
+ * Slider thumb recipe.
+ * The draggable handle. Full palette with a contrasting ring, and the
+ * interactive focus/hover/active states a keyboard- and pointer-operable
+ * control needs. Positioned absolutely by the consumer; this recipe owns the
+ * handle's appearance, not its location.
+ */
+export const useSliderThumbRecipe = createUseRecipe("slider-thumb", {
+	base: {
+		position: "absolute",
+		boxSizing: "border-box",
+		borderWidth: "@border-width.medium",
+		borderStyle: "@border-style.solid",
+		borderColor: "@color.white",
+		borderRadius: "@border-radius.full",
+		boxShadow: "@box-shadow.sm",
+		cursor: "grab",
+		outline: "none",
+		transitionProperty: "box-shadow, transform",
+		transitionTimingFunction: "@easing.ease-in-out",
+		transitionDuration: "150ms",
+		"&:hover": {
+			boxShadow: "@box-shadow.md",
+		},
+		"&:focus": {
+			boxShadow: "@box-shadow.md",
+		},
+		"&:focus-visible": {
+			outlineWidth: "2px",
+			outlineStyle: "solid",
+			outlineColor: "@color.primary",
+			outlineOffset: "2px",
+		},
+		"&:active": {
+			cursor: "grabbing",
+		},
+	},
+	variants: {
+		color: {
+			primary: {},
+			secondary: {},
+			success: {},
+			info: {},
+			warning: {},
+			error: {},
+			light: {},
+			dark: {},
+			neutral: {},
+		},
+		size: {
+			xs: { width: "@0.75", height: "@0.75" },
+			sm: { width: "@1", height: "@1" },
+			md: { width: "@1.25", height: "@1.25" },
+			lg: { width: "@1.5", height: "@1.5" },
+			xl: { width: "@2", height: "@2" },
+		},
+	},
+	compoundVariants: [
+		// Semantic colors (dynamic) — coloured handle with the base white ring.
+		...colors.flatMap((color) => [
+			{
+				match: { color },
+				css: {
+					background: `@color.${color}`,
+				},
+			},
+		]),
+
+		// Light — fixed across themes. Gray ring so the white handle stays visible.
+		{
+			match: { color: "light" as const },
+			css: {
+				background: "@color.white",
+				borderColor: "@color.gray-300",
+				"&:dark": {
+					background: "@color.white",
+					borderColor: "@color.gray-300",
+				},
+			},
+		},
+
+		// Dark — fixed across themes.
+		{
+			match: { color: "dark" as const },
+			css: {
+				background: "@color.gray-900",
+				borderColor: "@color.gray-700",
+				"&:dark": {
+					background: "@color.gray-900",
+					borderColor: "@color.gray-700",
+				},
+			},
+		},
+
+		// Neutral — adaptive (different light/dark values).
+		{
+			match: { color: "neutral" as const },
+			css: {
+				background: "@color.white",
+				borderColor: "@color.gray-300",
+				"&:dark": {
+					background: "@color.gray-700",
+					borderColor: "@color.gray-900",
+				},
+			},
+		},
+	],
+	defaultVariants: {
+		color: "primary",
+		size: "md",
+	},
+});

--- a/theme/src/recipes/slider/useSliderTrackRecipe.test.ts
+++ b/theme/src/recipes/slider/useSliderTrackRecipe.test.ts
@@ -1,0 +1,186 @@
+import { styleframe } from "@styleframe/core";
+import { useDarkModifier } from "../../modifiers/useMediaPreferenceModifiers";
+import { useSliderTrackRecipe } from "./useSliderTrackRecipe";
+
+function createInstance() {
+	const s = styleframe();
+	for (const name of [
+		"display",
+		"overflow",
+		"borderRadius",
+		"width",
+		"height",
+		"flexDirection",
+		"background",
+	]) {
+		s.utility(name, ({ value }) => ({ [name]: value }));
+	}
+	useDarkModifier(s);
+	return s;
+}
+
+describe("useSliderTrackRecipe", () => {
+	it("should create a recipe with correct metadata", () => {
+		const s = createInstance();
+		const recipe = useSliderTrackRecipe(s);
+
+		expect(recipe.type).toBe("recipe");
+		expect(recipe.name).toBe("slider-track");
+	});
+
+	it("should have correct base styles", () => {
+		const s = createInstance();
+		const recipe = useSliderTrackRecipe(s);
+
+		expect(recipe.base).toEqual({
+			display: "flex",
+			overflow: "hidden",
+			borderRadius: "@border-radius.full",
+		});
+	});
+
+	describe("variants", () => {
+		it("should have non-semantic color variants only", () => {
+			const s = createInstance();
+			const recipe = useSliderTrackRecipe(s);
+
+			expect(Object.keys(recipe.variants!.color)).toEqual([
+				"light",
+				"dark",
+				"neutral",
+			]);
+		});
+
+		it("should have orientation variants", () => {
+			const s = createInstance();
+			const recipe = useSliderTrackRecipe(s);
+
+			expect(recipe.variants!.orientation).toEqual({
+				horizontal: {
+					width: "100%",
+				},
+				vertical: {
+					flexDirection: "column-reverse",
+					height: "100%",
+				},
+			});
+		});
+
+		it("should have size variants with correct styles", () => {
+			const s = createInstance();
+			const recipe = useSliderTrackRecipe(s);
+
+			expect(recipe.variants!.size).toEqual({
+				xs: { height: "@0.25" },
+				sm: { height: "@0.375" },
+				md: { height: "@0.5" },
+				lg: { height: "@0.75" },
+				xl: { height: "@1" },
+			});
+		});
+	});
+
+	it("should have correct default variants", () => {
+		const s = createInstance();
+		const recipe = useSliderTrackRecipe(s);
+
+		expect(recipe.defaultVariants).toEqual({
+			color: "neutral",
+			orientation: "horizontal",
+			size: "md",
+		});
+	});
+
+	describe("compound variants", () => {
+		it("should have 8 compound variants total", () => {
+			const s = createInstance();
+			const recipe = useSliderTrackRecipe(s);
+
+			// 3 non-semantic colors + 5 vertical × size overrides = 8
+			expect(recipe.compoundVariants).toHaveLength(8);
+		});
+
+		it("should have correct neutral color compound variant with adaptive dark mode", () => {
+			const s = createInstance();
+			const recipe = useSliderTrackRecipe(s);
+
+			const neutral = recipe.compoundVariants!.find(
+				(cv) => cv.match.color === "neutral",
+			);
+
+			expect(neutral).toEqual({
+				match: { color: "neutral" },
+				css: {
+					background: "@color.gray-200",
+					"&:dark": {
+						background: "@color.gray-800",
+					},
+				},
+			});
+		});
+
+		it("should have vertical × size compound variants", () => {
+			const s = createInstance();
+			const recipe = useSliderTrackRecipe(s);
+
+			const verticalMd = recipe.compoundVariants!.find(
+				(cv) => cv.match.orientation === "vertical" && cv.match.size === "md",
+			);
+
+			expect(verticalMd).toEqual({
+				match: { orientation: "vertical", size: "md" },
+				css: {
+					height: "auto",
+					width: "@0.5",
+				},
+			});
+		});
+	});
+
+	describe("config overrides", () => {
+		it("should allow overriding base styles", () => {
+			const s = createInstance();
+			const recipe = useSliderTrackRecipe(s, {
+				base: { overflow: "visible" },
+			});
+
+			expect(recipe.base!.overflow).toBe("visible");
+		});
+	});
+
+	describe("filter", () => {
+		it("should filter color variants", () => {
+			const s = createInstance();
+			const recipe = useSliderTrackRecipe(s, {
+				filter: { color: ["neutral"] },
+			});
+
+			expect(Object.keys(recipe.variants!.color)).toEqual(["neutral"]);
+		});
+
+		it("should prune compound variants when filtering colors", () => {
+			const s = createInstance();
+			const recipe = useSliderTrackRecipe(s, {
+				filter: { color: ["neutral"] },
+			});
+
+			const colorOnlyCvs = recipe.compoundVariants!.filter(
+				(cv) => cv.match.color && !cv.match.orientation,
+			);
+			expect(colorOnlyCvs).toHaveLength(1);
+			expect(colorOnlyCvs.every((cv) => cv.match.color === "neutral")).toBe(
+				true,
+			);
+		});
+
+		it("should adjust default variants when filtered out", () => {
+			const s = createInstance();
+			const recipe = useSliderTrackRecipe(s, {
+				filter: { color: ["light"] },
+			});
+
+			expect(recipe.defaultVariants?.color).toBeUndefined();
+			expect(recipe.defaultVariants?.size).toBe("md");
+		});
+	});
+});

--- a/theme/src/recipes/slider/useSliderTrackRecipe.test.ts
+++ b/theme/src/recipes/slider/useSliderTrackRecipe.test.ts
@@ -130,7 +130,7 @@ describe("useSliderTrackRecipe", () => {
 			expect(verticalMd).toEqual({
 				match: { orientation: "vertical", size: "md" },
 				css: {
-					height: "auto",
+					height: "100%",
 					width: "@0.5",
 				},
 			});

--- a/theme/src/recipes/slider/useSliderTrackRecipe.ts
+++ b/theme/src/recipes/slider/useSliderTrackRecipe.ts
@@ -1,0 +1,98 @@
+import { createUseRecipe } from "../../utils/createUseRecipe";
+
+const sizes = ["xs", "sm", "md", "lg", "xl"] as const;
+
+const railSizeMap: Record<string, string> = {
+	xs: "@0.25",
+	sm: "@0.375",
+	md: "@0.5",
+	lg: "@0.75",
+	xl: "@1",
+};
+
+/**
+ * Slider track recipe.
+ * The neutral rail that contains the colored range. Non-semantic colors only —
+ * the track is a backdrop, never a brand surface.
+ */
+export const useSliderTrackRecipe = createUseRecipe("slider-track", {
+	base: {
+		display: "flex",
+		overflow: "hidden",
+		borderRadius: "@border-radius.full",
+	},
+	variants: {
+		color: {
+			light: {},
+			dark: {},
+			neutral: {},
+		},
+		orientation: {
+			horizontal: {
+				width: "100%",
+			},
+			vertical: {
+				flexDirection: "column-reverse",
+				height: "100%",
+			},
+		},
+		size: {
+			xs: { height: "@0.25" },
+			sm: { height: "@0.375" },
+			md: { height: "@0.5" },
+			lg: { height: "@0.75" },
+			xl: { height: "@1" },
+		},
+	},
+	compoundVariants: [
+		// Light — fixed across themes.
+		{
+			match: { color: "light" as const },
+			css: {
+				background: "@color.gray-200",
+				"&:dark": {
+					background: "@color.gray-200",
+				},
+			},
+		},
+
+		// Dark — fixed across themes.
+		{
+			match: { color: "dark" as const },
+			css: {
+				background: "@color.gray-800",
+				"&:dark": {
+					background: "@color.gray-800",
+				},
+			},
+		},
+
+		// Neutral — adaptive (different light/dark values).
+		{
+			match: { color: "neutral" as const },
+			css: {
+				background: "@color.gray-200",
+				"&:dark": {
+					background: "@color.gray-800",
+				},
+			},
+		},
+
+		// Vertical size overrides — swap rail thickness from height to width.
+		...sizes.map((size) => ({
+			match: {
+				orientation: "vertical" as const,
+				size: size as (typeof sizes)[number],
+			},
+			css: {
+				height: "auto",
+				width: railSizeMap[size],
+			},
+		})),
+	],
+	defaultVariants: {
+		color: "neutral",
+		orientation: "horizontal",
+		size: "md",
+	},
+});

--- a/theme/src/recipes/slider/useSliderTrackRecipe.ts
+++ b/theme/src/recipes/slider/useSliderTrackRecipe.ts
@@ -79,13 +79,15 @@ export const useSliderTrackRecipe = createUseRecipe("slider-track", {
 		},
 
 		// Vertical size overrides — swap rail thickness from height to width.
+		// The rail must fill the root's length (height: 100%) so the range's
+		// percentage height resolves; only its thickness moves to the width axis.
 		...sizes.map((size) => ({
 			match: {
 				orientation: "vertical" as const,
 				size: size as (typeof sizes)[number],
 			},
 			css: {
-				height: "auto",
+				height: "100%",
 				width: railSizeMap[size],
 			},
 		})),


### PR DESCRIPTION
## Summary

- Adds `useSliderRecipe`, `useSliderTrackRecipe`, `useSliderRangeRecipe`, and `useSliderThumbRecipe` to `@styleframe/theme`
- Supports color (light/dark/neutral), size (xs/sm/md/lg/xl), and orientation (horizontal/vertical) axes with disabled and invalid states
- Track renders the unfilled groove, range fills the selected region, and thumb is the draggable handle with focus-ring, hover, and active states
- Includes Storybook showcase components and documentation page

## Test plan

- [ ] `pnpm test` passes for `theme/src/recipes/slider/`
- [ ] Storybook renders all slider variants correctly
- [ ] Docs page renders at `/components/forms/slider`