### PR TITLE
chore: add GitHub issue/PR templates, security policy, and code of conduct

### DIFF
--- a/.changeset/github-templates.md
+++ b/.changeset/github-templates.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add GitHub community templates: bug, feature, and documentation issue forms with a chooser config, a pull request template, a `SECURITY.md` policy, and a Contributor Covenant `CODE_OF_CONDUCT.md`. Repo-meta only — no package is affected, so this changeset intentionally bumps nothing.

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at alex@styleframe.dev. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,121 @@
+name: 🐞 Bug Report
+description: Report a reproducible bug or regression in Styleframe.
+title: "[Bug]: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report! A clear, minimal
+        reproduction is the single most helpful thing you can provide.
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Pre-flight checklist
+      options:
+        - label: I searched [existing issues](https://github.com/styleframe-dev/styleframe/issues) and found no duplicate.
+          required: true
+        - label: I reproduced this on the latest version of Styleframe.
+          required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise summary of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Configure styleframe.config.ts with ...
+        2. Add a *.styleframe.ts file that ...
+        3. Run the build / dev server
+        4. See error
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal reproduction
+      description: >
+        Paste a minimal `styleframe.config.ts` + `*.styleframe.ts` pair, or link a
+        minimal repo / StackBlitz. Reports without a reproduction may be closed.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen instead?
+    validations:
+      required: true
+  - type: dropdown
+    id: package
+    attributes:
+      label: Affected package
+      options:
+        - "Not sure / multiple"
+        - styleframe
+        - "@styleframe/core"
+        - "@styleframe/theme"
+        - "@styleframe/plugin"
+        - "@styleframe/cli"
+        - "@styleframe/transpiler"
+        - "@styleframe/loader"
+        - "@styleframe/runtime"
+        - "@styleframe/scanner"
+        - "@styleframe/figma"
+        - "@styleframe/dtcg"
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Styleframe version
+      description: Output of `npm ls styleframe` or the version in your package.json.
+      placeholder: 1.0.0
+    validations:
+      required: true
+  - type: dropdown
+    id: bundler
+    attributes:
+      label: Bundler / framework
+      options:
+        - Vite
+        - Nuxt
+        - Webpack
+        - Rollup
+        - Rspack
+        - esbuild
+        - Astro
+        - Farm
+        - Bun
+        - Not applicable
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: "Run `npx envinfo --system --binaries --npmPackages '{styleframe,@styleframe/*}'` and paste the output."
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or error output
+      description: Paste any console output, stack traces, or build errors.
+      render: shell
+    validations:
+      required: false
+  - type: checkboxes
+    id: coc
+    attributes:
+      label: Code of Conduct
+      options:
+        - label: I agree to follow this project's [Code of Conduct](https://github.com/styleframe-dev/styleframe/blob/main/.github/CODE_OF_CONDUCT.md).
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Discord Community
+    url: https://discord.gg/KCVwuGz44M
+    about: Ask questions and chat with the community in real time.
+  - name: 📖 Documentation
+    url: https://styleframe.dev/docs
+    about: Browse the docs first — your answer may already be there.
+  - name: 💡 GitHub Discussions
+    url: https://github.com/styleframe-dev/styleframe/discussions
+    about: Share ideas or ask open-ended questions.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,51 @@
+name: 📖 Documentation
+description: Report an issue or suggest an improvement to the docs.
+title: "[Docs]: "
+labels: ["documentation", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve the documentation! Point us at the page and tell
+        us what's wrong or missing.
+  - type: input
+    id: page
+    attributes:
+      label: Page URL
+      description: Link to the affected documentation page, if applicable.
+      placeholder: https://styleframe.dev/docs/...
+    validations:
+      required: false
+  - type: dropdown
+    id: kind
+    attributes:
+      label: Issue type
+      options:
+        - Incorrect or outdated
+        - Missing content
+        - Unclear or confusing
+        - Typo or formatting
+        - Example doesn't work
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What is wrong, missing, or confusing?
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested improvement
+      description: How would you word or structure it instead?
+    validations:
+      required: false
+  - type: checkboxes
+    id: coc
+    attributes:
+      label: Code of Conduct
+      options:
+        - label: I agree to follow this project's [Code of Conduct](https://github.com/styleframe-dev/styleframe/blob/main/.github/CODE_OF_CONDUCT.md).
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,78 @@
+name: ✨ Feature Request
+description: Suggest an idea or enhancement for Styleframe.
+title: "[Feature]: "
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for sharing an idea! Please make a clear case for the feature — what
+        problem it solves and why it belongs in Styleframe.
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Pre-flight checklist
+      options:
+        - label: I searched [existing issues](https://github.com/styleframe-dev/styleframe/issues) and [discussions](https://github.com/styleframe-dev/styleframe/discussions) and found no duplicate.
+          required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What problem does this solve? What are you unable to do today?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe the feature and, if you can, sketch the API or usage.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches or workarounds you have tried or thought about.
+    validations:
+      required: false
+  - type: dropdown
+    id: package
+    attributes:
+      label: Affected area
+      options:
+        - "New package / not sure"
+        - styleframe
+        - "@styleframe/core"
+        - "@styleframe/theme"
+        - "@styleframe/plugin"
+        - "@styleframe/cli"
+        - "@styleframe/transpiler"
+        - "@styleframe/loader"
+        - "@styleframe/runtime"
+        - "@styleframe/scanner"
+        - "@styleframe/figma"
+        - "@styleframe/dtcg"
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Links, screenshots, prior art, or examples from other tools.
+    validations:
+      required: false
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      options:
+        - label: I am willing to open a pull request for this feature.
+          required: false
+  - type: checkboxes
+    id: coc
+    attributes:
+      label: Code of Conduct
+      options:
+        - label: I agree to follow this project's [Code of Conduct](https://github.com/styleframe-dev/styleframe/blob/main/.github/CODE_OF_CONDUCT.md).
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,38 @@
+<!--
+Thanks for contributing to Styleframe! Please read CONTRIBUTING.md first:
+https://github.com/styleframe-dev/styleframe/blob/main/CONTRIBUTING.md
+
+Please ask first before starting on any significant PR (new features, refactors,
+new engine capabilities) so your effort isn't wasted on something we can't merge.
+-->
+
+## Description
+
+<!-- What does this PR change, and why? -->
+
+## Related issue
+
+<!-- e.g. "Closes #123" or "Relates to #123". -->
+
+## Type of change
+
+- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
+- [ ] ✨ New feature (non-breaking change that adds functionality)
+- [ ] 💥 Breaking change (fix or feature that changes existing behavior)
+- [ ] 📖 Documentation
+- [ ] ♻️ Refactor / internal (no functional change)
+- [ ] 🔧 Build / tooling / CI
+
+## Checklist
+
+- [ ] My commits follow Conventional Commits with a package scope (e.g. `feat(theme): …`)
+- [ ] I ran `pnpm build:nodocs && pnpm lint && pnpm typecheck && pnpm test` and everything passes
+- [ ] I added a changeset (`pnpm changeset`) for changes to publishable packages, or this change only touches docs/storybook/app/playground/tests
+- [ ] I added or updated tests where relevant
+- [ ] I updated documentation where relevant
+- [ ] I did **not** edit generated files (`dist/`, `.styleframe/`)
+- [ ] My PR targets `main` and stays focused in scope
+
+## Notes / screenshots
+
+<!-- Optional: anything reviewers should know, before/after screenshots, etc. -->

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,41 @@
+# Security Policy
+
+We take the security of Styleframe and its users seriously. Thank you for helping
+keep the project and its community safe.
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.x     | :white_check_mark: |
+| < 1.0   | :x:                |
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.**
+
+Instead, report them privately using one of the following:
+
+1. **GitHub Security Advisories (preferred)** — open the repository's
+   [**Security** tab](https://github.com/styleframe-dev/styleframe/security/advisories/new)
+   and choose **Report a vulnerability**. This keeps the report private until a fix
+   is released.
+2. **Email** — write to **alex@styleframe.dev** if you cannot use private advisories.
+
+Please include as much of the following as you can:
+
+- The affected package(s) and version(s)
+- A description of the vulnerability and its potential impact
+- Steps to reproduce, or a minimal proof of concept
+- Any suggested mitigation, if you have one
+
+## What to Expect
+
+- We aim to acknowledge your report within **72 hours**.
+- We will keep you informed as we investigate and work on a fix.
+- We follow **coordinated disclosure**: please give us a reasonable window to release
+  a fix before any public disclosure, and we will credit you in the advisory unless
+  you prefer to remain anonymous.
+
+Thank you for contributing to the security of Styleframe.


### PR DESCRIPTION
## Description

Adds the full GitHub community-health and template suite under `.github/`: bug, feature, and documentation issue forms (YAML) with a chooser config, a pull request template, a `SECURITY.md` policy, and a Contributor Covenant `CODE_OF_CONDUCT.md`. The templates are wired to the project's real conventions — published packages and supported bundlers as dropdowns, the exact pre-PR command, the changeset rule, and the "don't edit generated files" rule from `CONTRIBUTING.md`. The repository previously had no issue/PR templates or security/conduct policies.

## Related issue

N/A

## Type of change

- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behavior)
- [ ] 📖 Documentation
- [ ] ♻️ Refactor / internal (no functional change)
- [x] 🔧 Build / tooling / CI

## Checklist

- [x] My commits follow Conventional Commits with a package scope (e.g. `feat(theme): …`)
- [ ] I ran `pnpm build:nodocs && pnpm lint && pnpm typecheck && pnpm test` and everything passes
- [x] I added a changeset (`pnpm changeset`) for changes to publishable packages, or this change only touches docs/storybook/app/playground/tests
- [ ] I added or updated tests where relevant
- [ ] I updated documentation where relevant
- [x] I did **not** edit generated files (`dist/`, `.styleframe/`)
- [x] My PR targets `main` and stays focused in scope

## Notes / screenshots

- Repo-meta only — no published package changes, so the included changeset is intentionally **empty** (bumps nothing).
- Build/lint/typecheck/test are N/A for `.github/`-only files; the four YAML issue forms were validated with `js-yaml` (parse + unique-id/dropdown/`required` checks).
- Two repo settings to flip for full effect: the `config.yml` **GitHub Discussions** link needs Discussions enabled, and the **SECURITY.md** private-reporting path needs *Settings → Code security → Private vulnerability reporting* turned on (the email fallback works regardless).
- Out of scope but noticed: there is **no `LICENSE` file** at the repo root, yet `CONTRIBUTING.md` and the README MIT badge link to one.
