### PR TITLE
ci: run integration tests only on engine/tooling changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,10 +328,38 @@ jobs:
                   slug: styleframe-dev/styleframe
                   fail_ci_if_error: false
 
+    detect-changes:
+        name: Detect Changes
+        runs-on: ubuntu-latest
+        outputs:
+            run-integration: ${{ steps.check.outputs.run }}
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - name: Check for relevant changes
+              id: check
+              run: |
+                  # Always run on push to main or manual dispatch
+                  if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+                    echo "run=true" >> "$GITHUB_OUTPUT"
+                    exit 0
+                  fi
+                  # Run if engine/ or tooling/ changed
+                  CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+                  if echo "$CHANGED" | grep -qE '^(engine|tooling)/'; then
+                    echo "run=true" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "run=false" >> "$GITHUB_OUTPUT"
+                  fi
+
     integration-tests:
         name: Integration Tests
         runs-on: ubuntu-latest
-        needs: build
+        needs: [build, detect-changes]
+        if: needs.detect-changes.outputs.run-integration == 'true'
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -381,6 +409,7 @@ jobs:
                 lint,
                 typecheck,
                 unit-tests,
+                detect-changes,
                 integration-tests,
             ]
         if: always()


### PR DESCRIPTION
## Summary

- Adds a `detect-changes` job that diffs `engine/` and `tooling/` against the PR base branch
- Gates `integration-tests` on that check — skipped for PRs that don't touch these paths
- Always runs on `push` to main and `workflow_dispatch` to ensure full coverage on trunk

The integration suite (Playwright + multi-bundler) is expensive; this avoids running it for theme, docs, app, or config-only changes.