### PR TITLE
feat(theme): make dark modifier theme-driven, drop media query

### DIFF
--- a/.changeset/dark-modifier-theme-driven.md
+++ b/.changeset/dark-modifier-theme-driven.md
@@ -1,0 +1,8 @@
+---
+"@styleframe/theme": minor
+"styleframe": minor
+---
+
+The built-in `dark` modifier is now theme-driven. It no longer emits `@media (prefers-color-scheme: dark)`; `_dark:` / `&:dark` now respond solely to `.dark-theme` / `[data-theme="dark"]`, matching the values set by the `dark` theme. This fixes light surfaces showing inverted (unreadable) text when the OS is in dark mode but no `data-theme` is set.
+
+Migration: to follow the operating-system preference, mirror it into `data-theme` — e.g. `window.matchMedia('(prefers-color-scheme: dark)')` → set `document.documentElement.dataset.theme`. See the theme-switcher guide.

--- a/apps/docs/content/docs/01.getting-started/03.guides/02.theme-switcher.md
+++ b/apps/docs/content/docs/01.getting-started/03.guides/02.theme-switcher.md
@@ -19,7 +19,9 @@ Theme switching provides:
 
 ## How it Works
 
-Styleframe uses the `data-theme` attribute to scope theme-specific styles. When you define a theme, you use a callback function that receives a context object to override variables:
+Styleframe uses the `data-theme` attribute to scope theme-specific styles. The built-in `dark` modifier (`_dark:` / `&:dark`) responds to the same `.dark-theme` / `[data-theme="dark"]` selector, so toggling `data-theme` drives both your theme's token values and any dark-modifier utilities together. To follow the operating-system preference, detect it with `matchMedia` and mirror it into `data-theme` (as shown below).
+
+When you define a theme, you use a callback function that receives a context object to override variables:
 
 ::tabs
 :::tabs-item{icon="i-lucide-code" label="Styleframe"}

--- a/apps/docs/content/docs/07.modifiers/00.index.md
+++ b/apps/docs/content/docs/07.modifiers/00.index.md
@@ -158,7 +158,7 @@ Modifiers for form element pseudo-class states like disabled, checked, and valid
 Modifiers for targeting user preferences and media conditions like dark mode and reduced motion.
 
 **Available composables:**
-- **`useDarkModifier()`**: Apply styles in `prefers-color-scheme: dark`
+- **`useDarkModifier()`**: Apply styles under `.dark-theme` / `[data-theme="dark"]`
 - **`useMotionSafeModifier()`**: Apply styles when motion is not reduced
 - **`useMotionReduceModifier()`**: Apply styles in `prefers-reduced-motion: reduce`
 - **`useContrastMoreModifier()`**: Apply styles in `prefers-contrast: more`

--- a/apps/docs/content/docs/07.modifiers/01.preset.md
+++ b/apps/docs/content/docs/07.modifiers/01.preset.md
@@ -64,9 +64,11 @@ export default s;
 ._focus\:background-color\:secondary:focus { background-color: #6c757d; }
 
 /* Dark mode modifier variants */
-@media (prefers-color-scheme: dark) {
-    ._dark\:background-color\:primary { background-color: #006cff; }
-    ._dark\:background-color\:secondary { background-color: #6c757d; }
+._dark\:background-color\:primary {
+    :is(.dark-theme, [data-theme="dark"]) & { background-color: #006cff; }
+}
+._dark\:background-color\:secondary {
+    :is(.dark-theme, [data-theme="dark"]) & { background-color: #6c757d; }
 }
 
 /* Opacity with hover */

--- a/apps/docs/content/docs/07.modifiers/05.media-preferences.md
+++ b/apps/docs/content/docs/07.modifiers/05.media-preferences.md
@@ -12,7 +12,7 @@ navigation:
 
 ## Overview
 
-Media and preference modifiers let you apply utility styles conditionally based on user preferences and media conditions. They wrap utility declarations in CSS `@media` queries like `prefers-color-scheme: dark` and `prefers-reduced-motion`, generating variant utility classes that adapt to the user's environment.
+Media and preference modifiers let you apply utility styles conditionally based on user preferences and media conditions. Most wrap utility declarations in CSS `@media` queries like `prefers-reduced-motion` and `prefers-contrast`; the `dark` modifier is theme-driven and instead targets the `.dark-theme` / `[data-theme="dark"]` selector. Together they generate variant utility classes that adapt to the user's environment.
 
 ## Why Use Media & Preference Modifiers?
 
@@ -27,7 +27,9 @@ Media and preference modifiers help you:
 
 ## `useDarkModifier`
 
-The `useDarkModifier()` function creates a modifier that applies styles when the user's system prefers a dark color scheme. It generates both a `@media (prefers-color-scheme: dark)` query and a `:is(.dark-theme, [data-theme="dark"])` class-based selector, and forwards variables and children through both paths.
+The `useDarkModifier()` function creates a modifier that applies styles when the dark theme is active. It generates a single `:is(.dark-theme, [data-theme="dark"])` class/attribute selector — the same selector the `dark` theme's token values use — and forwards variables and children through it.
+
+To follow the operating-system preference, mirror it into `data-theme` from JavaScript (`window.matchMedia('(prefers-color-scheme: dark)')`); see the [Theme Switcher Guide](/docs/getting-started/guides/theme-switcher).
 
 ::tabs
 :::tabs-item{icon="i-lucide-code" label="Code"}
@@ -64,18 +66,12 @@ export default s;
 ._text-color\:body-light { color: #e2e8f0; }
 
 ._dark\:background-color\:surface-dark {
-    @media (prefers-color-scheme: dark) {
-        background-color: #1a1a2e;
-    }
     :is(.dark-theme, [data-theme="dark"]) & {
         background-color: #1a1a2e;
     }
 }
 
 ._dark\:text-color\:body-light {
-    @media (prefers-color-scheme: dark) {
-        color: #e2e8f0;
-    }
     :is(.dark-theme, [data-theme="dark"]) & {
         color: #e2e8f0;
     }
@@ -87,7 +83,7 @@ export default s;
 
 ```html
 <body class="_background-color:surface _dark:background-color:surface-dark _text-color:body _dark:text-color:body-light">
-    <p>This text adapts to dark mode automatically.</p>
+    <p>This text adapts when the dark theme is active (data-theme="dark").</p>
 </body>
 ```
 
@@ -101,11 +97,6 @@ The dark modifier composes with other modifiers. When combined (e.g., `[dark, ho
 
 ```css [styleframe/index.css]
 ._dark\:hover\:background-color\:primary {
-    @media (prefers-color-scheme: dark) {
-        &:hover {
-            background-color: var(--color--primary);
-        }
-    }
     :is(.dark-theme, [data-theme="dark"]) & {
         &:hover {
             background-color: var(--color--primary);
@@ -121,7 +112,7 @@ The dark modifier composes with other modifiers. When combined (e.g., `[dark, ho
 
 | Modifier Name | Selectors |
 |---------------|------------|
-| `dark` | `@media (prefers-color-scheme: dark)` and `:is(.dark-theme, [data-theme="dark"]) &` |
+| `dark` | `:is(.dark-theme, [data-theme="dark"]) &` |
 
 ## `useMotionSafeModifier`
 
@@ -362,7 +353,7 @@ The `useMediaPreferenceModifiers()` function registers all media and preference 
 
 | Key | Modifier Name | Media Query |
 |-----|---------------|------------|
-| `dark` | `dark` | `@media (prefers-color-scheme: dark)` |
+| `dark` | `dark` | `:is(.dark-theme, [data-theme="dark"]) &` |
 | `motionSafe` | `motion-safe` | `@media (prefers-reduced-motion: no-preference)` |
 | `motionReduce` | `motion-reduce` | `@media (prefers-reduced-motion: reduce)` |
 | `contrastMore` | `contrast-more` | `@media (prefers-contrast: more)` |
@@ -489,11 +480,11 @@ Use `motion-safe` if you want animations to be opt-in (only animate when the use
 :::
 
 :::accordion-item{label="Can I combine dark with hover?" icon="i-lucide-circle-help"}
-Yes! Use a nested array `[dark, hover]` to generate a combined variant. The dark modifier wraps hover, producing nested selectors: `@media (prefers-color-scheme: dark) { &:hover { ... } }`. This lets you create different hover effects for dark mode.
+Yes! Use a nested array `[dark, hover]` to generate a combined variant. The dark modifier wraps hover, producing nested selectors: `:is(.dark-theme, [data-theme="dark"]) & { &:hover { ... } }`. This lets you create different hover effects for dark mode.
 :::
 
 :::accordion-item{label="Does the dark modifier work with data-theme?" icon="i-lucide-circle-help"}
-Yes. The `useDarkModifier` generates both `@media (prefers-color-scheme: dark)` (for system preference) and `:is(.dark-theme, [data-theme="dark"]) &` (for class/attribute-based toggling). Both selectors are produced for every dark modifier variant.
+Yes — `data-theme` is exactly what it responds to. The `useDarkModifier` generates a single `:is(.dark-theme, [data-theme="dark"]) &` selector, matching the values set by the `dark` theme. It does **not** emit `@media (prefers-color-scheme: dark)`; to follow the operating-system preference, mirror it into `data-theme` (see the [Theme Switcher Guide](/docs/getting-started/guides/theme-switcher)).
 :::
 
 :::accordion-item{label="How do I test orientation modifiers?" icon="i-lucide-circle-help"}

--- a/theme/src/modifiers/useMediaPreferenceModifiers.test.ts
+++ b/theme/src/modifiers/useMediaPreferenceModifiers.test.ts
@@ -40,7 +40,7 @@ describe("useMediaPreferenceModifiers", () => {
 		expect(css).toContain("._dark\\:background-color\\:primary {");
 	});
 
-	it("should generate dark modifier with both media query and theme selectors", () => {
+	it("should generate dark modifier with theme selectors only (no media query)", () => {
 		const s = styleframe();
 		const { dark } = useMediaPreferenceModifiers(s);
 
@@ -50,7 +50,7 @@ describe("useMediaPreferenceModifiers", () => {
 		createBg({ primary: "#006cff" }, [dark]);
 
 		const css = consumeCSS(s.root, s.options);
-		expect(css).toContain("@media (prefers-color-scheme: dark)");
+		expect(css).not.toContain("@media (prefers-color-scheme: dark)");
 		expect(css).toContain(".dark-theme");
 		expect(css).toContain('[data-theme="dark"]');
 	});

--- a/theme/src/modifiers/useMediaPreferenceModifiers.ts
+++ b/theme/src/modifiers/useMediaPreferenceModifiers.ts
@@ -14,13 +14,8 @@ export interface MediaPreferenceModifiers {
 
 export function useDarkModifier(s: Styleframe): ModifierFactory {
 	return s.modifier("dark", ({ declarations, variables, children }) => ({
-		"@media (prefers-color-scheme: dark)": {
-			declarations,
-			variables,
-			children,
-		},
 		':is(.dark-theme, [data-theme="dark"]) &': {
-			declarations: { ...declarations },
+			declarations,
 			variables,
 			children,
 		},


### PR DESCRIPTION
## Summary

- `useDarkModifier()` now emits only `:is(.dark-theme, [data-theme="dark"]) &` — the same selector used by the `dark` theme's token values — and no longer emits `@media (prefers-color-scheme: dark)`.
- This fixes light surfaces rendering with inverted (unreadable) text when the OS is in dark mode but no `data-theme` attribute is set.
- Docs updated across the theme-switcher guide, modifiers index, preset page, and media-preferences reference to reflect the new behavior and migration path (mirror OS preference into `data-theme` via `matchMedia`).

## Migration

To respond to the OS dark-mode preference, set `data-theme` from JavaScript:
```js
const mq = window.matchMedia('(prefers-color-scheme: dark)')
document.documentElement.dataset.theme = mq.matches ? 'dark' : 'light'
mq.addEventListener('change', e => { document.documentElement.dataset.theme = e.matches ? 'dark' : 'light' })
```
See the updated Theme Switcher guide for full details.