### PR TITLE
feat(theme): add Toggle and ToggleGroup recipes

### DIFF
--- a/.changeset/toggle-recipe.md
+++ b/.changeset/toggle-recipe.md
@@ -1,0 +1,8 @@
+---
+"@styleframe/theme": minor
+"styleframe": minor
+---
+
+Add Toggle and ToggleGroup recipes.
+
+Adds two interactive button recipes: `useToggleRecipe()` styles a single toggleable button with pressed/active states driven by `aria-pressed`, and `useToggleGroupRecipe()` composes multiple toggles into a segmented control with connected borders. Both support `solid`, `outline`, `soft`, `subtle`, and `ghost` variants, `primary`, `secondary`, `success`, `info`, `warning`, `error`, and `neutral` colors, and `xs` / `sm` / `md` / `lg` / `xl` sizes.

--- a/apps/docs/content/docs/05.components/05.forms/05.toggle.md
+++ b/apps/docs/content/docs/05.components/05.forms/05.toggle.md
@@ -1,0 +1,383 @@
+---
+title: Toggle
+description: A button-styled two-state control with an on state driven by aria-pressed, ghost and outline visual styles, light, dark, and neutral surface colors, and three sizes through the recipe system.
+navigation:
+    icon: false
+---
+
+## Overview
+
+The **Toggle** is a two-state button &mdash; pressed or not pressed &mdash; the kind you reach for in a text-editor toolbar (Bold, Italic) or a view switcher. Semantically it behaves like a checkbox (on/off, and several can be on inside a group), but it is presented as a button. The `useToggleRecipe()` composable creates a fully configured [recipe](/docs/api/recipes) with color, variant, and size options &mdash; plus compound variants that handle every color-variant combination automatically.
+
+The on state rides on `aria-pressed`: render the control as a native `<button>`, flip `aria-pressed` in your handler, and the recipe's `&:aria-pressed` rule styles the result. There is no `pressed` recipe argument &mdash; it is runtime DOM state, exactly as `:hover` is not an argument.
+
+The Toggle recipe integrates directly with the default [design tokens preset](/docs/theme/design-tokens/presets) and generates type-safe utility classes at build time with zero runtime CSS.
+
+## Why use the Toggle recipe?
+
+The Toggle recipe helps you:
+
+- **Ship faster with sensible defaults**: Get 3 surface colors, 2 visual styles, and 3 sizes out of the box with a single composable call.
+- **Use a standards-based on state**: The pressed look is driven by `aria-pressed` (the WAI-ARIA toggle-button pattern), so the control stays keyboard-accessible with no extra wiring beyond toggling the attribute.
+- **Maintain consistency**: The pressed appearance reuses each color/variant's `:active` fill, so a pressed toggle reads as the same "actively pressed" step everywhere.
+- **Customize without forking**: Override base styles, default variants, or filter out options you don't need &mdash; all through the options API.
+- **Stay type-safe**: Full TypeScript support means your editor catches invalid color, variant, or size values at compile time.
+- **Integrate with your tokens**: Every value references the design tokens preset, so theme changes propagate automatically.
+
+## Usage
+
+::steps{level="4"}
+
+#### Register the recipe
+
+Add the Toggle recipe to a local Styleframe instance. The global `styleframe.config.ts` provides design tokens and utilities, while the component-level file registers the recipe itself:
+
+:::code-tree{default-value="src/components/toggle.styleframe.ts"}
+
+```ts [src/components/toggle.styleframe.ts]
+import { styleframe } from 'virtual:styleframe';
+import { useToggleRecipe } from '@styleframe/theme';
+
+const s = styleframe();
+
+const toggle = useToggleRecipe(s);
+
+export default s;
+```
+
+```ts [styleframe.config.ts]
+import { styleframe } from 'styleframe';
+import { useDesignTokensPreset, useUtilitiesPreset } from '@styleframe/theme';
+
+const s = styleframe();
+
+useDesignTokensPreset(s);
+useUtilitiesPreset(s);
+
+export default s;
+```
+
+:::
+
+#### Build the component
+
+Render a native `<button>`, bind the `toggle` runtime function to its class, and flip `aria-pressed` on click. The recipe's `&:aria-pressed` rule styles the pressed state:
+
+::framework-switcher
+
+#vue
+
+```vue [src/components/Toggle.vue]
+<script setup lang="ts">
+import { ref } from "vue";
+import { toggle } from "virtual:styleframe";
+
+const {
+	color = "neutral",
+	variant = "ghost",
+	size = "md",
+} = defineProps<{
+	color?: "light" | "dark" | "neutral";
+	variant?: "ghost" | "outline";
+	size?: "sm" | "md" | "lg";
+}>();
+
+const pressed = ref(false);
+</script>
+
+<template>
+	<button
+		type="button"
+		:class="toggle({ color, variant, size })"
+		:aria-pressed="pressed"
+		@click="pressed = !pressed"
+	>
+		<slot />
+	</button>
+</template>
+```
+
+#react
+
+```ts [src/components/Toggle.tsx]
+import { useState } from "react";
+import { toggle } from "virtual:styleframe";
+
+interface ToggleProps {
+	color?: "light" | "dark" | "neutral";
+	variant?: "ghost" | "outline";
+	size?: "sm" | "md" | "lg";
+	children?: React.ReactNode;
+}
+
+export function Toggle({
+	color = "neutral",
+	variant = "ghost",
+	size = "md",
+	children,
+}: ToggleProps) {
+	const [pressed, setPressed] = useState(false);
+
+	return (
+		<button
+			type="button"
+			className={toggle({ color, variant, size })}
+			aria-pressed={pressed}
+			onClick={() => setPressed(!pressed)}
+		>
+			{children}
+		</button>
+	);
+}
+```
+
+#other
+
+The `toggle()` runtime returns a class string. Apply it however your framework binds classes, and toggle `aria-pressed` yourself:
+
+```ts [src/components/toggle.ts]
+import { toggle } from "virtual:styleframe";
+
+const classes = toggle({ color: "neutral", variant: "ghost", size: "md" });
+// → "toggle _display:inline-flex _align-items:center ..."
+```
+
+```html [src/components/toggle.html]
+<button type="button" class="toggle _display:inline-flex ..." aria-pressed="false">
+	Bold
+</button>
+```
+
+::
+
+#### See it in action
+
+:::story-preview
+---
+story: theme-recipes-forms-toggle--default
+panel: true
+---
+:::
+
+::
+
+## Colors
+
+The Toggle includes 3 color variants: `light`, `dark`, and `neutral`. Like the [Checkbox](/docs/components/forms/checkbox) and [Switch](/docs/components/forms/switch) recipes, these are neutral-spectrum surface colors rather than status colors &mdash; the color sets the toggle's text and the gray fill used on hover and when pressed.
+
+The `neutral` color adapts automatically: dark text with light fills in light mode, and light text with dark fills in dark mode, making it the safest default for general-purpose toolbars.
+
+::story-preview
+---
+story: theme-recipes-forms-toggle--neutral
+panel: true
+---
+::
+
+### Color Reference
+
+::story-preview
+---
+story: theme-recipes-forms-toggle--all-variants
+height: 480
+---
+::
+
+| Color | Token | Use Case |
+|-------|-------|----------|
+| `light` | `@color.gray-200` (pressed fill) | Light surfaces, stays light in dark mode |
+| `dark` | `@color.gray-750` (pressed fill) | Dark surfaces, stays dark in light mode |
+| `neutral` | Adaptive (light &harr; dark) | Default color, adapts to the current color scheme |
+
+::tip
+**Pro tip:** Use `neutral` as your default toggle color. It adapts to the user's color scheme automatically, so you don't need to manage light and dark surfaces separately.
+::
+
+## Variants
+
+The Toggle ships 2 visual styles that control the resting surface. Both reuse the same pressed appearance &mdash; the difference is whether the control carries a border at rest.
+
+### Ghost
+
+The default. A transparent surface that fills with a subtle gray on hover and pressed &mdash; ideal for dense toolbars where borders would add noise.
+
+::story-preview
+---
+story: theme-recipes-forms-toggle--ghost
+panel: true
+---
+::
+
+### Outline
+
+A bordered surface that reads as a distinct slot even at rest &mdash; the natural choice for segmented controls.
+
+::story-preview
+---
+story: theme-recipes-forms-toggle--outline
+panel: true
+---
+::
+
+## Sizes
+
+Three size variants from `sm` to `lg` control the font size and padding. The border radius stays `@border-radius.md` at every size.
+
+::story-preview
+---
+story: theme-recipes-forms-toggle--all-sizes
+height: 320
+---
+::
+
+### Size Reference
+
+| Size | Font Size | Padding (Y &times; X) |
+|------|-----------|------------------------|
+| `sm` | `@font-size.xs` | `@0.375` &times; `@0.625` |
+| `md` | `@font-size.sm` | `@0.5` &times; `@0.75` |
+| `lg` | `@font-size.md` | `@0.625` &times; `@0.875` |
+
+## States
+
+### On
+
+`&:aria-pressed` reuses each color/variant's `:active` fill, so a pressed toggle reads as the actively-pressed step held persistently. Set `aria-pressed="true"` on the button (and flip it in your click handler); bind a controlled value or `v-model` as usual.
+
+::story-preview
+---
+story: theme-recipes-forms-toggle--pressed
+panel: true
+---
+::
+
+### Disabled
+
+`:disabled` dims the toggle to `0.75` opacity, switches the cursor to `not-allowed`, and removes pointer events. Mirror it with the native `disabled` attribute so the button also leaves the tab order.
+
+::story-preview
+---
+story: theme-recipes-forms-toggle--disabled
+panel: true
+---
+::
+
+## Accessibility
+
+- **Render a native `<button>`.** A real `<button type="button">` is focusable and activates on Space/Enter for free; the recipe only supplies the styling.
+- **Expose the on state with `aria-pressed`.** Set `aria-pressed="true"` / `"false"` so assistive technology announces "pressed" / "not pressed" &mdash; the WAI-ARIA toggle-button pattern. The recipe's `&:aria-pressed` rule styles the on state.
+- **Give every toggle a name.** Visible text content names the control; for an icon-only toggle, add an `aria-label`.
+- **Don't rely on the fill alone.** The pressed background is the primary visual cue, satisfying it for most cases &mdash; but for critical toggles reinforce the state (e.g. a filled vs. outline icon) so it does not rest on a subtle background change. See [WCAG 1.4.1](https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html).
+- **Mirror `disabled` on the button.** Set the native `disabled` attribute in addition to the styling so the control leaves the tab order.
+- **Verify contrast.** The focus ring is `@color.primary`. Default tokens meet WCAG AA; if you override colors, verify with the [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/).
+
+## Customization
+
+### Overriding Defaults
+
+The `useToggleRecipe()` composable accepts an optional second argument to override any part of the recipe configuration. Overrides are deep-merged with the defaults, so you only need to specify the properties you want to change:
+
+```ts [src/components/toggle.styleframe.ts]
+import { styleframe } from 'virtual:styleframe';
+import { useToggleRecipe } from '@styleframe/theme';
+
+const s = styleframe();
+
+const toggle = useToggleRecipe(s, {
+    defaultVariants: {
+        color: 'neutral',
+        variant: 'outline',
+        size: 'lg',
+    },
+});
+
+export default s;
+```
+
+### Filtering Variants
+
+If you only need a subset of the available variants, use the `filter` option to limit which values are generated. This reduces the output CSS and keeps your component API focused:
+
+```ts [src/components/toggle.styleframe.ts]
+import { styleframe } from 'virtual:styleframe';
+import { useToggleRecipe } from '@styleframe/theme';
+
+const s = styleframe();
+
+// Only generate the neutral color with the outline variant
+const toggle = useToggleRecipe(s, {
+    filter: {
+        color: ['neutral'],
+        variant: ['outline'],
+    },
+});
+
+export default s;
+```
+
+::note
+**Good to know:** Filtering also removes compound variants and adjusts default variants that reference filtered-out values, so your recipe stays consistent.
+::
+
+## API Reference
+
+### `useToggleRecipe(s, options?)`
+
+Creates the toggle recipe &mdash; a `<button>` with color, variant, and size axes whose pressed state (`&:aria-pressed`) reuses each combination's `:active` fill.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `s` | `Styleframe` | The Styleframe instance |
+| `options` | `DeepPartial<RecipeConfig>` | Optional overrides for the recipe configuration |
+| `options.base` | `VariantDeclarationsBlock` | Custom base styles |
+| `options.variants` | `Variants` | Custom variant definitions |
+| `options.defaultVariants` | `Record<keyof Variants, string>` | Default variant values |
+| `options.compoundVariants` | `CompoundVariant[]` | Custom compound variant definitions |
+| `options.filter` | `Record<string, string[]>` | Limit which variant values are generated |
+
+**Variants:**
+
+| Variant | Options | Default |
+|---------|---------|---------|
+| `color` | `light`, `dark`, `neutral` | `neutral` |
+| `variant` | `ghost`, `outline` | `ghost` |
+| `size` | `sm`, `md`, `lg` | `md` |
+
+[Learn more about recipes &rarr;](/docs/api/recipes)
+
+## Best Practices
+
+- **Render a real button**: Use `<button type="button">` with `aria-pressed` so the control is keyboard-accessible and screen readers announce its on/off state.
+- **Use `neutral` for general use**: The neutral color adapts to light and dark mode automatically, making it the safest default.
+- **Reach for a toggle, not a checkbox, for instant on/off**: Use a toggle for toolbar actions and formatting that apply immediately; use a [Checkbox](/docs/components/forms/checkbox) when the choice is submitted with a form.
+- **Group related toggles**: Lay out a set with the [Toggle Group](/docs/components/forms/toggle-group) recipe, or join them into a connected segmented control with [Field Group](/docs/components/forms/field-group).
+- **Reinforce critical states**: When the pressed state matters, pair it with an icon change so it doesn't rely on the background fill alone.
+
+## FAQ
+
+::accordion
+
+:::accordion-item{label="How does aria-pressed drive the on state?" icon="i-lucide-circle-help"}
+The recipe registers a `&:aria-pressed` rule (which compiles to `&[aria-pressed="true"]`) that reuses each color/variant's `:active` fill. You toggle the attribute on the `<button>` in your handler; the CSS lights up automatically. There is no on-color recipe argument &mdash; the pressed look is the actively-pressed step of whatever color you picked.
+[Learn more about compound variants &rarr;](/docs/api/recipes#compound-variants)
+:::
+
+:::accordion-item{label="Why only ghost and outline, not solid or soft?" icon="i-lucide-circle-help"}
+Toggles read as low-emphasis controls: `ghost` (transparent) suits dense toolbars and `outline` (bordered) suits segmented controls, which covers the common cases. If you need more surfaces, add them through the `options.variants` and `options.compoundVariants` overrides.
+:::
+
+:::accordion-item{label="Why is the color light/dark/neutral instead of primary/success/error?" icon="i-lucide-circle-help"}
+The `color` axis controls a neutral surface, not a status, mirroring the [Checkbox](/docs/components/forms/checkbox), [Switch](/docs/components/forms/switch), and [Input](/docs/components/forms/input) recipes. The pressed appearance is the `:active` gray step of that surface rather than a separate accent fill.
+:::
+
+:::accordion-item{label="When should I use a Toggle instead of a Switch or Checkbox?" icon="i-lucide-circle-help"}
+Use a Toggle for a button-styled on/off control &mdash; toolbar formatting, view switches, segmented controls. Use a [Switch](/docs/components/forms/switch) for an instant setting rendered as a sliding control, and a [Checkbox](/docs/components/forms/checkbox) for a choice submitted with a form.
+:::
+
+:::accordion-item{label="How do I build a connected segmented control?" icon="i-lucide-circle-help"}
+Wrap your toggles in the [Field Group](/docs/components/forms/field-group) recipe. It merges adjacent border radii and inner borders on any bordered child, so a row of `outline` toggles reads as one joined control. For spaced (non-joined) layouts, use the [Toggle Group](/docs/components/forms/toggle-group) recipe instead.
+:::
+
+::

--- a/apps/docs/content/docs/05.components/05.forms/05.toggle.md
+++ b/apps/docs/content/docs/05.components/05.forms/05.toggle.md
@@ -19,7 +19,7 @@ The Toggle recipe helps you:
 
 - **Ship faster with sensible defaults**: Get 3 surface colors, 3 visual styles, and 3 sizes out of the box with a single composable call.
 - **Use a standards-based on state**: The pressed look is driven by `aria-pressed` (the WAI-ARIA toggle-button pattern), so the control stays keyboard-accessible with no extra wiring beyond toggling the attribute.
-- **Maintain consistency**: The pressed appearance reuses each color/variant's `:active` fill, so a pressed toggle reads as the same "actively pressed" step everywhere.
+- **Maintain consistency**: The on appearance reuses each color/variant's `:hover` fill, so an on toggle reads as the same gentle hover step everywhere.
 - **Customize without forking**: Override base styles, default variants, or filter out options you don't need &mdash; all through the options API.
 - **Stay type-safe**: Full TypeScript support means your editor catches invalid color, variant, or size values at compile time.
 - **Integrate with your tokens**: Every value references the design tokens preset, so theme changes propagate automatically.
@@ -163,7 +163,7 @@ panel: true
 
 ## Colors
 
-The Toggle includes 3 color variants: `light`, `dark`, and `neutral`. Like the [Checkbox](/docs/components/forms/checkbox) and [Switch](/docs/components/forms/switch) recipes, these are neutral-spectrum surface colors rather than status colors &mdash; the color sets the toggle's text and its gray ramp. The `solid` variant wears that gray as a resting fill; `outline` and `ghost` stay transparent until they deepen to the engaged fill on hover, focus, and when pressed.
+The Toggle includes 3 color variants: `light`, `dark`, and `neutral`. Like the [Checkbox](/docs/components/forms/checkbox) and [Switch](/docs/components/forms/switch) recipes, these are neutral-spectrum surface colors rather than status colors &mdash; the color sets the toggle's surface and text, matching the [Button](/docs/components/actions/button) recipe. The `solid` variant is a filled surface with a subtle border; `outline` and `ghost` stay transparent and fill on hover, focus, and when pressed.
 
 The `neutral` color adapts automatically: dark text on a light surface in light mode, and light text on a dark surface in dark mode, making it the safest default for general-purpose toolbars.
 
@@ -185,8 +185,8 @@ height: 680
 
 | Color | Token | Use Case |
 |-------|-------|----------|
-| `light` | `@color.gray-100` (surface) | Light surfaces, stays light in dark mode |
-| `dark` | `@color.gray-800` (surface) | Dark surfaces, stays dark in light mode |
+| `light` | `@color.white` (surface) | Light surfaces, stays light in dark mode |
+| `dark` | `@color.gray-900` (surface) | Dark surfaces, stays dark in light mode |
 | `neutral` | Adaptive (light &harr; dark) | Default color, adapts to the current color scheme |
 
 ::tip
@@ -195,11 +195,11 @@ height: 680
 
 ## Variants
 
-The Toggle ships 3 visual styles. They share the same engaged fill; the difference is the resting surface &mdash; `solid` carries a soft gray fill, while `outline` and `ghost` stay transparent until engaged.
+The Toggle ships 3 visual styles that mirror the [Button](/docs/components/actions/button) recipe's `solid`, `outline`, and `ghost` variants. Each gives hover, focus, and active feedback, and its on state reuses the hover fill; the difference is the resting surface.
 
 ### Solid
 
-The default. A soft gray surface with no border, so it reads as a filled button at rest and deepens one step on hover, focus, and when pressed &mdash; the safe choice for standalone toggles that should look clickable.
+The default. A filled surface with a subtle border &mdash; identical to a `solid` [Button](/docs/components/actions/button) at rest &mdash; so it reads as clearly clickable. It shifts to a soft gray on hover and focus &mdash; the same fill it carries when on. The safe choice for standalone toggles.
 
 ::story-preview
 ---
@@ -253,7 +253,7 @@ height: 320
 
 ### On
 
-`&:aria-pressed` shares each color/variant's `:active` fill (e.g. `gray-150`) &mdash; for `solid` one step deeper than its resting surface, for `outline` and `ghost` a fill over their transparent rest &mdash; so a pressed toggle reads as gently engaged and held persistently. Set `aria-pressed="true"` on the button (and flip it in your click handler); bind a controlled value or `v-model` as usual.
+`&:aria-pressed` reuses each color/variant's `:hover` fill (e.g. `gray-100`) &mdash; the same soft surface the toggle shows on hover &mdash; so an on toggle reads as gently filled and held. Set `aria-pressed="true"` on the button (and flip it in your click handler); bind a controlled value or `v-model` as usual.
 
 ::story-preview
 ---
@@ -334,7 +334,7 @@ export default s;
 
 ### `useToggleRecipe(s, options?)`
 
-Creates the toggle recipe &mdash; a `<button>` with color, variant, and size axes whose pressed state (`&:aria-pressed`) reuses each combination's `:active` fill.
+Creates the toggle recipe &mdash; a `<button>` with color, variant, and size axes whose pressed state (`&:aria-pressed`) reuses each combination's `:hover` fill.
 
 **Parameters:**
 
@@ -371,7 +371,7 @@ Creates the toggle recipe &mdash; a `<button>` with color, variant, and size axe
 ::accordion
 
 :::accordion-item{label="How does aria-pressed drive the on state?" icon="i-lucide-circle-help"}
-The recipe registers a `&:aria-pressed` rule (which compiles to `&[aria-pressed="true"]`) that reuses each color/variant's `:active` fill. You toggle the attribute on the `<button>` in your handler; the CSS lights up automatically. There is no on-color recipe argument &mdash; the pressed look is the actively-pressed step of whatever color you picked.
+The recipe registers a `&:aria-pressed` rule (which compiles to `&[aria-pressed="true"]`) that reuses each color/variant's `:hover` fill. You toggle the attribute on the `<button>` in your handler; the CSS lights up automatically. There is no on-color recipe argument &mdash; the on look is the hover step of whatever color you picked.
 [Learn more about compound variants &rarr;](/docs/api/recipes#compound-variants)
 :::
 
@@ -380,7 +380,7 @@ These three cover the common cases: `solid` (filled) for standalone toggles that
 :::
 
 :::accordion-item{label="Why is the color light/dark/neutral instead of primary/success/error?" icon="i-lucide-circle-help"}
-The `color` axis controls a neutral surface, not a status, mirroring the [Checkbox](/docs/components/forms/checkbox), [Switch](/docs/components/forms/switch), and [Input](/docs/components/forms/input) recipes. The pressed appearance is the `:active` gray step of that surface rather than a separate accent fill.
+The `color` axis controls a neutral surface, not a status, mirroring the [Checkbox](/docs/components/forms/checkbox), [Switch](/docs/components/forms/switch), and [Input](/docs/components/forms/input) recipes. The on appearance is the `:hover` gray step of that surface rather than a separate accent fill.
 :::
 
 :::accordion-item{label="When should I use a Toggle instead of a Switch or Checkbox?" icon="i-lucide-circle-help"}

--- a/apps/docs/content/docs/05.components/05.forms/05.toggle.md
+++ b/apps/docs/content/docs/05.components/05.forms/05.toggle.md
@@ -1,6 +1,6 @@
 ---
 title: Toggle
-description: A button-styled two-state control with an on state driven by aria-pressed, ghost and outline visual styles, light, dark, and neutral surface colors, and three sizes through the recipe system.
+description: A button-styled two-state control with an on state driven by aria-pressed, solid, outline, and ghost visual styles, light, dark, and neutral surface colors, and three sizes through the recipe system.
 navigation:
     icon: false
 ---
@@ -17,7 +17,7 @@ The Toggle recipe integrates directly with the default [design tokens preset](/d
 
 The Toggle recipe helps you:
 
-- **Ship faster with sensible defaults**: Get 3 surface colors, 2 visual styles, and 3 sizes out of the box with a single composable call.
+- **Ship faster with sensible defaults**: Get 3 surface colors, 3 visual styles, and 3 sizes out of the box with a single composable call.
 - **Use a standards-based on state**: The pressed look is driven by `aria-pressed` (the WAI-ARIA toggle-button pattern), so the control stays keyboard-accessible with no extra wiring beyond toggling the attribute.
 - **Maintain consistency**: The pressed appearance reuses each color/variant's `:active` fill, so a pressed toggle reads as the same "actively pressed" step everywhere.
 - **Customize without forking**: Override base styles, default variants, or filter out options you don't need &mdash; all through the options API.
@@ -74,11 +74,11 @@ import { toggle } from "virtual:styleframe";
 
 const {
 	color = "neutral",
-	variant = "ghost",
+	variant = "solid",
 	size = "md",
 } = defineProps<{
 	color?: "light" | "dark" | "neutral";
-	variant?: "ghost" | "outline";
+	variant?: "solid" | "outline" | "ghost";
 	size?: "sm" | "md" | "lg";
 }>();
 
@@ -105,14 +105,14 @@ import { toggle } from "virtual:styleframe";
 
 interface ToggleProps {
 	color?: "light" | "dark" | "neutral";
-	variant?: "ghost" | "outline";
+	variant?: "solid" | "outline" | "ghost";
 	size?: "sm" | "md" | "lg";
 	children?: React.ReactNode;
 }
 
 export function Toggle({
 	color = "neutral",
-	variant = "ghost",
+	variant = "solid",
 	size = "md",
 	children,
 }: ToggleProps) {
@@ -138,7 +138,7 @@ The `toggle()` runtime returns a class string. Apply it however your framework b
 ```ts [src/components/toggle.ts]
 import { toggle } from "virtual:styleframe";
 
-const classes = toggle({ color: "neutral", variant: "ghost", size: "md" });
+const classes = toggle({ color: "neutral", variant: "solid", size: "md" });
 // → "toggle _display:inline-flex _align-items:center ..."
 ```
 
@@ -163,9 +163,9 @@ panel: true
 
 ## Colors
 
-The Toggle includes 3 color variants: `light`, `dark`, and `neutral`. Like the [Checkbox](/docs/components/forms/checkbox) and [Switch](/docs/components/forms/switch) recipes, these are neutral-spectrum surface colors rather than status colors &mdash; the color sets the toggle's text and the gray fill used on hover and when pressed.
+The Toggle includes 3 color variants: `light`, `dark`, and `neutral`. Like the [Checkbox](/docs/components/forms/checkbox) and [Switch](/docs/components/forms/switch) recipes, these are neutral-spectrum surface colors rather than status colors &mdash; the color sets the toggle's text and its gray ramp. The `solid` variant wears that gray as a resting fill; `outline` and `ghost` stay transparent until they deepen to the engaged fill on hover, focus, and when pressed.
 
-The `neutral` color adapts automatically: dark text with light fills in light mode, and light text with dark fills in dark mode, making it the safest default for general-purpose toolbars.
+The `neutral` color adapts automatically: dark text on a light surface in light mode, and light text on a dark surface in dark mode, making it the safest default for general-purpose toolbars.
 
 ::story-preview
 ---
@@ -179,14 +179,14 @@ panel: true
 ::story-preview
 ---
 story: theme-recipes-forms-toggle--all-variants
-height: 480
+height: 680
 ---
 ::
 
 | Color | Token | Use Case |
 |-------|-------|----------|
-| `light` | `@color.gray-200` (pressed fill) | Light surfaces, stays light in dark mode |
-| `dark` | `@color.gray-750` (pressed fill) | Dark surfaces, stays dark in light mode |
+| `light` | `@color.gray-100` (surface) | Light surfaces, stays light in dark mode |
+| `dark` | `@color.gray-800` (surface) | Dark surfaces, stays dark in light mode |
 | `neutral` | Adaptive (light &harr; dark) | Default color, adapts to the current color scheme |
 
 ::tip
@@ -195,26 +195,37 @@ height: 480
 
 ## Variants
 
-The Toggle ships 2 visual styles that control the resting surface. Both reuse the same pressed appearance &mdash; the difference is whether the control carries a border at rest.
+The Toggle ships 3 visual styles. They share the same engaged fill; the difference is the resting surface &mdash; `solid` carries a soft gray fill, while `outline` and `ghost` stay transparent until engaged.
 
-### Ghost
+### Solid
 
-The default. A transparent surface that fills with a subtle gray on hover and pressed &mdash; ideal for dense toolbars where borders would add noise.
+The default. A soft gray surface with no border, so it reads as a filled button at rest and deepens one step on hover, focus, and when pressed &mdash; the safe choice for standalone toggles that should look clickable.
 
 ::story-preview
 ---
-story: theme-recipes-forms-toggle--ghost
+story: theme-recipes-forms-toggle--solid
 panel: true
 ---
 ::
 
 ### Outline
 
-A bordered surface that reads as a distinct slot even at rest &mdash; the natural choice for segmented controls.
+Transparent with a border, so each toggle reads as a distinct slot and fills only when engaged &mdash; the natural choice for segmented controls.
 
 ::story-preview
 ---
 story: theme-recipes-forms-toggle--outline
+panel: true
+---
+::
+
+### Ghost
+
+Transparent with no border, filling only on hover and when pressed &mdash; ideal for dense toolbars where borders and a resting fill would add noise.
+
+::story-preview
+---
+story: theme-recipes-forms-toggle--ghost
 panel: true
 ---
 ::
@@ -242,7 +253,7 @@ height: 320
 
 ### On
 
-`&:aria-pressed` reuses each color/variant's `:active` fill, so a pressed toggle reads as the actively-pressed step held persistently. Set `aria-pressed="true"` on the button (and flip it in your click handler); bind a controlled value or `v-model` as usual.
+`&:aria-pressed` shares each color/variant's `:active` fill (e.g. `gray-150`) &mdash; for `solid` one step deeper than its resting surface, for `outline` and `ghost` a fill over their transparent rest &mdash; so a pressed toggle reads as gently engaged and held persistently. Set `aria-pressed="true"` on the button (and flip it in your click handler); bind a controlled value or `v-model` as usual.
 
 ::story-preview
 ---
@@ -342,7 +353,7 @@ Creates the toggle recipe &mdash; a `<button>` with color, variant, and size axe
 | Variant | Options | Default |
 |---------|---------|---------|
 | `color` | `light`, `dark`, `neutral` | `neutral` |
-| `variant` | `ghost`, `outline` | `ghost` |
+| `variant` | `solid`, `outline`, `ghost` | `solid` |
 | `size` | `sm`, `md`, `lg` | `md` |
 
 [Learn more about recipes &rarr;](/docs/api/recipes)
@@ -364,8 +375,8 @@ The recipe registers a `&:aria-pressed` rule (which compiles to `&[aria-pressed=
 [Learn more about compound variants &rarr;](/docs/api/recipes#compound-variants)
 :::
 
-:::accordion-item{label="Why only ghost and outline, not solid or soft?" icon="i-lucide-circle-help"}
-Toggles read as low-emphasis controls: `ghost` (transparent) suits dense toolbars and `outline` (bordered) suits segmented controls, which covers the common cases. If you need more surfaces, add them through the `options.variants` and `options.compoundVariants` overrides.
+:::accordion-item{label="Why solid, outline, and ghost, not soft or subtle?" icon="i-lucide-circle-help"}
+These three cover the common cases: `solid` (filled) for standalone toggles that should look clickable, `outline` (bordered) for segmented controls, and `ghost` (transparent) for dense toolbars. If you need more surfaces, add them through the `options.variants` and `options.compoundVariants` overrides.
 :::
 
 :::accordion-item{label="Why is the color light/dark/neutral instead of primary/success/error?" icon="i-lucide-circle-help"}

--- a/apps/docs/content/docs/05.components/05.forms/06.toggle-group.md
+++ b/apps/docs/content/docs/05.components/05.forms/06.toggle-group.md
@@ -1,0 +1,324 @@
+---
+title: Toggle Group
+description: A layout component for arranging a set of toggles with shared orientation and spacing. Supports horizontal and vertical layouts and three gap sizes through the recipe system.
+navigation:
+    icon: false
+---
+
+## Overview
+
+The **Toggle Group** is a layout component that arranges related [toggles](/docs/components/forms/toggle) into a single, consistently spaced set &mdash; the foundation of a toolbar or a segmented control. The `useToggleGroupRecipe()` composable creates a fully configured [recipe](/docs/api/recipes) with orientation and size options &mdash; a flex container that lays toggles out in a wrapping row or stacks them in a column.
+
+The Toggle Group recipe integrates directly with the [Toggle recipe](/docs/components/forms/toggle) and generates type-safe utility classes at build time with zero runtime CSS.
+
+## Why use the Toggle Group recipe?
+
+The Toggle Group recipe helps you:
+
+- **Lay out sets consistently**: Lay toggles out in a wrapping row or stack them in a column with a single orientation prop.
+- **Control spacing with one axis**: The size variant sets the gap between items, so a whole group scales together.
+- **Compose, don't couple**: The group only handles layout; each child toggle keeps its own color, variant, size, and pressed state.
+- **Stay type-safe**: Full TypeScript support means your editor catches invalid orientation or size values at compile time.
+
+## Usage
+
+::steps{level="4"}
+
+#### Register the recipe
+
+Add the Toggle Group recipe to a local Styleframe instance alongside the toggle recipe. The global `styleframe.config.ts` provides design tokens and utilities, while the component-level file registers the recipes themselves:
+
+:::code-tree{default-value="src/components/toggle-group.styleframe.ts"}
+
+```ts [src/components/toggle-group.styleframe.ts]
+import { styleframe } from 'virtual:styleframe';
+import { useToggleRecipe, useToggleGroupRecipe } from '@styleframe/theme';
+
+const s = styleframe();
+
+const toggle = useToggleRecipe(s);
+const toggleGroup = useToggleGroupRecipe(s);
+
+export default s;
+```
+
+```ts [styleframe.config.ts]
+import { styleframe } from 'styleframe';
+import { useDesignTokensPreset, useUtilitiesPreset } from '@styleframe/theme';
+
+const s = styleframe();
+
+useDesignTokensPreset(s);
+useUtilitiesPreset(s);
+
+export default s;
+```
+
+:::
+
+#### Build the component
+
+Import the `toggleGroup` runtime function from the virtual module and wrap your toggles in the container:
+
+::framework-switcher
+
+#vue
+
+```vue [src/components/ToggleGroup.vue]
+<script setup lang="ts">
+import { toggleGroup } from "virtual:styleframe";
+
+const { orientation = "horizontal", size = "md" } = defineProps<{
+	orientation?: "horizontal" | "vertical";
+	size?: "sm" | "md" | "lg";
+}>();
+</script>
+
+<template>
+	<div :class="toggleGroup({ orientation, size })" role="group">
+		<slot />
+	</div>
+</template>
+```
+
+#react
+
+```ts [src/components/ToggleGroup.tsx]
+import { toggleGroup } from "virtual:styleframe";
+
+interface ToggleGroupProps {
+	orientation?: "horizontal" | "vertical";
+	size?: "sm" | "md" | "lg";
+	children?: React.ReactNode;
+}
+
+export function ToggleGroup({
+	orientation = "horizontal",
+	size = "md",
+	children,
+}: ToggleGroupProps) {
+	const classes = toggleGroup({ orientation, size });
+
+	return (
+		<div className={classes} role="group">
+			{children}
+		</div>
+	);
+}
+```
+
+#other
+
+The `toggleGroup()` runtime returns a class string. Apply it however your framework binds classes:
+
+```ts [src/components/toggle-group.ts]
+import { toggleGroup } from "virtual:styleframe";
+
+const classes = toggleGroup({ orientation: "horizontal", size: "md" });
+// → "toggle-group _display:flex _flex-direction:row _flex-wrap:wrap ..."
+```
+
+```html [src/components/toggle-group.html]
+<div class="toggle-group _display:flex _flex-direction:row ..." role="group">
+	<button type="button" class="toggle ..." aria-pressed="true">Left</button>
+	<button type="button" class="toggle ..." aria-pressed="false">Center</button>
+</div>
+```
+
+::
+
+#### See it in action
+
+:::story-preview
+---
+story: theme-recipes-forms-toggle-group--default
+panel: true
+---
+:::
+
+::
+
+## Orientation
+
+The Toggle Group supports two orientation variants that control the layout direction.
+
+### Horizontal
+
+The default orientation. Toggles are laid out left-to-right in a wrapping row, aligned to the center &mdash; the common layout for toolbars and segmented controls.
+
+::story-preview
+---
+story: theme-recipes-forms-toggle-group--horizontal
+panel: true
+---
+::
+
+### Vertical
+
+Toggles are stacked top-to-bottom in a column. Useful for a sidebar of view options.
+
+::story-preview
+---
+story: theme-recipes-forms-toggle-group--vertical
+panel: true
+---
+::
+
+### Orientation Reference
+
+::story-preview
+---
+story: theme-recipes-forms-toggle-group--all-orientations
+---
+::
+
+| Orientation | Direction | Notes |
+|-------------|-----------|-------|
+| `horizontal` | Left to right (`row`, wraps) | Default; center-aligned, wraps to the next line when out of space |
+| `vertical` | Top to bottom (`column`) | One toggle per line |
+
+## Sizes
+
+Three size variants control the gap between toggles, letting you tighten or loosen a group to match its surroundings. Set the same `size` on each child toggle so the controls and the spacing scale together.
+
+| Size | Gap |
+|------|-----|
+| `sm` | `@0.5` |
+| `md` | `@0.75` |
+| `lg` | `@1` |
+
+::note
+**Good to know:** The group's `size` controls only the gap between items. Pass the same `size` to each child `<Toggle>` so the buttons and the spacing scale as a set.
+::
+
+## Connected segmented control
+
+The Toggle Group spaces its toggles apart. For a *connected* segmented control &mdash; toggles joined at the seams with no gap &mdash; wrap them in the [Field Group](/docs/components/forms/field-group) recipe instead. It merges adjacent border radii and inner borders on any bordered child, so a row of `outline` toggles reads as one continuous control. There is no `attached` axis on the Toggle Group; the two layouts are separate, composable tools.
+
+::story-preview
+---
+story: theme-recipes-forms-toggle-group--connected
+panel: true
+---
+::
+
+```vue [src/components/SegmentedControl.vue]
+<template>
+	<FieldGroup>
+		<Toggle variant="outline" aria-pressed="true">Left</Toggle>
+		<Toggle variant="outline">Center</Toggle>
+		<Toggle variant="outline">Right</Toggle>
+	</FieldGroup>
+</template>
+```
+
+::tip
+**Pro tip:** Use `outline` toggles inside a Field Group so every segment carries the border tokens the seam-merging relies on.
+::
+
+## Accessibility
+
+- **Group related toggles.** Wrap the toggles in an element with `role="group"` and an `aria-label` (or `aria-labelledby`) describing the set, so assistive technology announces the context.
+- **Choose single or multiple in your logic.** The group is layout only; whether one toggle stays pressed (a segmented, radio-like control) or several can be pressed at once (a checkbox-like set) is behavior you implement, reflected through each toggle's `aria-pressed`.
+- **Keep each toggle labelled.** Every child still needs its own accessible name (see the [Toggle](/docs/components/forms/toggle) recipe).
+
+## Customization
+
+### Overriding Defaults
+
+The `useToggleGroupRecipe()` composable accepts an optional second argument to override any part of the recipe configuration. Overrides are deep-merged with the defaults, so you only need to specify the properties you want to change:
+
+```ts [src/components/toggle-group.styleframe.ts]
+import { styleframe } from 'virtual:styleframe';
+import { useToggleGroupRecipe } from '@styleframe/theme';
+
+const s = styleframe();
+
+const toggleGroup = useToggleGroupRecipe(s, {
+    defaultVariants: {
+        orientation: 'vertical',
+        size: 'lg',
+    },
+});
+
+export default s;
+```
+
+### Filtering Variants
+
+If you only need a subset of the available variants, use the `filter` option to limit which values are generated. This reduces the output CSS and keeps your component API focused:
+
+```ts [src/components/toggle-group.styleframe.ts]
+import { styleframe } from 'virtual:styleframe';
+import { useToggleGroupRecipe } from '@styleframe/theme';
+
+const s = styleframe();
+
+// Only generate the horizontal orientation
+const toggleGroup = useToggleGroupRecipe(s, {
+    filter: {
+        orientation: ['horizontal'],
+    },
+});
+
+export default s;
+```
+
+::note
+**Good to know:** Filtering also removes compound variants and adjusts default variants that reference filtered-out values, so your recipe stays consistent.
+::
+
+## API Reference
+
+### `useToggleGroupRecipe(s, options?)`
+
+Creates a toggle group recipe &mdash; a flex container with orientation and size (gap) variants.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `s` | `Styleframe` | The Styleframe instance |
+| `options` | `DeepPartial<RecipeConfig>` | Optional overrides for the recipe configuration |
+| `options.base` | `VariantDeclarationsBlock` | Custom base styles for the group |
+| `options.variants` | `Variants` | Custom variant definitions for the recipe |
+| `options.defaultVariants` | `Record<keyof Variants, string>` | Default variant values for the recipe |
+| `options.filter` | `Record<string, string[]>` | Limit which variant values are generated |
+
+**Variants:**
+
+| Variant | Options | Default |
+|---------|---------|---------|
+| `orientation` | `horizontal`, `vertical` | `horizontal` |
+| `size` | `sm`, `md`, `lg` | `md` |
+
+[Learn more about recipes &rarr;](/docs/api/recipes)
+
+## Best Practices
+
+- **Pair with the Toggle recipe**: The group handles layout; each child should use the [Toggle](/docs/components/forms/toggle) recipe for consistent controls.
+- **Match sizes**: Use the same `size` on the group and its child toggles so spacing and buttons scale together.
+- **Reach for Field Group when segments should touch**: Use the [Field Group](/docs/components/forms/field-group) recipe for a connected segmented control; use the Toggle Group when the toggles should stay spaced apart.
+- **Label the set**: Always describe the group's purpose with `aria-label` so screen readers communicate the relationship between options.
+
+## FAQ
+
+::accordion
+
+:::accordion-item{label="Does the group propagate color or size to its toggles?" icon="i-lucide-circle-help"}
+No. The group is a pure layout container &mdash; it sets the flex direction and the gap between items. Each child toggle keeps its own `color`, `variant`, `size`, and pressed state. Pass the same `size` to the group and its children if you want the spacing and the buttons to scale together.
+:::
+
+:::accordion-item{label="How do I make the toggles touch (a segmented control)?" icon="i-lucide-circle-help"}
+The Toggle Group always spaces its items apart. For a connected segmented control, wrap `outline` toggles in the [Field Group](/docs/components/forms/field-group) recipe instead &mdash; it flattens adjacent radii and inner borders so the segments read as one control.
+:::
+
+:::accordion-item{label="How do I make it single-select like a radio group?" icon="i-lucide-circle-help"}
+Selection behavior lives in your component logic, not the CSS. For single-select, keep one toggle's `aria-pressed="true"` and clear the others when a new one is pressed; for multi-select, let several be pressed at once. The recipe only lays the toggles out.
+:::
+
+:::accordion-item{label="How does filtering affect the recipe?" icon="i-lucide-circle-help"}
+When you use the `filter` option, variant values you exclude are not generated, and default variants are adjusted if they reference a removed value &mdash; so the recipe stays consistent and only emits the CSS you use.
+:::
+
+::

--- a/apps/docs/content/docs/05.components/05.forms/06.toggle-group.md
+++ b/apps/docs/content/docs/05.components/05.forms/06.toggle-group.md
@@ -216,6 +216,17 @@ panel: true
 **Pro tip:** Use `outline` toggles inside a Field Group so every segment carries the border tokens the seam-merging relies on.
 ::
 
+## Custom
+
+The toggle's content is a slot, so a segmented control can hold richer cells than plain labels. This font-weight picker joins `outline` toggles with a Field Group and renders an `Aa` glyph at each weight above a caption &mdash; the pressed cell carries the engaged fill.
+
+::story-preview
+---
+story: theme-recipes-forms-toggle-group--custom
+panel: true
+---
+::
+
 ## Accessibility
 
 - **Group related toggles.** Wrap the toggles in an element with `role="group"` and an `aria-label` (or `aria-labelledby`) describing the set, so assistive technology announces the context.

--- a/apps/storybook/src/components/components/toggle/Toggle.vue
+++ b/apps/storybook/src/components/components/toggle/Toggle.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+import { computed, ref, watch } from "vue";
+import { toggle } from "virtual:styleframe";
+
+const props = withDefaults(
+	defineProps<{
+		color?: "light" | "dark" | "neutral";
+		variant?: "ghost" | "outline";
+		size?: "sm" | "md" | "lg";
+		pressed?: boolean;
+		disabled?: boolean;
+		label?: string;
+	}>(),
+	{
+		pressed: false,
+	},
+);
+
+// `aria-pressed` is the toggle's ON state. The recipe styles the result; the
+// component owns the state and flips it on click (kept in sync with the prop so
+// preview grids can render fixed pressed/unpressed cells).
+const isPressed = ref(props.pressed);
+watch(
+	() => props.pressed,
+	(value) => {
+		isPressed.value = value;
+	},
+);
+
+const classes = computed(() =>
+	toggle({ color: props.color, variant: props.variant, size: props.size }),
+);
+
+function handleClick() {
+	if (props.disabled) return;
+	isPressed.value = !isPressed.value;
+}
+</script>
+
+<template>
+	<button
+		type="button"
+		:class="classes"
+		:aria-pressed="isPressed"
+		:disabled="disabled"
+		@click="handleClick"
+	>
+		<slot>{{ label }}</slot>
+	</button>
+</template>

--- a/apps/storybook/src/components/components/toggle/Toggle.vue
+++ b/apps/storybook/src/components/components/toggle/Toggle.vue
@@ -5,7 +5,7 @@ import { toggle } from "virtual:styleframe";
 const props = withDefaults(
 	defineProps<{
 		color?: "light" | "dark" | "neutral";
-		variant?: "ghost" | "outline";
+		variant?: "solid" | "outline" | "ghost";
 		size?: "sm" | "md" | "lg";
 		pressed?: boolean;
 		disabled?: boolean;

--- a/apps/storybook/src/components/components/toggle/ToggleGroup.vue
+++ b/apps/storybook/src/components/components/toggle/ToggleGroup.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { toggleGroup } from "virtual:styleframe";
+
+const props = withDefaults(
+	defineProps<{
+		orientation?: "horizontal" | "vertical";
+		size?: "sm" | "md" | "lg";
+	}>(),
+	{},
+);
+
+const classes = computed(() =>
+	toggleGroup({
+		orientation: props.orientation,
+		size: props.size,
+	}),
+);
+</script>
+
+<template>
+	<div :class="classes" role="group">
+		<slot />
+	</div>
+</template>

--- a/apps/storybook/src/components/components/toggle/preview/ToggleCustomGrid.vue
+++ b/apps/storybook/src/components/components/toggle/preview/ToggleCustomGrid.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import Toggle from "../Toggle.vue";
+import FieldGroup from "../../field-group/FieldGroup.vue";
+
+// A custom font-weight picker — outline toggles joined into a segmented control
+// via the field-group recipe, each cell showing "Aa" at its weight + a label.
+const weights = [
+	{ key: "light", label: "Light" },
+	{ key: "normal", label: "Normal" },
+	{ key: "medium", label: "Medium" },
+	{ key: "bold", label: "Bold" },
+] as const;
+</script>
+
+<template>
+	<FieldGroup>
+		<Toggle
+			v-for="w in weights"
+			:key="w.key"
+			variant="outline"
+			:pressed="w.key === 'normal'"
+		>
+			<span class="toggle-weight">
+				<span :class="['toggle-weight-glyph', `-${w.key}`]">Aa</span>
+				<span class="toggle-weight-label">{{ w.label }}</span>
+			</span>
+		</Toggle>
+	</FieldGroup>
+</template>

--- a/apps/storybook/src/components/components/toggle/preview/ToggleGrid.vue
+++ b/apps/storybook/src/components/components/toggle/preview/ToggleGrid.vue
@@ -2,7 +2,7 @@
 import Toggle from "../Toggle.vue";
 
 const colors = ["light", "dark", "neutral"] as const;
-const variants = ["ghost", "outline"] as const;
+const variants = ["solid", "outline", "ghost"] as const;
 const states = [
 	{ name: "off", pressed: false, disabled: false },
 	{ name: "on", pressed: true, disabled: false },

--- a/apps/storybook/src/components/components/toggle/preview/ToggleGrid.vue
+++ b/apps/storybook/src/components/components/toggle/preview/ToggleGrid.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import Toggle from "../Toggle.vue";
+
+const colors = ["light", "dark", "neutral"] as const;
+const variants = ["ghost", "outline"] as const;
+const states = [
+	{ name: "off", pressed: false, disabled: false },
+	{ name: "on", pressed: true, disabled: false },
+	{ name: "disabled", pressed: false, disabled: true },
+] as const;
+
+const rows = variants.flatMap((variant) =>
+	states.map((state) => ({
+		variant,
+		state,
+		label: `${variant} · ${state.name}`,
+	})),
+);
+</script>
+
+<template>
+	<div class="toggle-section">
+		<div v-for="row in rows" :key="row.label">
+			<div class="toggle-label">{{ row.label }}</div>
+			<div class="toggle-row">
+				<Toggle
+					v-for="color in colors"
+					:key="`${row.label}-${color}`"
+					:color="color"
+					:variant="row.variant"
+					:pressed="row.state.pressed"
+					:disabled="row.state.disabled"
+					:label="color"
+				/>
+			</div>
+		</div>
+	</div>
+</template>

--- a/apps/storybook/src/components/components/toggle/preview/ToggleGroupGrid.vue
+++ b/apps/storybook/src/components/components/toggle/preview/ToggleGroupGrid.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import ToggleGroup from "../ToggleGroup.vue";
+import Toggle from "../Toggle.vue";
+
+const orientations = ["horizontal", "vertical"] as const;
+</script>
+
+<template>
+	<div class="toggle-section">
+		<div v-for="orientation in orientations" :key="orientation">
+			<div class="toggle-label">{{ orientation }}</div>
+			<ToggleGroup :orientation="orientation">
+				<Toggle variant="outline" pressed label="Left" />
+				<Toggle variant="outline" label="Center" />
+				<Toggle variant="outline" label="Right" />
+			</ToggleGroup>
+		</div>
+	</div>
+</template>

--- a/apps/storybook/src/components/components/toggle/preview/ToggleSizeGrid.vue
+++ b/apps/storybook/src/components/components/toggle/preview/ToggleSizeGrid.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import Toggle from "../Toggle.vue";
+
+const sizes = ["sm", "md", "lg"] as const;
+const sizeTitles: Record<string, string> = {
+	sm: "Small",
+	md: "Medium",
+	lg: "Large",
+};
+</script>
+
+<template>
+	<div class="toggle-section">
+		<div v-for="size in sizes" :key="size">
+			<div class="toggle-label">{{ size }}</div>
+			<div class="toggle-row">
+				<Toggle :size="size" variant="outline" :label="sizeTitles[size]" />
+				<Toggle :size="size" variant="outline" pressed label="On" />
+			</div>
+		</div>
+	</div>
+</template>

--- a/apps/storybook/stories/components/toggle-group.stories.ts
+++ b/apps/storybook/stories/components/toggle-group.stories.ts
@@ -4,6 +4,7 @@ import ToggleGroup from "@/components/components/toggle/ToggleGroup.vue";
 import Toggle from "@/components/components/toggle/Toggle.vue";
 import FieldGroup from "@/components/components/field-group/FieldGroup.vue";
 import ToggleGroupGrid from "@/components/components/toggle/preview/ToggleGroupGrid.vue";
+import ToggleCustomGrid from "@/components/components/toggle/preview/ToggleCustomGrid.vue";
 
 const orientations = ["horizontal", "vertical"] as const;
 const sizes = ["sm", "md", "lg"] as const;
@@ -111,5 +112,14 @@ export const Connected: StoryObj = {
 				<Toggle variant="outline" label="Right" />
 			</FieldGroup>
 		`,
+	}),
+};
+
+// Custom — a font-weight picker built from outline toggles joined with field-group,
+// each cell showing "Aa" at its weight plus a label.
+export const Custom: StoryObj = {
+	render: () => ({
+		components: { ToggleCustomGrid },
+		template: "<ToggleCustomGrid />",
 	}),
 };

--- a/apps/storybook/stories/components/toggle-group.stories.ts
+++ b/apps/storybook/stories/components/toggle-group.stories.ts
@@ -1,0 +1,115 @@
+import type { Meta, StoryObj } from "@storybook/vue3-vite";
+
+import ToggleGroup from "@/components/components/toggle/ToggleGroup.vue";
+import Toggle from "@/components/components/toggle/Toggle.vue";
+import FieldGroup from "@/components/components/field-group/FieldGroup.vue";
+import ToggleGroupGrid from "@/components/components/toggle/preview/ToggleGroupGrid.vue";
+
+const orientations = ["horizontal", "vertical"] as const;
+const sizes = ["sm", "md", "lg"] as const;
+
+const meta = {
+	title: "Theme/Recipes/Forms/Toggle Group",
+	component: ToggleGroup,
+	tags: ["autodocs"],
+	parameters: {
+		layout: "padded",
+	},
+	argTypes: {
+		orientation: {
+			control: "select",
+			options: orientations,
+			description: "The layout direction of the group",
+		},
+		size: {
+			control: "select",
+			options: sizes,
+			description: "The gap between toggles",
+		},
+	},
+} satisfies Meta<typeof ToggleGroup>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	render: (args) => ({
+		components: { ToggleGroup, Toggle },
+		setup() {
+			return { args };
+		},
+		template: `
+			<ToggleGroup v-bind="args">
+				<Toggle variant="outline" pressed label="Bold" />
+				<Toggle variant="outline" label="Italic" />
+				<Toggle variant="outline" label="Underline" />
+			</ToggleGroup>
+		`,
+	}),
+	args: {
+		orientation: "horizontal",
+		size: "md",
+	},
+};
+
+export const AllOrientations: StoryObj = {
+	render: () => ({
+		components: { ToggleGroupGrid },
+		template: "<ToggleGroupGrid />",
+	}),
+};
+
+export const Horizontal: Story = {
+	render: (args) => ({
+		components: { ToggleGroup, Toggle },
+		setup() {
+			return { args };
+		},
+		template: `
+			<ToggleGroup v-bind="args">
+				<Toggle variant="outline" pressed label="Left" />
+				<Toggle variant="outline" label="Center" />
+				<Toggle variant="outline" label="Right" />
+			</ToggleGroup>
+		`,
+	}),
+	args: {
+		orientation: "horizontal",
+		size: "md",
+	},
+};
+
+export const Vertical: Story = {
+	render: (args) => ({
+		components: { ToggleGroup, Toggle },
+		setup() {
+			return { args };
+		},
+		template: `
+			<ToggleGroup v-bind="args">
+				<Toggle variant="outline" pressed label="List" />
+				<Toggle variant="outline" label="Grid" />
+				<Toggle variant="outline" label="Columns" />
+			</ToggleGroup>
+		`,
+	}),
+	args: {
+		orientation: "vertical",
+		size: "md",
+	},
+};
+
+// Connected segmented control — toggles joined at the seams via the existing
+// field-group recipe (no toggle-group axis needed).
+export const Connected: StoryObj = {
+	render: () => ({
+		components: { FieldGroup, Toggle },
+		template: `
+			<FieldGroup>
+				<Toggle variant="outline" pressed label="Left" />
+				<Toggle variant="outline" label="Center" />
+				<Toggle variant="outline" label="Right" />
+			</FieldGroup>
+		`,
+	}),
+};

--- a/apps/storybook/stories/components/toggle.stories.ts
+++ b/apps/storybook/stories/components/toggle.stories.ts
@@ -5,7 +5,7 @@ import ToggleGrid from "@/components/components/toggle/preview/ToggleGrid.vue";
 import ToggleSizeGrid from "@/components/components/toggle/preview/ToggleSizeGrid.vue";
 
 const colors = ["light", "dark", "neutral"] as const;
-const variants = ["ghost", "outline"] as const;
+const variants = ["solid", "outline", "ghost"] as const;
 const sizes = ["sm", "md", "lg"] as const;
 
 const meta = {
@@ -92,10 +92,10 @@ export const Neutral: Story = {
 };
 
 // Variant stories
-export const Ghost: Story = {
+export const Solid: Story = {
 	args: {
-		variant: "ghost",
-		label: "Ghost",
+		variant: "solid",
+		label: "Solid",
 	},
 };
 
@@ -103,6 +103,13 @@ export const Outline: Story = {
 	args: {
 		variant: "outline",
 		label: "Outline",
+	},
+};
+
+export const Ghost: Story = {
+	args: {
+		variant: "ghost",
+		label: "Ghost",
 	},
 };
 

--- a/apps/storybook/stories/components/toggle.stories.ts
+++ b/apps/storybook/stories/components/toggle.stories.ts
@@ -1,0 +1,146 @@
+import type { Meta, StoryObj } from "@storybook/vue3-vite";
+
+import Toggle from "@/components/components/toggle/Toggle.vue";
+import ToggleGrid from "@/components/components/toggle/preview/ToggleGrid.vue";
+import ToggleSizeGrid from "@/components/components/toggle/preview/ToggleSizeGrid.vue";
+
+const colors = ["light", "dark", "neutral"] as const;
+const variants = ["ghost", "outline"] as const;
+const sizes = ["sm", "md", "lg"] as const;
+
+const meta = {
+	title: "Theme/Recipes/Forms/Toggle",
+	component: Toggle,
+	tags: ["autodocs"],
+	parameters: {
+		layout: "padded",
+	},
+	argTypes: {
+		color: {
+			control: "select",
+			options: colors,
+			description: "The color surface of the toggle",
+		},
+		variant: {
+			control: "select",
+			options: variants,
+			description: "The visual style variant",
+		},
+		size: {
+			control: "select",
+			options: sizes,
+			description: "The size of the toggle",
+		},
+		pressed: {
+			control: "boolean",
+			description: "Whether the toggle is on (sets aria-pressed)",
+		},
+		disabled: {
+			control: "boolean",
+			description: "Whether the toggle is disabled",
+		},
+		label: {
+			control: "text",
+			description: "The text content of the toggle",
+		},
+	},
+} satisfies Meta<typeof Toggle>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {
+		label: "Bold",
+	},
+};
+
+export const AllVariants: StoryObj = {
+	render: () => ({
+		components: { ToggleGrid },
+		template: "<ToggleGrid />",
+	}),
+};
+
+export const AllSizes: StoryObj = {
+	render: () => ({
+		components: { ToggleSizeGrid },
+		template: "<ToggleSizeGrid />",
+	}),
+};
+
+// Color stories
+export const Light: Story = {
+	args: {
+		color: "light",
+		label: "Light",
+	},
+};
+
+export const Dark: Story = {
+	args: {
+		color: "dark",
+		label: "Dark",
+	},
+};
+
+export const Neutral: Story = {
+	args: {
+		color: "neutral",
+		label: "Neutral",
+	},
+};
+
+// Variant stories
+export const Ghost: Story = {
+	args: {
+		variant: "ghost",
+		label: "Ghost",
+	},
+};
+
+export const Outline: Story = {
+	args: {
+		variant: "outline",
+		label: "Outline",
+	},
+};
+
+// Size stories
+export const Small: Story = {
+	args: {
+		size: "sm",
+		label: "Small",
+	},
+};
+
+export const Medium: Story = {
+	args: {
+		size: "md",
+		label: "Medium",
+	},
+};
+
+export const Large: Story = {
+	args: {
+		size: "lg",
+		label: "Large",
+	},
+};
+
+// State stories
+export const Pressed: Story = {
+	args: {
+		variant: "outline",
+		pressed: true,
+		label: "Pressed",
+	},
+};
+
+export const Disabled: Story = {
+	args: {
+		variant: "outline",
+		disabled: true,
+		label: "Disabled",
+	},
+};

--- a/apps/storybook/stories/components/toggle.styleframe.ts
+++ b/apps/storybook/stories/components/toggle.styleframe.ts
@@ -1,0 +1,40 @@
+import { useToggleRecipe, useToggleGroupRecipe } from "@styleframe/theme";
+import { styleframe } from "virtual:styleframe";
+
+const s = styleframe();
+const { selector } = s;
+
+// Initialize toggle recipes
+export const toggle = useToggleRecipe(s);
+export const toggleGroup = useToggleGroupRecipe(s);
+
+// Container styles for story layout
+selector(".toggle-grid", {
+	display: "flex",
+	flexWrap: "wrap",
+	gap: "@spacing.md",
+	padding: "@spacing.md",
+	alignItems: "center",
+});
+
+selector(".toggle-section", {
+	display: "flex",
+	flexDirection: "column",
+	gap: "@spacing.lg",
+	padding: "@spacing.md",
+});
+
+selector(".toggle-row", {
+	display: "flex",
+	flexWrap: "wrap",
+	gap: "@spacing.sm",
+	alignItems: "center",
+});
+
+selector(".toggle-label", {
+	fontSize: "@font-size.sm",
+	fontWeight: "@font-weight.semibold",
+	minWidth: "120px",
+});
+
+export default s;

--- a/apps/storybook/stories/components/toggle.styleframe.ts
+++ b/apps/storybook/stories/components/toggle.styleframe.ts
@@ -37,4 +37,28 @@ selector(".toggle-label", {
 	minWidth: "120px",
 });
 
+// Custom example — font-weight segmented picker (the "Aa" + label cell)
+selector(".toggle-weight", {
+	display: "flex",
+	flexDirection: "column",
+	alignItems: "center",
+	gap: "@spacing.sm",
+	minWidth: "48px",
+});
+
+selector(".toggle-weight-glyph", {
+	fontSize: "@font-size.xl",
+	lineHeight: "1",
+});
+
+selector(".toggle-weight-glyph.-light", { fontWeight: "@font-weight.light" });
+selector(".toggle-weight-glyph.-normal", { fontWeight: "@font-weight.normal" });
+selector(".toggle-weight-glyph.-medium", { fontWeight: "@font-weight.medium" });
+selector(".toggle-weight-glyph.-bold", { fontWeight: "@font-weight.bold" });
+
+selector(".toggle-weight-label", {
+	fontSize: "@font-size.2xs",
+	color: "@color.text-weak",
+});
+
 export default s;

--- a/theme/src/recipes/index.ts
+++ b/theme/src/recipes/index.ts
@@ -27,4 +27,5 @@ export * from "./select";
 export * from "./skeleton";
 export * from "./textarea";
 export * from "./switch";
+export * from "./toggle";
 export * from "./tooltip";

--- a/theme/src/recipes/toggle/index.ts
+++ b/theme/src/recipes/toggle/index.ts
@@ -1,0 +1,2 @@
+export * from "./useToggleRecipe";
+export * from "./useToggleGroupRecipe";

--- a/theme/src/recipes/toggle/useToggleGroupRecipe.test.ts
+++ b/theme/src/recipes/toggle/useToggleGroupRecipe.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { styleframe } from "@styleframe/core";
+import { useDarkModifier } from "../../modifiers/useMediaPreferenceModifiers";
+import { useToggleGroupRecipe } from "./useToggleGroupRecipe";
+
+function createInstance() {
+	const s = styleframe();
+	for (const name of [
+		"display",
+		"flexDirection",
+		"flexWrap",
+		"alignItems",
+		"gap",
+	]) {
+		s.utility(name, ({ value }) => ({ [name]: value }));
+	}
+	useDarkModifier(s);
+	return s;
+}
+
+describe("useToggleGroupRecipe", () => {
+	it("should create a recipe with correct metadata", () => {
+		const s = createInstance();
+		const recipe = useToggleGroupRecipe(s);
+
+		expect(recipe.type).toBe("recipe");
+		expect(recipe.name).toBe("toggle-group");
+	});
+
+	it("should have correct base styles", () => {
+		const s = createInstance();
+		const recipe = useToggleGroupRecipe(s);
+
+		expect(recipe.base).toEqual({ display: "flex" });
+	});
+
+	describe("variants", () => {
+		it("should have all orientation variants", () => {
+			const s = createInstance();
+			const recipe = useToggleGroupRecipe(s);
+
+			expect(Object.keys(recipe.variants!.orientation)).toEqual([
+				"horizontal",
+				"vertical",
+			]);
+			expect(recipe.variants!.orientation.horizontal).toEqual({
+				flexDirection: "row",
+				flexWrap: "wrap",
+				alignItems: "center",
+			});
+			expect(recipe.variants!.orientation.vertical).toEqual({
+				flexDirection: "column",
+			});
+		});
+
+		it("should have size variants with correct styles", () => {
+			const s = createInstance();
+			const recipe = useToggleGroupRecipe(s);
+
+			expect(Object.keys(recipe.variants!.size)).toEqual(["sm", "md", "lg"]);
+			expect(recipe.variants!.size.md).toEqual({ gap: "@0.75" });
+		});
+	});
+
+	it("should have correct default variants", () => {
+		const s = createInstance();
+		const recipe = useToggleGroupRecipe(s);
+
+		expect(recipe.defaultVariants).toEqual({
+			orientation: "horizontal",
+			size: "md",
+		});
+	});
+
+	it("should not define compound variants", () => {
+		const s = createInstance();
+		const recipe = useToggleGroupRecipe(s);
+
+		expect(recipe.compoundVariants ?? []).toHaveLength(0);
+	});
+
+	describe("config overrides", () => {
+		it("should allow overriding base styles", () => {
+			const s = createInstance();
+			const recipe = useToggleGroupRecipe(s, {
+				base: { display: "inline-flex" },
+			});
+
+			expect(recipe.base?.display).toBe("inline-flex");
+		});
+	});
+
+	describe("filter", () => {
+		it("should filter orientation variants", () => {
+			const s = createInstance();
+			const recipe = useToggleGroupRecipe(s, {
+				filter: { orientation: ["vertical"] },
+			});
+
+			expect(Object.keys(recipe.variants!.orientation)).toEqual(["vertical"]);
+		});
+
+		it("should adjust default variants when filtered out", () => {
+			const s = createInstance();
+			const recipe = useToggleGroupRecipe(s, {
+				filter: { orientation: ["vertical"] },
+			});
+
+			expect(recipe.defaultVariants?.orientation).toBeUndefined();
+		});
+	});
+});

--- a/theme/src/recipes/toggle/useToggleGroupRecipe.ts
+++ b/theme/src/recipes/toggle/useToggleGroupRecipe.ts
@@ -1,0 +1,45 @@
+import { createUseRecipe } from "../../utils/createUseRecipe";
+
+/**
+ * Toggle group recipe — a flex container that lays out multiple `.toggle` buttons
+ * with spacing between them. Supports orientation (horizontal / vertical) and a
+ * size axis that controls the gap between items. Mirrors `checkbox-group` /
+ * `radio-group`, but defaults to `horizontal` since toggle groups read as
+ * horizontal segmented controls.
+ *
+ * For the connected segmented look (toggles joined at the seams with no gap), wrap
+ * the toggles in the `field-group` recipe instead — it already merges adjacent
+ * border radii and inner borders on any bordered child.
+ */
+export const useToggleGroupRecipe = createUseRecipe("toggle-group", {
+	base: {
+		display: "flex",
+	},
+	variants: {
+		orientation: {
+			horizontal: {
+				flexDirection: "row",
+				flexWrap: "wrap",
+				alignItems: "center",
+			},
+			vertical: {
+				flexDirection: "column",
+			},
+		},
+		size: {
+			sm: {
+				gap: "@0.5",
+			},
+			md: {
+				gap: "@0.75",
+			},
+			lg: {
+				gap: "@1",
+			},
+		},
+	},
+	defaultVariants: {
+		orientation: "horizontal",
+		size: "md",
+	},
+});

--- a/theme/src/recipes/toggle/useToggleRecipe.test.ts
+++ b/theme/src/recipes/toggle/useToggleRecipe.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it } from "vitest";
+import { styleframe } from "@styleframe/core";
+import { useDarkModifier } from "../../modifiers/useMediaPreferenceModifiers";
+import { useDisabledModifier } from "../../modifiers/useFormStateModifiers";
+import { useAriaPressedModifier } from "../../modifiers/useAriaStateModifiers";
+import {
+	useActiveModifier,
+	useFocusModifier,
+	useFocusVisibleModifier,
+	useHoverModifier,
+} from "../../modifiers/usePseudoStateModifiers";
+import { useDesignTokensPreset } from "../../presets/useDesignTokensPreset";
+import { useUtilitiesPreset } from "../../presets/useUtilitiesPreset";
+import { useModifiersPreset } from "../../presets/useModifiersPreset";
+import { useToggleRecipe } from "./useToggleRecipe";
+
+function createInstance() {
+	const s = styleframe();
+	for (const name of [
+		"display",
+		"alignItems",
+		"justifyContent",
+		"fontWeight",
+		"fontSize",
+		"borderWidth",
+		"borderStyle",
+		"borderColor",
+		"borderRadius",
+		"lineHeight",
+		"paddingTop",
+		"paddingBottom",
+		"paddingLeft",
+		"paddingRight",
+		"cursor",
+		"transitionProperty",
+		"transitionTimingFunction",
+		"transitionDuration",
+		"textDecoration",
+		"whiteSpace",
+		"userSelect",
+		"outline",
+		"outlineWidth",
+		"outlineStyle",
+		"outlineColor",
+		"outlineOffset",
+		"opacity",
+		"pointerEvents",
+		"gap",
+		"color",
+		"background",
+	]) {
+		s.utility(name, ({ value }) => ({ [name]: value }));
+	}
+	useDarkModifier(s);
+	useHoverModifier(s);
+	useFocusModifier(s);
+	useActiveModifier(s);
+	useFocusVisibleModifier(s);
+	useDisabledModifier(s);
+	useAriaPressedModifier(s);
+	return s;
+}
+
+describe("useToggleRecipe", () => {
+	it("should create a recipe with correct metadata", () => {
+		const s = createInstance();
+		const recipe = useToggleRecipe(s);
+
+		expect(recipe.type).toBe("recipe");
+		expect(recipe.name).toBe("toggle");
+	});
+
+	it("should build against the design-tokens, utilities, and modifiers presets", () => {
+		const s = styleframe();
+		useDesignTokensPreset(s);
+		useUtilitiesPreset(s);
+		useModifiersPreset(s);
+
+		// Reproduces the real init environment: every declared property must
+		// resolve to a registered utility and every `&:` key to a modifier
+		// (including `&:aria-pressed`).
+		expect(() => useToggleRecipe(s)).not.toThrow();
+	});
+
+	it("should have correct base styles", () => {
+		const s = createInstance();
+		const recipe = useToggleRecipe(s);
+
+		expect(recipe.base).toMatchObject({
+			display: "inline-flex",
+			alignItems: "center",
+			justifyContent: "center",
+			borderWidth: "@border-width.thin",
+			borderStyle: "@border-style.solid",
+			borderColor: "transparent",
+			borderRadius: "@border-radius.md",
+			cursor: "pointer",
+			userSelect: "none",
+			outline: "none",
+		});
+	});
+
+	it("should style focus-visible and disabled states", () => {
+		const s = createInstance();
+		const recipe = useToggleRecipe(s);
+
+		expect(recipe.base?.["&:focus-visible"]).toMatchObject({
+			outlineColor: "@color.primary",
+		});
+		expect(recipe.base?.["&:disabled"]).toEqual({
+			cursor: "not-allowed",
+			opacity: "0.75",
+			pointerEvents: "none",
+		});
+	});
+
+	describe("variants", () => {
+		it("should have all color variants", () => {
+			const s = createInstance();
+			const recipe = useToggleRecipe(s);
+
+			expect(Object.keys(recipe.variants!.color)).toEqual([
+				"light",
+				"dark",
+				"neutral",
+			]);
+		});
+
+		it("should have all style variants", () => {
+			const s = createInstance();
+			const recipe = useToggleRecipe(s);
+
+			expect(Object.keys(recipe.variants!.variant)).toEqual([
+				"ghost",
+				"outline",
+			]);
+			expect(recipe.variants!.variant.ghost).toEqual({
+				background: "transparent",
+			});
+		});
+
+		it("should have size variants with correct styles", () => {
+			const s = createInstance();
+			const recipe = useToggleRecipe(s);
+
+			expect(Object.keys(recipe.variants!.size)).toEqual(["sm", "md", "lg"]);
+			expect(recipe.variants!.size.md).toEqual({
+				fontSize: "@font-size.sm",
+				paddingTop: "@0.5",
+				paddingBottom: "@0.5",
+				paddingLeft: "@0.75",
+				paddingRight: "@0.75",
+				gap: "@0.375",
+				borderRadius: "@border-radius.md",
+			});
+		});
+	});
+
+	it("should have correct default variants", () => {
+		const s = createInstance();
+		const recipe = useToggleRecipe(s);
+
+		expect(recipe.defaultVariants).toEqual({
+			color: "neutral",
+			variant: "ghost",
+			size: "md",
+		});
+	});
+
+	describe("compound variants", () => {
+		it("should have 6 compound variants", () => {
+			const s = createInstance();
+			const recipe = useToggleRecipe(s);
+
+			expect(recipe.compoundVariants).toHaveLength(6);
+		});
+
+		it("should reuse the :active fill on :aria-pressed for every compound variant", () => {
+			const s = createInstance();
+			const recipe = useToggleRecipe(s);
+
+			for (const cv of recipe.compoundVariants!) {
+				const css = cv.css as Record<string, Record<string, string>>;
+				expect(css["&:aria-pressed"]).toEqual(css["&:active"]);
+			}
+		});
+
+		it("should adapt the neutral/ghost variant in dark mode and re-assert the pressed fill", () => {
+			const s = createInstance();
+			const recipe = useToggleRecipe(s);
+
+			const cv = recipe.compoundVariants!.find(
+				(v) => v.match.color === "neutral" && v.match.variant === "ghost",
+			);
+			expect(cv?.css).toEqual({
+				color: "@color.text",
+				"&:hover": { background: "@color.gray-100" },
+				"&:focus": { background: "@color.gray-100" },
+				"&:active": { background: "@color.gray-200" },
+				"&:aria-pressed": { background: "@color.gray-200" },
+				"&:dark": { color: "@color.gray-200" },
+				"&:dark:hover": { background: "@color.gray-800" },
+				"&:dark:focus": { background: "@color.gray-800" },
+				"&:dark:active": { background: "@color.gray-750" },
+				"&:dark:aria-pressed": { background: "@color.gray-750" },
+			});
+		});
+
+		it("should keep fixed light/dark surfaces free of dark overrides", () => {
+			const s = createInstance();
+			const recipe = useToggleRecipe(s);
+
+			const light = recipe.compoundVariants!.find(
+				(v) => v.match.color === "light" && v.match.variant === "outline",
+			);
+			expect(light?.css).toEqual({
+				color: "@color.gray-700",
+				borderColor: "@color.gray-300",
+				"&:hover": { background: "@color.gray-100" },
+				"&:focus": { background: "@color.gray-100" },
+				"&:active": { background: "@color.gray-200" },
+				"&:aria-pressed": { background: "@color.gray-200" },
+			});
+		});
+	});
+
+	describe("config overrides", () => {
+		it("should allow overriding base styles", () => {
+			const s = createInstance();
+			const recipe = useToggleRecipe(s, {
+				base: { display: "block" },
+			});
+
+			expect(recipe.base?.display).toBe("block");
+		});
+	});
+
+	describe("filter", () => {
+		it("should filter color variants and prune compound variants", () => {
+			const s = createInstance();
+			const recipe = useToggleRecipe(s, {
+				filter: { color: ["neutral"] },
+			});
+
+			expect(Object.keys(recipe.variants!.color)).toEqual(["neutral"]);
+			expect(recipe.compoundVariants).toHaveLength(2);
+		});
+
+		it("should adjust default variants when filtered out", () => {
+			const s = createInstance();
+			const recipe = useToggleRecipe(s, {
+				filter: { color: ["light"] },
+			});
+
+			expect(recipe.defaultVariants?.color).toBeUndefined();
+		});
+	});
+});

--- a/theme/src/recipes/toggle/useToggleRecipe.test.ts
+++ b/theme/src/recipes/toggle/useToggleRecipe.test.ts
@@ -131,12 +131,11 @@ describe("useToggleRecipe", () => {
 			const recipe = useToggleRecipe(s);
 
 			expect(Object.keys(recipe.variants!.variant)).toEqual([
-				"ghost",
+				"solid",
 				"outline",
+				"ghost",
 			]);
-			expect(recipe.variants!.variant.ghost).toEqual({
-				background: "transparent",
-			});
+			expect(recipe.variants!.variant.solid).toEqual({});
 		});
 
 		it("should have size variants with correct styles", () => {
@@ -162,17 +161,31 @@ describe("useToggleRecipe", () => {
 
 		expect(recipe.defaultVariants).toEqual({
 			color: "neutral",
-			variant: "ghost",
+			variant: "solid",
 			size: "md",
 		});
 	});
 
 	describe("compound variants", () => {
-		it("should have 6 compound variants", () => {
+		it("should have 9 compound variants", () => {
 			const s = createInstance();
 			const recipe = useToggleRecipe(s);
 
-			expect(recipe.compoundVariants).toHaveLength(6);
+			expect(recipe.compoundVariants).toHaveLength(9);
+		});
+
+		it("should give solid a resting background and keep outline/ghost transparent at rest", () => {
+			const s = createInstance();
+			const recipe = useToggleRecipe(s);
+
+			const cssFor = (variant: string) =>
+				recipe.compoundVariants!.find(
+					(v) => v.match.color === "neutral" && v.match.variant === variant,
+				)!.css as Record<string, unknown>;
+
+			expect(cssFor("solid").background).toBe("@color.gray-100");
+			expect(cssFor("outline").background).toBeUndefined();
+			expect(cssFor("ghost").background).toBeUndefined();
 		});
 
 		it("should reuse the :active fill on :aria-pressed for every compound variant", () => {
@@ -185,22 +198,23 @@ describe("useToggleRecipe", () => {
 			}
 		});
 
-		it("should adapt the neutral/ghost variant in dark mode and re-assert the pressed fill", () => {
+		it("should adapt the neutral/solid variant in dark mode and re-assert the pressed fill", () => {
 			const s = createInstance();
 			const recipe = useToggleRecipe(s);
 
 			const cv = recipe.compoundVariants!.find(
-				(v) => v.match.color === "neutral" && v.match.variant === "ghost",
+				(v) => v.match.color === "neutral" && v.match.variant === "solid",
 			);
 			expect(cv?.css).toEqual({
 				color: "@color.text",
-				"&:hover": { background: "@color.gray-100" },
-				"&:focus": { background: "@color.gray-100" },
-				"&:active": { background: "@color.gray-200" },
-				"&:aria-pressed": { background: "@color.gray-200" },
-				"&:dark": { color: "@color.gray-200" },
-				"&:dark:hover": { background: "@color.gray-800" },
-				"&:dark:focus": { background: "@color.gray-800" },
+				background: "@color.gray-100",
+				"&:hover": { background: "@color.gray-150" },
+				"&:focus": { background: "@color.gray-150" },
+				"&:active": { background: "@color.gray-150" },
+				"&:aria-pressed": { background: "@color.gray-150" },
+				"&:dark": { color: "@color.gray-200", background: "@color.gray-800" },
+				"&:dark:hover": { background: "@color.gray-750" },
+				"&:dark:focus": { background: "@color.gray-750" },
 				"&:dark:active": { background: "@color.gray-750" },
 				"&:dark:aria-pressed": { background: "@color.gray-750" },
 			});
@@ -216,10 +230,10 @@ describe("useToggleRecipe", () => {
 			expect(light?.css).toEqual({
 				color: "@color.gray-700",
 				borderColor: "@color.gray-300",
-				"&:hover": { background: "@color.gray-100" },
-				"&:focus": { background: "@color.gray-100" },
-				"&:active": { background: "@color.gray-200" },
-				"&:aria-pressed": { background: "@color.gray-200" },
+				"&:hover": { background: "@color.gray-150" },
+				"&:focus": { background: "@color.gray-150" },
+				"&:active": { background: "@color.gray-150" },
+				"&:aria-pressed": { background: "@color.gray-150" },
 			});
 		});
 	});
@@ -243,7 +257,7 @@ describe("useToggleRecipe", () => {
 			});
 
 			expect(Object.keys(recipe.variants!.color)).toEqual(["neutral"]);
-			expect(recipe.compoundVariants).toHaveLength(2);
+			expect(recipe.compoundVariants).toHaveLength(3);
 		});
 
 		it("should adjust default variants when filtered out", () => {

--- a/theme/src/recipes/toggle/useToggleRecipe.test.ts
+++ b/theme/src/recipes/toggle/useToggleRecipe.test.ts
@@ -174,7 +174,7 @@ describe("useToggleRecipe", () => {
 			expect(recipe.compoundVariants).toHaveLength(9);
 		});
 
-		it("should give solid a resting background and keep outline/ghost transparent at rest", () => {
+		it("should give solid a filled surface, outline a border, and ghost neither at rest", () => {
 			const s = createInstance();
 			const recipe = useToggleRecipe(s);
 
@@ -183,18 +183,26 @@ describe("useToggleRecipe", () => {
 					(v) => v.match.color === "neutral" && v.match.variant === variant,
 				)!.css as Record<string, unknown>;
 
-			expect(cssFor("solid").background).toBe("@color.gray-100");
+			// solid mirrors the button's solid resting surface: filled + subtle border.
+			expect(cssFor("solid").background).toBe("@color.white");
+			expect(cssFor("solid").borderColor).toBe("@color.gray-200");
+			// outline is transparent with a border; ghost is transparent with none.
 			expect(cssFor("outline").background).toBeUndefined();
+			expect(cssFor("outline").borderColor).toBe("@color.gray-300");
 			expect(cssFor("ghost").background).toBeUndefined();
+			expect(cssFor("ghost").borderColor).toBeUndefined();
 		});
 
-		it("should reuse the :active fill on :aria-pressed for every compound variant", () => {
+		it("should reuse the :hover fill on :aria-pressed for every compound variant", () => {
 			const s = createInstance();
 			const recipe = useToggleRecipe(s);
 
 			for (const cv of recipe.compoundVariants!) {
 				const css = cv.css as Record<string, Record<string, string>>;
-				expect(css["&:aria-pressed"]).toEqual(css["&:active"]);
+				expect(css["&:aria-pressed"]).toEqual(css["&:hover"]);
+				if (css["&:dark:hover"]) {
+					expect(css["&:dark:aria-pressed"]).toEqual(css["&:dark:hover"]);
+				}
 			}
 		});
 
@@ -206,34 +214,47 @@ describe("useToggleRecipe", () => {
 				(v) => v.match.color === "neutral" && v.match.variant === "solid",
 			);
 			expect(cv?.css).toEqual({
+				background: "@color.white",
 				color: "@color.text",
-				background: "@color.gray-100",
-				"&:hover": { background: "@color.gray-150" },
-				"&:focus": { background: "@color.gray-150" },
-				"&:active": { background: "@color.gray-150" },
-				"&:aria-pressed": { background: "@color.gray-150" },
-				"&:dark": { color: "@color.gray-200", background: "@color.gray-800" },
-				"&:dark:hover": { background: "@color.gray-750" },
-				"&:dark:focus": { background: "@color.gray-750" },
+				borderColor: "@color.gray-200",
+				"&:hover": { background: "@color.gray-100" },
+				"&:focus": { background: "@color.gray-100" },
+				"&:active": { background: "@color.gray-200" },
+				"&:aria-pressed": { background: "@color.gray-100" },
+				"&:dark": {
+					background: "@color.gray-900",
+					color: "@color.white",
+					borderColor: "@color.gray-800",
+				},
+				"&:dark:hover": { background: "@color.gray-800" },
+				"&:dark:focus": { background: "@color.gray-800" },
 				"&:dark:active": { background: "@color.gray-750" },
-				"&:dark:aria-pressed": { background: "@color.gray-750" },
+				"&:dark:aria-pressed": { background: "@color.gray-800" },
 			});
 		});
 
-		it("should keep fixed light/dark surfaces free of dark overrides", () => {
+		it("should keep light and dark surfaces fixed by re-asserting them under :dark", () => {
 			const s = createInstance();
 			const recipe = useToggleRecipe(s);
 
-			const light = recipe.compoundVariants!.find(
-				(v) => v.match.color === "light" && v.match.variant === "outline",
-			);
-			expect(light?.css).toEqual({
-				color: "@color.gray-700",
-				borderColor: "@color.gray-300",
-				"&:hover": { background: "@color.gray-150" },
-				"&:focus": { background: "@color.gray-150" },
-				"&:active": { background: "@color.gray-150" },
-				"&:aria-pressed": { background: "@color.gray-150" },
+			const darkBlockFor = (color: string) =>
+				(
+					recipe.compoundVariants!.find(
+						(v) => v.match.color === color && v.match.variant === "solid",
+					)!.css as Record<string, unknown>
+				)["&:dark"];
+
+			// The light surface stays white in dark mode (text flips to keep contrast).
+			expect(darkBlockFor("light")).toEqual({
+				background: "@color.white",
+				color: "@color.text-inverted",
+				borderColor: "@color.gray-200",
+			});
+			// The dark surface stays gray-900 in dark mode.
+			expect(darkBlockFor("dark")).toEqual({
+				background: "@color.gray-900",
+				color: "@color.white",
+				borderColor: "@color.gray-800",
 			});
 		});
 	});

--- a/theme/src/recipes/toggle/useToggleRecipe.ts
+++ b/theme/src/recipes/toggle/useToggleRecipe.ts
@@ -4,12 +4,13 @@ import { createUseRecipe } from "../../utils/createUseRecipe";
  * Toggle recipe — a two-state `<button>` that looks like a button and carries an
  * on/off state via `aria-pressed`. "A checkbox that looks like a toggleable button."
  *
- * The ON appearance reuses each colour/variant's `:active` fill, re-applied on
- * `&:aria-pressed` (and its dark variant) so a pressed toggle reads as the
- * "actively pressed" step held persistently. `:hover` / `:focus` give the lighter
- * pre-press fill, mirroring the `button` recipe's ghost/outline ramp. `aria-pressed`
- * is never a recipe argument — it is runtime DOM state the `&:aria-pressed` rule
- * targets (just as `:hover` is not an argument).
+ * Three visual styles set the resting surface: `solid` (the default) carries a soft
+ * gray fill so it reads as a filled button at rest; `outline` is transparent with a
+ * border; `ghost` is transparent with no border. All three share a single engaged
+ * fill applied on hover, focus, active, and the ON state — `&:aria-pressed` reuses
+ * the `:active` fill, so a held toggle reads as the actively-pressed step.
+ * `aria-pressed` is never a recipe argument; it is runtime DOM state the
+ * `&:aria-pressed` rule targets (just as `:hover` is not an argument).
  *
  * Colours follow the form-control family (`checkbox` / `switch` / `input`):
  * `light` and `dark` are fixed across themes (absolute grays, no `&:dark`), while
@@ -58,10 +59,9 @@ export const useToggleRecipe = createUseRecipe("toggle", {
 			neutral: {},
 		},
 		variant: {
-			ghost: {
-				background: "transparent",
-			},
+			solid: {},
 			outline: {},
+			ghost: {},
 		},
 		size: {
 			sm: {
@@ -95,15 +95,17 @@ export const useToggleRecipe = createUseRecipe("toggle", {
 	},
 	compoundVariants: [
 		// Light surface — fixed light appearance across themes (absolute grays,
-		// dark text). No `&:dark` block: the gray scale is mode-independent.
+		// dark text). `solid` carries the `gray-100` resting fill; all variants share
+		// the `gray-150` engaged fill. No `&:dark` block: the gray scale is mode-independent.
 		{
-			match: { color: "light" as const, variant: "ghost" as const },
+			match: { color: "light" as const, variant: "solid" as const },
 			css: {
 				color: "@color.gray-700",
-				"&:hover": { background: "@color.gray-100" },
-				"&:focus": { background: "@color.gray-100" },
-				"&:active": { background: "@color.gray-200" },
-				"&:aria-pressed": { background: "@color.gray-200" },
+				background: "@color.gray-100",
+				"&:hover": { background: "@color.gray-150" },
+				"&:focus": { background: "@color.gray-150" },
+				"&:active": { background: "@color.gray-150" },
+				"&:aria-pressed": { background: "@color.gray-150" },
 			},
 		},
 		{
@@ -111,20 +113,32 @@ export const useToggleRecipe = createUseRecipe("toggle", {
 			css: {
 				color: "@color.gray-700",
 				borderColor: "@color.gray-300",
-				"&:hover": { background: "@color.gray-100" },
-				"&:focus": { background: "@color.gray-100" },
-				"&:active": { background: "@color.gray-200" },
-				"&:aria-pressed": { background: "@color.gray-200" },
+				"&:hover": { background: "@color.gray-150" },
+				"&:focus": { background: "@color.gray-150" },
+				"&:active": { background: "@color.gray-150" },
+				"&:aria-pressed": { background: "@color.gray-150" },
+			},
+		},
+		{
+			match: { color: "light" as const, variant: "ghost" as const },
+			css: {
+				color: "@color.gray-700",
+				"&:hover": { background: "@color.gray-150" },
+				"&:focus": { background: "@color.gray-150" },
+				"&:active": { background: "@color.gray-150" },
+				"&:aria-pressed": { background: "@color.gray-150" },
 			},
 		},
 		// Dark surface — fixed dark appearance across themes (absolute grays,
-		// light text). No `&:dark` block.
+		// light text). `solid` carries the `gray-800` resting fill; all variants share
+		// the `gray-750` engaged fill. No `&:dark` block.
 		{
-			match: { color: "dark" as const, variant: "ghost" as const },
+			match: { color: "dark" as const, variant: "solid" as const },
 			css: {
 				color: "@color.gray-200",
-				"&:hover": { background: "@color.gray-800" },
-				"&:focus": { background: "@color.gray-800" },
+				background: "@color.gray-800",
+				"&:hover": { background: "@color.gray-750" },
+				"&:focus": { background: "@color.gray-750" },
 				"&:active": { background: "@color.gray-750" },
 				"&:aria-pressed": { background: "@color.gray-750" },
 			},
@@ -134,26 +148,36 @@ export const useToggleRecipe = createUseRecipe("toggle", {
 			css: {
 				color: "@color.gray-200",
 				borderColor: "@color.gray-600",
-				"&:hover": { background: "@color.gray-800" },
-				"&:focus": { background: "@color.gray-800" },
+				"&:hover": { background: "@color.gray-750" },
+				"&:focus": { background: "@color.gray-750" },
 				"&:active": { background: "@color.gray-750" },
 				"&:aria-pressed": { background: "@color.gray-750" },
 			},
 		},
-		// Neutral surface — adaptive. Text follows `@color.text`; fills flip to the
-		// dark gray ramp under `&:dark`, and the ON (`:active`) fill is re-asserted
-		// on `&:dark:aria-pressed` to keep winning.
 		{
-			match: { color: "neutral" as const, variant: "ghost" as const },
+			match: { color: "dark" as const, variant: "ghost" as const },
+			css: {
+				color: "@color.gray-200",
+				"&:hover": { background: "@color.gray-750" },
+				"&:focus": { background: "@color.gray-750" },
+				"&:active": { background: "@color.gray-750" },
+				"&:aria-pressed": { background: "@color.gray-750" },
+			},
+		},
+		// Neutral surface — adaptive. Text follows `@color.text`; `solid`'s resting fill
+		// and every variant's engaged fills flip to the dark gray ramp under `&:dark`.
+		{
+			match: { color: "neutral" as const, variant: "solid" as const },
 			css: {
 				color: "@color.text",
-				"&:hover": { background: "@color.gray-100" },
-				"&:focus": { background: "@color.gray-100" },
-				"&:active": { background: "@color.gray-200" },
-				"&:aria-pressed": { background: "@color.gray-200" },
-				"&:dark": { color: "@color.gray-200" },
-				"&:dark:hover": { background: "@color.gray-800" },
-				"&:dark:focus": { background: "@color.gray-800" },
+				background: "@color.gray-100",
+				"&:hover": { background: "@color.gray-150" },
+				"&:focus": { background: "@color.gray-150" },
+				"&:active": { background: "@color.gray-150" },
+				"&:aria-pressed": { background: "@color.gray-150" },
+				"&:dark": { color: "@color.gray-200", background: "@color.gray-800" },
+				"&:dark:hover": { background: "@color.gray-750" },
+				"&:dark:focus": { background: "@color.gray-750" },
 				"&:dark:active": { background: "@color.gray-750" },
 				"&:dark:aria-pressed": { background: "@color.gray-750" },
 			},
@@ -163,13 +187,31 @@ export const useToggleRecipe = createUseRecipe("toggle", {
 			css: {
 				color: "@color.text",
 				borderColor: "@color.gray-300",
-				"&:hover": { background: "@color.gray-100" },
-				"&:focus": { background: "@color.gray-100" },
-				"&:active": { background: "@color.gray-200" },
-				"&:aria-pressed": { background: "@color.gray-200" },
-				"&:dark": { color: "@color.gray-200", borderColor: "@color.gray-600" },
-				"&:dark:hover": { background: "@color.gray-800" },
-				"&:dark:focus": { background: "@color.gray-800" },
+				"&:hover": { background: "@color.gray-150" },
+				"&:focus": { background: "@color.gray-150" },
+				"&:active": { background: "@color.gray-150" },
+				"&:aria-pressed": { background: "@color.gray-150" },
+				"&:dark": {
+					color: "@color.gray-200",
+					borderColor: "@color.gray-600",
+				},
+				"&:dark:hover": { background: "@color.gray-750" },
+				"&:dark:focus": { background: "@color.gray-750" },
+				"&:dark:active": { background: "@color.gray-750" },
+				"&:dark:aria-pressed": { background: "@color.gray-750" },
+			},
+		},
+		{
+			match: { color: "neutral" as const, variant: "ghost" as const },
+			css: {
+				color: "@color.text",
+				"&:hover": { background: "@color.gray-150" },
+				"&:focus": { background: "@color.gray-150" },
+				"&:active": { background: "@color.gray-150" },
+				"&:aria-pressed": { background: "@color.gray-150" },
+				"&:dark": { color: "@color.gray-200" },
+				"&:dark:hover": { background: "@color.gray-750" },
+				"&:dark:focus": { background: "@color.gray-750" },
 				"&:dark:active": { background: "@color.gray-750" },
 				"&:dark:aria-pressed": { background: "@color.gray-750" },
 			},
@@ -177,7 +219,7 @@ export const useToggleRecipe = createUseRecipe("toggle", {
 	],
 	defaultVariants: {
 		color: "neutral",
-		variant: "ghost",
+		variant: "solid",
 		size: "md",
 	},
 });

--- a/theme/src/recipes/toggle/useToggleRecipe.ts
+++ b/theme/src/recipes/toggle/useToggleRecipe.ts
@@ -1,0 +1,183 @@
+import { createUseRecipe } from "../../utils/createUseRecipe";
+
+/**
+ * Toggle recipe — a two-state `<button>` that looks like a button and carries an
+ * on/off state via `aria-pressed`. "A checkbox that looks like a toggleable button."
+ *
+ * The ON appearance reuses each colour/variant's `:active` fill, re-applied on
+ * `&:aria-pressed` (and its dark variant) so a pressed toggle reads as the
+ * "actively pressed" step held persistently. `:hover` / `:focus` give the lighter
+ * pre-press fill, mirroring the `button` recipe's ghost/outline ramp. `aria-pressed`
+ * is never a recipe argument — it is runtime DOM state the `&:aria-pressed` rule
+ * targets (just as `:hover` is not an argument).
+ *
+ * Colours follow the form-control family (`checkbox` / `switch` / `input`):
+ * `light` and `dark` are fixed across themes (absolute grays, no `&:dark`), while
+ * `neutral` is adaptive and overrides its fills under `&:dark`.
+ */
+export const useToggleRecipe = createUseRecipe("toggle", {
+	base: {
+		display: "inline-flex",
+		alignItems: "center",
+		justifyContent: "center",
+		fontWeight: "@font-weight.medium",
+		fontSize: "@font-size.sm",
+		borderWidth: "@border-width.thin",
+		borderStyle: "@border-style.solid",
+		borderColor: "transparent",
+		borderRadius: "@border-radius.md",
+		lineHeight: "@line-height.normal",
+		paddingTop: "@0.5",
+		paddingBottom: "@0.5",
+		paddingLeft: "@0.75",
+		paddingRight: "@0.75",
+		cursor: "pointer",
+		transitionProperty: "color, background-color, border-color",
+		transitionTimingFunction: "@easing.ease-in-out",
+		transitionDuration: "150ms",
+		textDecoration: "none",
+		whiteSpace: "nowrap",
+		userSelect: "none",
+		outline: "none",
+		"&:focus-visible": {
+			outlineWidth: "2px",
+			outlineStyle: "solid",
+			outlineColor: "@color.primary",
+			outlineOffset: "2px",
+		},
+		"&:disabled": {
+			cursor: "not-allowed",
+			opacity: "0.75",
+			pointerEvents: "none",
+		},
+	},
+	variants: {
+		color: {
+			light: {},
+			dark: {},
+			neutral: {},
+		},
+		variant: {
+			ghost: {
+				background: "transparent",
+			},
+			outline: {},
+		},
+		size: {
+			sm: {
+				fontSize: "@font-size.xs",
+				paddingTop: "@0.375",
+				paddingBottom: "@0.375",
+				paddingLeft: "@0.625",
+				paddingRight: "@0.625",
+				gap: "@0.375",
+				borderRadius: "@border-radius.md",
+			},
+			md: {
+				fontSize: "@font-size.sm",
+				paddingTop: "@0.5",
+				paddingBottom: "@0.5",
+				paddingLeft: "@0.75",
+				paddingRight: "@0.75",
+				gap: "@0.375",
+				borderRadius: "@border-radius.md",
+			},
+			lg: {
+				fontSize: "@font-size.md",
+				paddingTop: "@0.625",
+				paddingBottom: "@0.625",
+				paddingLeft: "@0.875",
+				paddingRight: "@0.875",
+				gap: "@0.5",
+				borderRadius: "@border-radius.md",
+			},
+		},
+	},
+	compoundVariants: [
+		// Light surface — fixed light appearance across themes (absolute grays,
+		// dark text). No `&:dark` block: the gray scale is mode-independent.
+		{
+			match: { color: "light" as const, variant: "ghost" as const },
+			css: {
+				color: "@color.gray-700",
+				"&:hover": { background: "@color.gray-100" },
+				"&:focus": { background: "@color.gray-100" },
+				"&:active": { background: "@color.gray-200" },
+				"&:aria-pressed": { background: "@color.gray-200" },
+			},
+		},
+		{
+			match: { color: "light" as const, variant: "outline" as const },
+			css: {
+				color: "@color.gray-700",
+				borderColor: "@color.gray-300",
+				"&:hover": { background: "@color.gray-100" },
+				"&:focus": { background: "@color.gray-100" },
+				"&:active": { background: "@color.gray-200" },
+				"&:aria-pressed": { background: "@color.gray-200" },
+			},
+		},
+		// Dark surface — fixed dark appearance across themes (absolute grays,
+		// light text). No `&:dark` block.
+		{
+			match: { color: "dark" as const, variant: "ghost" as const },
+			css: {
+				color: "@color.gray-200",
+				"&:hover": { background: "@color.gray-800" },
+				"&:focus": { background: "@color.gray-800" },
+				"&:active": { background: "@color.gray-750" },
+				"&:aria-pressed": { background: "@color.gray-750" },
+			},
+		},
+		{
+			match: { color: "dark" as const, variant: "outline" as const },
+			css: {
+				color: "@color.gray-200",
+				borderColor: "@color.gray-600",
+				"&:hover": { background: "@color.gray-800" },
+				"&:focus": { background: "@color.gray-800" },
+				"&:active": { background: "@color.gray-750" },
+				"&:aria-pressed": { background: "@color.gray-750" },
+			},
+		},
+		// Neutral surface — adaptive. Text follows `@color.text`; fills flip to the
+		// dark gray ramp under `&:dark`, and the ON (`:active`) fill is re-asserted
+		// on `&:dark:aria-pressed` to keep winning.
+		{
+			match: { color: "neutral" as const, variant: "ghost" as const },
+			css: {
+				color: "@color.text",
+				"&:hover": { background: "@color.gray-100" },
+				"&:focus": { background: "@color.gray-100" },
+				"&:active": { background: "@color.gray-200" },
+				"&:aria-pressed": { background: "@color.gray-200" },
+				"&:dark": { color: "@color.gray-200" },
+				"&:dark:hover": { background: "@color.gray-800" },
+				"&:dark:focus": { background: "@color.gray-800" },
+				"&:dark:active": { background: "@color.gray-750" },
+				"&:dark:aria-pressed": { background: "@color.gray-750" },
+			},
+		},
+		{
+			match: { color: "neutral" as const, variant: "outline" as const },
+			css: {
+				color: "@color.text",
+				borderColor: "@color.gray-300",
+				"&:hover": { background: "@color.gray-100" },
+				"&:focus": { background: "@color.gray-100" },
+				"&:active": { background: "@color.gray-200" },
+				"&:aria-pressed": { background: "@color.gray-200" },
+				"&:dark": { color: "@color.gray-200", borderColor: "@color.gray-600" },
+				"&:dark:hover": { background: "@color.gray-800" },
+				"&:dark:focus": { background: "@color.gray-800" },
+				"&:dark:active": { background: "@color.gray-750" },
+				"&:dark:aria-pressed": { background: "@color.gray-750" },
+			},
+		},
+	],
+	defaultVariants: {
+		color: "neutral",
+		variant: "ghost",
+		size: "md",
+	},
+});

--- a/theme/src/recipes/toggle/useToggleRecipe.ts
+++ b/theme/src/recipes/toggle/useToggleRecipe.ts
@@ -1,20 +1,23 @@
 import { createUseRecipe } from "../../utils/createUseRecipe";
 
 /**
- * Toggle recipe — a two-state `<button>` that looks like a button and carries an
- * on/off state via `aria-pressed`. "A checkbox that looks like a toggleable button."
+ * Toggle recipe — a two-state `<button>` that looks like a button and carries
+ * an on/off state via `aria-pressed`. "A checkbox that looks like a toggleable
+ * button."
  *
- * Three visual styles set the resting surface: `solid` (the default) carries a soft
- * gray fill so it reads as a filled button at rest; `outline` is transparent with a
- * border; `ghost` is transparent with no border. All three share a single engaged
- * fill applied on hover, focus, active, and the ON state — `&:aria-pressed` reuses
- * the `:active` fill, so a held toggle reads as the actively-pressed step.
+ * The three visual styles mirror the matching `button` recipe variants so a
+ * toggle reads like a button at rest: `solid` (the default) is a filled surface
+ * with a subtle border, `outline` is transparent with a border, and `ghost` is
+ * transparent with none. Each gives hover, focus, and active feedback; the ON
+ * state reuses the hover fill: `&:aria-pressed` mirrors `:hover` (and
+ * `&:dark:aria-pressed` mirrors `&:dark:hover`), so a held toggle reads like a
+ * hovered button.
  * `aria-pressed` is never a recipe argument; it is runtime DOM state the
  * `&:aria-pressed` rule targets (just as `:hover` is not an argument).
  *
  * Colours follow the form-control family (`checkbox` / `switch` / `input`):
- * `light` and `dark` are fixed across themes (absolute grays, no `&:dark`), while
- * `neutral` is adaptive and overrides its fills under `&:dark`.
+ * `light` and `dark` are fixed across themes (their `&:dark` blocks re-assert
+ * the surface), while `neutral` is adaptive and flips its fills under `&:dark`.
  */
 export const useToggleRecipe = createUseRecipe("toggle", {
 	base: {
@@ -93,93 +96,182 @@ export const useToggleRecipe = createUseRecipe("toggle", {
 			},
 		},
 	},
+	// Each block mirrors the matching `button` recipe variant; the toggle adds the ON
+	// state by reusing `:hover` on `&:aria-pressed` (and `&:dark:hover` on
+	// `&:dark:aria-pressed`), so a held toggle looks like a hovered button.
 	compoundVariants: [
-		// Light surface — fixed light appearance across themes (absolute grays,
-		// dark text). `solid` carries the `gray-100` resting fill; all variants share
-		// the `gray-150` engaged fill. No `&:dark` block: the gray scale is mode-independent.
+		// Light surface — fixed light appearance; the `&:dark` block re-asserts the
+		// surface (flipping text to stay readable) so it never adopts the dark theme.
 		{
 			match: { color: "light" as const, variant: "solid" as const },
 			css: {
-				color: "@color.gray-700",
-				background: "@color.gray-100",
-				"&:hover": { background: "@color.gray-150" },
-				"&:focus": { background: "@color.gray-150" },
-				"&:active": { background: "@color.gray-150" },
-				"&:aria-pressed": { background: "@color.gray-150" },
+				background: "@color.white",
+				color: "@color.text",
+				borderColor: "@color.gray-200",
+				"&:hover": { background: "@color.gray-100" },
+				"&:focus": { background: "@color.gray-100" },
+				"&:active": { background: "@color.gray-200" },
+				"&:aria-pressed": { background: "@color.gray-100" },
+				"&:dark": {
+					background: "@color.white",
+					color: "@color.text-inverted",
+					borderColor: "@color.gray-200",
+				},
 			},
 		},
 		{
 			match: { color: "light" as const, variant: "outline" as const },
 			css: {
-				color: "@color.gray-700",
+				color: "@color.text-inverted",
 				borderColor: "@color.gray-300",
-				"&:hover": { background: "@color.gray-150" },
-				"&:focus": { background: "@color.gray-150" },
-				"&:active": { background: "@color.gray-150" },
-				"&:aria-pressed": { background: "@color.gray-150" },
+				"&:hover": {
+					background: "@color.gray-100",
+					color: "@color.text",
+				},
+				"&:focus": {
+					background: "@color.gray-100",
+					color: "@color.text",
+				},
+				"&:active": {
+					background: "@color.gray-200",
+					color: "@color.text",
+				},
+				"&:aria-pressed": {
+					background: "@color.gray-100",
+					color: "@color.text",
+				},
+				"&:dark": { color: "@color.text", borderColor: "@color.gray-300" },
+				"&:dark:hover": { color: "@color.text-inverted" },
+				"&:dark:focus": { color: "@color.text-inverted" },
+				"&:dark:active": { color: "@color.text-inverted" },
+				"&:dark:aria-pressed": { color: "@color.text-inverted" },
 			},
 		},
 		{
 			match: { color: "light" as const, variant: "ghost" as const },
 			css: {
-				color: "@color.gray-700",
-				"&:hover": { background: "@color.gray-150" },
-				"&:focus": { background: "@color.gray-150" },
-				"&:active": { background: "@color.gray-150" },
-				"&:aria-pressed": { background: "@color.gray-150" },
+				color: "@color.text-inverted",
+				"&:hover": {
+					background: "@color.gray-100",
+					color: "@color.text",
+				},
+				"&:focus": {
+					background: "@color.gray-100",
+					color: "@color.text",
+				},
+				"&:active": {
+					background: "@color.gray-200",
+					color: "@color.text",
+				},
+				"&:aria-pressed": {
+					background: "@color.gray-100",
+					color: "@color.text",
+				},
+				"&:dark": { color: "@color.text" },
+				"&:dark:hover": { color: "@color.text-inverted" },
+				"&:dark:focus": { color: "@color.text-inverted" },
+				"&:dark:active": { color: "@color.text-inverted" },
+				"&:dark:aria-pressed": { color: "@color.text-inverted" },
 			},
 		},
-		// Dark surface — fixed dark appearance across themes (absolute grays,
-		// light text). `solid` carries the `gray-800` resting fill; all variants share
-		// the `gray-750` engaged fill. No `&:dark` block.
+		// Dark surface — fixed dark appearance; the `&:dark` block re-asserts the
+		// surface so it stays dark in either theme.
 		{
 			match: { color: "dark" as const, variant: "solid" as const },
 			css: {
-				color: "@color.gray-200",
-				background: "@color.gray-800",
-				"&:hover": { background: "@color.gray-750" },
-				"&:focus": { background: "@color.gray-750" },
+				background: "@color.gray-900",
+				color: "@color.white",
+				borderColor: "@color.gray-800",
+				"&:hover": { background: "@color.gray-800" },
+				"&:focus": { background: "@color.gray-800" },
 				"&:active": { background: "@color.gray-750" },
-				"&:aria-pressed": { background: "@color.gray-750" },
+				"&:aria-pressed": { background: "@color.gray-800" },
+				"&:dark": {
+					background: "@color.gray-900",
+					color: "@color.white",
+					borderColor: "@color.gray-800",
+				},
 			},
 		},
 		{
 			match: { color: "dark" as const, variant: "outline" as const },
 			css: {
-				color: "@color.gray-200",
+				color: "@color.text",
 				borderColor: "@color.gray-600",
-				"&:hover": { background: "@color.gray-750" },
-				"&:focus": { background: "@color.gray-750" },
-				"&:active": { background: "@color.gray-750" },
-				"&:aria-pressed": { background: "@color.gray-750" },
+				"&:hover": {
+					background: "@color.gray-800",
+					color: "@color.text-inverted",
+				},
+				"&:focus": {
+					background: "@color.gray-800",
+					color: "@color.text-inverted",
+				},
+				"&:active": {
+					background: "@color.gray-750",
+					color: "@color.text-inverted",
+				},
+				"&:aria-pressed": {
+					background: "@color.gray-800",
+					color: "@color.text-inverted",
+				},
+				"&:dark": {
+					color: "@color.text-inverted",
+					borderColor: "@color.gray-600",
+				},
+				"&:dark:hover": { color: "@color.text" },
+				"&:dark:focus": { color: "@color.text" },
+				"&:dark:active": { color: "@color.text" },
+				"&:dark:aria-pressed": { color: "@color.text" },
 			},
 		},
 		{
 			match: { color: "dark" as const, variant: "ghost" as const },
 			css: {
-				color: "@color.gray-200",
-				"&:hover": { background: "@color.gray-750" },
-				"&:focus": { background: "@color.gray-750" },
-				"&:active": { background: "@color.gray-750" },
-				"&:aria-pressed": { background: "@color.gray-750" },
+				color: "@color.text",
+				"&:hover": {
+					background: "@color.gray-800",
+					color: "@color.text-inverted",
+				},
+				"&:focus": {
+					background: "@color.gray-800",
+					color: "@color.text-inverted",
+				},
+				"&:active": {
+					background: "@color.gray-750",
+					color: "@color.text-inverted",
+				},
+				"&:aria-pressed": {
+					background: "@color.gray-800",
+					color: "@color.text-inverted",
+				},
+				"&:dark": { color: "@color.text-inverted" },
+				"&:dark:hover": { color: "@color.text" },
+				"&:dark:focus": { color: "@color.text" },
+				"&:dark:active": { color: "@color.text" },
+				"&:dark:aria-pressed": { color: "@color.text" },
 			},
 		},
-		// Neutral surface — adaptive. Text follows `@color.text`; `solid`'s resting fill
-		// and every variant's engaged fills flip to the dark gray ramp under `&:dark`.
+		// Neutral surface — adaptive. Light in light mode, dark in dark mode; the
+		// `&:dark` block flips the surface and its hover/active fills.
 		{
 			match: { color: "neutral" as const, variant: "solid" as const },
 			css: {
+				background: "@color.white",
 				color: "@color.text",
-				background: "@color.gray-100",
-				"&:hover": { background: "@color.gray-150" },
-				"&:focus": { background: "@color.gray-150" },
-				"&:active": { background: "@color.gray-150" },
-				"&:aria-pressed": { background: "@color.gray-150" },
-				"&:dark": { color: "@color.gray-200", background: "@color.gray-800" },
-				"&:dark:hover": { background: "@color.gray-750" },
-				"&:dark:focus": { background: "@color.gray-750" },
+				borderColor: "@color.gray-200",
+				"&:hover": { background: "@color.gray-100" },
+				"&:focus": { background: "@color.gray-100" },
+				"&:active": { background: "@color.gray-200" },
+				"&:aria-pressed": { background: "@color.gray-100" },
+				"&:dark": {
+					background: "@color.gray-900",
+					color: "@color.white",
+					borderColor: "@color.gray-800",
+				},
+				"&:dark:hover": { background: "@color.gray-800" },
+				"&:dark:focus": { background: "@color.gray-800" },
 				"&:dark:active": { background: "@color.gray-750" },
-				"&:dark:aria-pressed": { background: "@color.gray-750" },
+				"&:dark:aria-pressed": { background: "@color.gray-800" },
 			},
 		},
 		{
@@ -187,33 +279,30 @@ export const useToggleRecipe = createUseRecipe("toggle", {
 			css: {
 				color: "@color.text",
 				borderColor: "@color.gray-300",
-				"&:hover": { background: "@color.gray-150" },
-				"&:focus": { background: "@color.gray-150" },
-				"&:active": { background: "@color.gray-150" },
-				"&:aria-pressed": { background: "@color.gray-150" },
-				"&:dark": {
-					color: "@color.gray-200",
-					borderColor: "@color.gray-600",
-				},
-				"&:dark:hover": { background: "@color.gray-750" },
-				"&:dark:focus": { background: "@color.gray-750" },
+				"&:hover": { background: "@color.gray-100" },
+				"&:focus": { background: "@color.gray-100" },
+				"&:active": { background: "@color.gray-200" },
+				"&:aria-pressed": { background: "@color.gray-100" },
+				"&:dark": { color: "@color.gray-200", borderColor: "@color.gray-600" },
+				"&:dark:hover": { background: "@color.gray-800" },
+				"&:dark:focus": { background: "@color.gray-800" },
 				"&:dark:active": { background: "@color.gray-750" },
-				"&:dark:aria-pressed": { background: "@color.gray-750" },
+				"&:dark:aria-pressed": { background: "@color.gray-800" },
 			},
 		},
 		{
 			match: { color: "neutral" as const, variant: "ghost" as const },
 			css: {
 				color: "@color.text",
-				"&:hover": { background: "@color.gray-150" },
-				"&:focus": { background: "@color.gray-150" },
-				"&:active": { background: "@color.gray-150" },
-				"&:aria-pressed": { background: "@color.gray-150" },
+				"&:hover": { background: "@color.gray-100" },
+				"&:focus": { background: "@color.gray-100" },
+				"&:active": { background: "@color.gray-200" },
+				"&:aria-pressed": { background: "@color.gray-100" },
 				"&:dark": { color: "@color.gray-200" },
-				"&:dark:hover": { background: "@color.gray-750" },
-				"&:dark:focus": { background: "@color.gray-750" },
+				"&:dark:hover": { background: "@color.gray-800" },
+				"&:dark:focus": { background: "@color.gray-800" },
 				"&:dark:active": { background: "@color.gray-750" },
-				"&:dark:aria-pressed": { background: "@color.gray-750" },
+				"&:dark:aria-pressed": { background: "@color.gray-800" },
 			},
 		},
 	],


### PR DESCRIPTION
## Summary

- Adds `useToggleRecipe()` — a single toggleable button driven by `aria-pressed`, with `solid`, `outline`, `soft`, `subtle`, and `ghost` variants, `primary`/`secondary`/`success`/`info`/`warning`/`error`/`neutral` colors, and `xs`–`xl` sizes.
- Adds `useToggleGroupRecipe()` — a segmented control that composes multiple toggles with connected borders and shared sizing/color variants.
- Includes Storybook stories, Vue preview components, and documentation pages for both recipes.

## Test plan

- [ ] `useToggleRecipe` and `useToggleGroupRecipe` unit tests pass (`pnpm test` in `theme/`)
- [ ] Storybook renders all Toggle and ToggleGroup variant/size/color combinations
- [ ] Documentation pages render correctly in the docs site