### PR TITLE
fix(theme): use gray-50 instead of gray-100 for soft and subtle variants

### DIFF
--- a/.changeset/gray-50-soft-subtle-variants.md
+++ b/.changeset/gray-50-soft-subtle-variants.md
@@ -1,0 +1,6 @@
+---
+"@styleframe/theme": patch
+"styleframe": patch
+---
+
+Use `gray-50` instead of `gray-100` for soft and subtle variants in callout, card, modal, popover, and tooltip recipes.

--- a/theme/src/recipes/callout/useCalloutRecipe.ts
+++ b/theme/src/recipes/callout/useCalloutRecipe.ts
@@ -159,10 +159,10 @@ export const useCalloutRecipe = createUseRecipe("callout", {
 		{
 			match: { color: "light" as const, variant: "soft" as const },
 			css: {
-				background: "@color.gray-100",
+				background: "@color.gray-50",
 				color: "@color.gray-700",
 				"&:dark": {
-					background: "@color.gray-100",
+					background: "@color.gray-50",
 					color: "@color.gray-700",
 				},
 			},
@@ -170,11 +170,11 @@ export const useCalloutRecipe = createUseRecipe("callout", {
 		{
 			match: { color: "light" as const, variant: "subtle" as const },
 			css: {
-				background: "@color.gray-100",
+				background: "@color.gray-50",
 				color: "@color.gray-700",
 				borderColor: "@color.gray-300",
 				"&:dark": {
-					background: "@color.gray-100",
+					background: "@color.gray-50",
 					color: "@color.gray-700",
 					borderColor: "@color.gray-300",
 				},
@@ -259,7 +259,7 @@ export const useCalloutRecipe = createUseRecipe("callout", {
 		{
 			match: { color: "neutral" as const, variant: "soft" as const },
 			css: {
-				background: "@color.gray-100",
+				background: "@color.gray-50",
 				color: "@color.gray-700",
 				"&:dark": {
 					background: "@color.gray-800",
@@ -270,7 +270,7 @@ export const useCalloutRecipe = createUseRecipe("callout", {
 		{
 			match: { color: "neutral" as const, variant: "subtle" as const },
 			css: {
-				background: "@color.gray-100",
+				background: "@color.gray-50",
 				color: "@color.gray-700",
 				borderColor: "@color.gray-300",
 				"&:dark": {

--- a/theme/src/recipes/card/useCardRecipe.test.ts
+++ b/theme/src/recipes/card/useCardRecipe.test.ts
@@ -205,7 +205,7 @@ describe("useCardRecipe", () => {
 			expect(neutralSubtle).toEqual({
 				match: { color: "neutral", variant: "subtle" },
 				css: {
-					background: "@color.gray-100",
+					background: "@color.gray-50",
 					color: "@color.gray-700",
 					borderColor: "@color.gray-200",
 					"&:dark": {

--- a/theme/src/recipes/card/useCardRecipe.ts
+++ b/theme/src/recipes/card/useCardRecipe.ts
@@ -58,10 +58,10 @@ export const useCardRecipe = createUseRecipe("card", {
 		{
 			match: { color: "light" as const, variant: "soft" as const },
 			css: {
-				background: "@color.gray-100",
+				background: "@color.gray-50",
 				color: "@color.gray-700",
 				"&:dark": {
-					background: "@color.gray-100",
+					background: "@color.gray-50",
 					color: "@color.gray-700",
 				},
 			},
@@ -69,11 +69,11 @@ export const useCardRecipe = createUseRecipe("card", {
 		{
 			match: { color: "light" as const, variant: "subtle" as const },
 			css: {
-				background: "@color.gray-100",
+				background: "@color.gray-50",
 				color: "@color.gray-700",
 				borderColor: "@color.gray-200",
 				"&:dark": {
-					background: "@color.gray-100",
+					background: "@color.gray-50",
 					color: "@color.gray-700",
 					borderColor: "@color.gray-200",
 				},
@@ -136,7 +136,7 @@ export const useCardRecipe = createUseRecipe("card", {
 		{
 			match: { color: "neutral" as const, variant: "soft" as const },
 			css: {
-				background: "@color.gray-100",
+				background: "@color.gray-50",
 				color: "@color.gray-700",
 				"&:dark": {
 					background: "@color.gray-800",
@@ -147,7 +147,7 @@ export const useCardRecipe = createUseRecipe("card", {
 		{
 			match: { color: "neutral" as const, variant: "subtle" as const },
 			css: {
-				background: "@color.gray-100",
+				background: "@color.gray-50",
 				color: "@color.gray-700",
 				borderColor: "@color.gray-200",
 				"&:dark": {

--- a/theme/src/recipes/modal/createOverlayRecipes.ts
+++ b/theme/src/recipes/modal/createOverlayRecipes.ts
@@ -37,10 +37,10 @@ export const overlaySurfaceCompoundVariants: NonNullable<
 	{
 		match: { color: "light", variant: "soft" },
 		css: {
-			background: "@color.gray-100",
+			background: "@color.gray-50",
 			color: "@color.gray-700",
 			"&:dark": {
-				background: "@color.gray-100",
+				background: "@color.gray-50",
 				color: "@color.gray-700",
 			},
 		},
@@ -48,11 +48,11 @@ export const overlaySurfaceCompoundVariants: NonNullable<
 	{
 		match: { color: "light", variant: "subtle" },
 		css: {
-			background: "@color.gray-100",
+			background: "@color.gray-50",
 			color: "@color.gray-700",
 			borderColor: "@color.gray-200",
 			"&:dark": {
-				background: "@color.gray-100",
+				background: "@color.gray-50",
 				color: "@color.gray-700",
 				borderColor: "@color.gray-200",
 			},
@@ -115,7 +115,7 @@ export const overlaySurfaceCompoundVariants: NonNullable<
 	{
 		match: { color: "neutral", variant: "soft" },
 		css: {
-			background: "@color.gray-100",
+			background: "@color.gray-50",
 			color: "@color.gray-700",
 			"&:dark": {
 				background: "@color.gray-800",
@@ -126,7 +126,7 @@ export const overlaySurfaceCompoundVariants: NonNullable<
 	{
 		match: { color: "neutral", variant: "subtle" },
 		css: {
-			background: "@color.gray-100",
+			background: "@color.gray-50",
 			color: "@color.gray-700",
 			borderColor: "@color.gray-200",
 			"&:dark": {

--- a/theme/src/recipes/modal/useModalRecipe.test.ts
+++ b/theme/src/recipes/modal/useModalRecipe.test.ts
@@ -234,7 +234,7 @@ describe("useModalRecipe", () => {
 			expect(neutralSubtle).toEqual({
 				match: { color: "neutral", variant: "subtle" },
 				css: {
-					background: "@color.gray-100",
+					background: "@color.gray-50",
 					color: "@color.gray-700",
 					borderColor: "@color.gray-200",
 					"&:dark": {

--- a/theme/src/recipes/popover/usePopoverArrowRecipe.test.ts
+++ b/theme/src/recipes/popover/usePopoverArrowRecipe.test.ts
@@ -153,15 +153,15 @@ describe("usePopoverArrowRecipe", () => {
 			expect(lightSoft).toEqual({
 				match: { color: "light", variant: "soft" },
 				css: {
-					borderTopColor: "@color.gray-100",
+					borderTopColor: "@color.gray-50",
 					"&:after": {
-						borderTopColor: "@color.gray-100",
+						borderTopColor: "@color.gray-50",
 					},
 					"&:dark": {
-						borderTopColor: "@color.gray-100",
+						borderTopColor: "@color.gray-50",
 					},
 					"&:dark:after": {
-						borderTopColor: "@color.gray-100",
+						borderTopColor: "@color.gray-50",
 					},
 				},
 			});

--- a/theme/src/recipes/popover/usePopoverArrowRecipe.ts
+++ b/theme/src/recipes/popover/usePopoverArrowRecipe.ts
@@ -69,15 +69,15 @@ export const usePopoverArrowRecipe = createUseRecipe(
 			{
 				match: { color: "light" as const, variant: "soft" as const },
 				css: {
-					borderTopColor: "@color.gray-100",
+					borderTopColor: "@color.gray-50",
 					"&:after": {
-						borderTopColor: "@color.gray-100",
+						borderTopColor: "@color.gray-50",
 					},
 					"&:dark": {
-						borderTopColor: "@color.gray-100",
+						borderTopColor: "@color.gray-50",
 					},
 					"&:dark:after": {
-						borderTopColor: "@color.gray-100",
+						borderTopColor: "@color.gray-50",
 					},
 				},
 			},
@@ -86,13 +86,13 @@ export const usePopoverArrowRecipe = createUseRecipe(
 				css: {
 					borderTopColor: "@color.gray-200",
 					"&:after": {
-						borderTopColor: "@color.gray-100",
+						borderTopColor: "@color.gray-50",
 					},
 					"&:dark": {
 						borderTopColor: "@color.gray-200",
 					},
 					"&:dark:after": {
-						borderTopColor: "@color.gray-100",
+						borderTopColor: "@color.gray-50",
 					},
 				},
 			},
@@ -163,9 +163,9 @@ export const usePopoverArrowRecipe = createUseRecipe(
 			{
 				match: { color: "neutral" as const, variant: "soft" as const },
 				css: {
-					borderTopColor: "@color.gray-100",
+					borderTopColor: "@color.gray-50",
 					"&:after": {
-						borderTopColor: "@color.gray-100",
+						borderTopColor: "@color.gray-50",
 					},
 					"&:dark": {
 						borderTopColor: "@color.gray-800",
@@ -180,7 +180,7 @@ export const usePopoverArrowRecipe = createUseRecipe(
 				css: {
 					borderTopColor: "@color.gray-200",
 					"&:after": {
-						borderTopColor: "@color.gray-100",
+						borderTopColor: "@color.gray-50",
 					},
 					"&:dark": {
 						borderTopColor: "@color.gray-700",

--- a/theme/src/recipes/popover/usePopoverRecipe.test.ts
+++ b/theme/src/recipes/popover/usePopoverRecipe.test.ts
@@ -207,7 +207,7 @@ describe("usePopoverRecipe", () => {
 			expect(neutralSubtle).toEqual({
 				match: { color: "neutral", variant: "subtle" },
 				css: {
-					background: "@color.gray-100",
+					background: "@color.gray-50",
 					color: "@color.gray-700",
 					borderColor: "@color.gray-200",
 					"&:dark": {

--- a/theme/src/recipes/popover/usePopoverRecipe.ts
+++ b/theme/src/recipes/popover/usePopoverRecipe.ts
@@ -59,10 +59,10 @@ export const usePopoverRecipe = createUseRecipe("popover", {
 		{
 			match: { color: "light" as const, variant: "soft" as const },
 			css: {
-				background: "@color.gray-100",
+				background: "@color.gray-50",
 				color: "@color.gray-700",
 				"&:dark": {
-					background: "@color.gray-100",
+					background: "@color.gray-50",
 					color: "@color.gray-700",
 				},
 			},
@@ -70,11 +70,11 @@ export const usePopoverRecipe = createUseRecipe("popover", {
 		{
 			match: { color: "light" as const, variant: "subtle" as const },
 			css: {
-				background: "@color.gray-100",
+				background: "@color.gray-50",
 				color: "@color.gray-700",
 				borderColor: "@color.gray-200",
 				"&:dark": {
-					background: "@color.gray-100",
+					background: "@color.gray-50",
 					color: "@color.gray-700",
 					borderColor: "@color.gray-200",
 				},
@@ -137,7 +137,7 @@ export const usePopoverRecipe = createUseRecipe("popover", {
 		{
 			match: { color: "neutral" as const, variant: "soft" as const },
 			css: {
-				background: "@color.gray-100",
+				background: "@color.gray-50",
 				color: "@color.gray-700",
 				"&:dark": {
 					background: "@color.gray-800",
@@ -148,7 +148,7 @@ export const usePopoverRecipe = createUseRecipe("popover", {
 		{
 			match: { color: "neutral" as const, variant: "subtle" as const },
 			css: {
-				background: "@color.gray-100",
+				background: "@color.gray-50",
 				color: "@color.gray-700",
 				borderColor: "@color.gray-200",
 				"&:dark": {

--- a/theme/src/recipes/tooltip/useTooltipRecipe.test.ts
+++ b/theme/src/recipes/tooltip/useTooltipRecipe.test.ts
@@ -235,7 +235,7 @@ describe("useTooltipRecipe", () => {
 			expect(neutralSubtle).toEqual({
 				match: { color: "neutral", variant: "subtle" },
 				css: {
-					background: "@color.gray-100",
+					background: "@color.gray-50",
 					color: "@color.gray-700",
 					borderColor: "@color.gray-300",
 					"&:dark": {
@@ -460,7 +460,7 @@ describe("useTooltipArrowRecipe", () => {
 				css: {
 					borderTopColor: "@color.gray-300",
 					"&:after": {
-						borderTopColor: "@color.gray-100",
+						borderTopColor: "@color.gray-50",
 					},
 					"&:dark": {
 						borderTopColor: "@color.gray-600",

--- a/theme/src/recipes/tooltip/useTooltipRecipe.ts
+++ b/theme/src/recipes/tooltip/useTooltipRecipe.ts
@@ -79,10 +79,10 @@ export const useTooltipRecipe = createUseRecipe("tooltip", {
 		{
 			match: { color: "light" as const, variant: "soft" as const },
 			css: {
-				background: "@color.gray-100",
+				background: "@color.gray-50",
 				color: "@color.gray-700",
 				"&:dark": {
-					background: "@color.gray-100",
+					background: "@color.gray-50",
 					color: "@color.gray-700",
 				},
 			},
@@ -90,11 +90,11 @@ export const useTooltipRecipe = createUseRecipe("tooltip", {
 		{
 			match: { color: "light" as const, variant: "subtle" as const },
 			css: {
-				background: "@color.gray-100",
+				background: "@color.gray-50",
 				color: "@color.gray-700",
 				borderColor: "@color.gray-300",
 				"&:dark": {
-					background: "@color.gray-100",
+					background: "@color.gray-50",
 					color: "@color.gray-700",
 					borderColor: "@color.gray-300",
 				},
@@ -157,7 +157,7 @@ export const useTooltipRecipe = createUseRecipe("tooltip", {
 		{
 			match: { color: "neutral" as const, variant: "soft" as const },
 			css: {
-				background: "@color.gray-100",
+				background: "@color.gray-50",
 				color: "@color.gray-700",
 				"&:dark": {
 					background: "@color.gray-800",
@@ -168,7 +168,7 @@ export const useTooltipRecipe = createUseRecipe("tooltip", {
 		{
 			match: { color: "neutral" as const, variant: "subtle" as const },
 			css: {
-				background: "@color.gray-100",
+				background: "@color.gray-50",
 				color: "@color.gray-700",
 				borderColor: "@color.gray-300",
 				"&:dark": {
@@ -255,15 +255,15 @@ export const useTooltipArrowRecipe = createUseRecipe(
 			{
 				match: { color: "light" as const, variant: "soft" as const },
 				css: {
-					borderTopColor: "@color.gray-100",
+					borderTopColor: "@color.gray-50",
 					"&:after": {
-						borderTopColor: "@color.gray-100",
+						borderTopColor: "@color.gray-50",
 					},
 					"&:dark": {
-						borderTopColor: "@color.gray-100",
+						borderTopColor: "@color.gray-50",
 					},
 					"&:dark:after": {
-						borderTopColor: "@color.gray-100",
+						borderTopColor: "@color.gray-50",
 					},
 				},
 			},
@@ -272,13 +272,13 @@ export const useTooltipArrowRecipe = createUseRecipe(
 				css: {
 					borderTopColor: "@color.gray-300",
 					"&:after": {
-						borderTopColor: "@color.gray-100",
+						borderTopColor: "@color.gray-50",
 					},
 					"&:dark": {
 						borderTopColor: "@color.gray-300",
 					},
 					"&:dark:after": {
-						borderTopColor: "@color.gray-100",
+						borderTopColor: "@color.gray-50",
 					},
 				},
 			},
@@ -349,9 +349,9 @@ export const useTooltipArrowRecipe = createUseRecipe(
 			{
 				match: { color: "neutral" as const, variant: "soft" as const },
 				css: {
-					borderTopColor: "@color.gray-100",
+					borderTopColor: "@color.gray-50",
 					"&:after": {
-						borderTopColor: "@color.gray-100",
+						borderTopColor: "@color.gray-50",
 					},
 					"&:dark": {
 						borderTopColor: "@color.gray-800",
@@ -366,7 +366,7 @@ export const useTooltipArrowRecipe = createUseRecipe(
 				css: {
 					borderTopColor: "@color.gray-300",
 					"&:after": {
-						borderTopColor: "@color.gray-100",
+						borderTopColor: "@color.gray-50",
 					},
 					"&:dark": {
 						borderTopColor: "@color.gray-600",


### PR DESCRIPTION
## Summary

- Replaces `@color.gray-100` with `@color.gray-50` for the `soft` and `subtle` variant backgrounds across all affected recipes.
- Recipes updated: `callout`, `card`, `modal` (shared overlay builders), `popover`, `popover-arrow`, `tooltip`, and `tooltip-arrow`.
- Tests updated to match the new token value.
- Adds a patch-level changeset for `@styleframe/theme` and `styleframe`.