### PR TITLE
fix(docs): fix broken internal links across 109 doc pages

### DIFF
--- a/apps/docs/content/docs/01.getting-started/03.guides/01.create-design-system-in-under-15-minutes.md
+++ b/apps/docs/content/docs/01.getting-started/03.guides/01.create-design-system-in-under-15-minutes.md
@@ -141,7 +141,7 @@ useDesignTokensPreset(s, {
 
 Pass `meta: { merge: false }` if you want your custom record to replace the default palette entirely.
 
-[Learn more about color generation options &rarr;](/docs/design-tokens/preset#color-generation-options)
+[Learn more about color generation options &rarr;](/docs/theme/design-tokens/preset#color-generation-options)
 ::
 
 ::note
@@ -177,7 +177,7 @@ useDesignTokensPreset(s, {
 });
 ```
 
-[Learn more about fluid typography &rarr;](/docs/design-tokens/preset#fluid-typography)
+[Learn more about fluid typography &rarr;](/docs/theme/design-tokens/preset#fluid-typography)
 
 ## Step 3: Polish the Globals (1 minute)
 
@@ -343,7 +343,7 @@ panel: true
 ::
 
 ::note
-**Compound variants do the heavy lifting.** Each color-variant pairing has its own background, text, and border colors plus hover/focus/active overrides. You write `<Button color="success" variant="soft" />`, and the recipe resolves it to the right CSS class. [Learn more about the Button recipe &rarr;](/docs/components/actions/button)
+**Compound variants do the heavy lifting.** Each color-variant pairing has its own background, text, and border colors plus hover/focus/active overrides. You write `<Button color="success" variant="soft" />`, and the recipe resolves it to the right CSS class. [Learn more about the Button recipe &rarr;](/docs/theme/components/button)
 ::
 
 ::tip
@@ -459,7 +459,7 @@ panel: true
 ::
 
 ::note
-**Twenty-one more recipes are ready to drop in.** Badge, Callout, Chip, Modal, Popover, Tooltip, Input, Spinner, Skeleton, Placeholder, Pagination, Breadcrumb, Nav, Dropdown, Hamburger Menu, Page Hero, Progress, Media, Field Group, and the Card sub-parts. [Browse the full component catalog &rarr;](/docs/components)
+**Twenty-one more recipes are ready to drop in.** Badge, Callout, Chip, Modal, Popover, Tooltip, Input, Spinner, Skeleton, Placeholder, Pagination, Breadcrumb, Nav, Dropdown, Hamburger Menu, Page Hero, Progress, Media, Field Group, and the Card sub-parts. [Browse the full component catalog &rarr;](/docs/theme/components)
 ::
 
 ## Step 6: Add Dark Mode (2 minutes)
@@ -546,7 +546,7 @@ useDesignTokensPreset(s, {
 });
 ```
 
-[Learn more about themes &rarr;](/docs/design-tokens/preset#themes)
+[Learn more about themes &rarr;](/docs/theme/design-tokens/preset#themes)
 
 ## Step 7: Style on the Fly with Utilities & Modifiers (1 minute)
 
@@ -716,8 +716,8 @@ With Styleframe presets and recipes you get:
 
 ## Next Steps
 
-- **Customize deeper:** [Design Tokens Preset API](/docs/design-tokens/preset) covers every option, every default, every override.
-- **Browse components:** the [Components catalog](/docs/components) lists Button, Card, Modal, Tooltip, Popover, Input, and 17 more, each with its own variant reference.
+- **Customize deeper:** [Design Tokens Preset API](/docs/theme/design-tokens/preset) covers every option, every default, every override.
+- **Browse components:** the [Components catalog](/docs/theme/components) lists Button, Card, Modal, Tooltip, Popover, Input, and 17 more, each with its own variant reference.
 - **Implement a theme switcher:** the [Theme Switcher Guide](/docs/getting-started/guides/theme-switcher) covers system preference detection, persistence, and FOUC prevention.
 - **Author your own recipes:** the [Recipes API](/docs/api/recipes) lets you build type-safe variant systems for your custom components.
 - **Master utilities:** [Utilities API](/docs/api/utilities) and [Utility Modifiers API](/docs/api/utility-modifiers).
@@ -768,7 +768,7 @@ useDesignTokensPreset(s, {
 });
 ```
 
-For a hybrid approach (static everywhere, fluid only on display headings), see the [Customizing Fluid Typography example](/docs/design-tokens/preset#customizing-fluid-typography).
+For a hybrid approach (static everywhere, fluid only on display headings), see the [Customizing Fluid Typography example](/docs/theme/design-tokens/preset#customizing-fluid-typography).
 :::
 
 :::accordion-item{label="How do I disable a sanitize.css category?" icon="i-lucide-circle-help"}
@@ -817,7 +817,7 @@ const button = useButtonRecipe(s, {
 });
 ```
 
-Each component's reference page documents its full variant matrix and customization API. [Browse the catalog &rarr;](/docs/components)
+Each component's reference page documents its full variant matrix and customization API. [Browse the catalog &rarr;](/docs/theme/components)
 :::
 
 ::

--- a/apps/docs/content/docs/02.api/01.instance.md
+++ b/apps/docs/content/docs/02.api/01.instance.md
@@ -305,7 +305,7 @@ interface UtilitySelectorOptions {
 }
 ```
 
-By default, utility class names follow the `_modifiers:name:value` format (e.g., `_hover:margin:sm`). Provide a custom function to change how class names are generated. The transpiler handles CSS escaping internally. If you use the [scanner](/docs/tooling/scanner#custom-utility-syntax), set the same function in both places.
+By default, utility class names follow the `_modifiers:name:value` format (e.g., `_hover:margin:sm`). Provide a custom function to change how class names are generated. The transpiler handles CSS escaping internally. If you use the [scanner](/docs/getting-started/tooling/scanner#custom-utility-syntax), set the same function in both places.
 ::
 ::
 

--- a/apps/docs/content/docs/03.design-tokens/00.index.md
+++ b/apps/docs/content/docs/03.design-tokens/00.index.md
@@ -89,7 +89,7 @@ const {
 });
 ```
 
-[Learn more about Border Radiuses →](/docs/design-tokens/border-radiuses)
+[Learn more about Border Radiuses →](/docs/theme/design-tokens/border-radiuses)
 
 
 ### Borders
@@ -122,7 +122,7 @@ const { borderColor, borderColorPrimary } = useBorderColorDesignTokens(s, {
 } as const);
 ```
 
-[Learn more about Borders →](/docs/design-tokens/borders)
+[Learn more about Borders →](/docs/theme/design-tokens/borders)
 
 
 ### Box Shadows
@@ -147,7 +147,7 @@ const {
 } = useBoxShadowDesignTokens(s);
 ```
 
-[Learn more about Box Shadows →](/docs/design-tokens/box-shadows)
+[Learn more about Box Shadows →](/docs/theme/design-tokens/box-shadows)
 
 
 ### Breakpoints
@@ -179,7 +179,7 @@ media(`(min-width: ${breakpointMd.value}px)`, ({ selector }) => {
 });
 ```
 
-[Learn more about Breakpoints →](/docs/design-tokens/breakpoints)
+[Learn more about Breakpoints →](/docs/theme/design-tokens/breakpoints)
 
 
 
@@ -210,7 +210,7 @@ const {
 } = useColorLevelDesignTokens(s, colorPrimary);
 ```
 
-[Learn more about Colors →](/docs/design-tokens/colors)
+[Learn more about Colors →](/docs/theme/design-tokens/colors)
 
 
 ### Easing
@@ -229,7 +229,7 @@ const s = styleframe();
 const { easing, easingSpring, easingBounce } = useEasingDesignTokens(s);
 ```
 
-[Learn more about Easing →](/docs/design-tokens/easing)
+[Learn more about Easing →](/docs/theme/design-tokens/easing)
 
 
 ### Fluid Design
@@ -262,7 +262,7 @@ const { fontSize, fontSizeSm, fontSizeMd, fontSizeLg } = useFontSizeDesignTokens
 });
 ```
 
-[Learn more about Fluid Design →](/docs/design-tokens/fluid-design)
+[Learn more about Fluid Design →](/docs/theme/design-tokens/fluid-design)
 
 
 
@@ -295,7 +295,7 @@ const { fontSizeSm, fontSizeMd, fontSizeLg } = useMultiplierDesignTokens(s, font
 });
 ```
 
-[Learn more about Scales →](/docs/design-tokens/scales)
+[Learn more about Scales →](/docs/theme/design-tokens/scales)
 
 
 ### Spacing
@@ -314,7 +314,7 @@ const s = styleframe();
 const { spacing } = useSpacingDesignTokens(s, { default: '1rem' } as const);
 ```
 
-[Learn more about Spacing →](/docs/design-tokens/spacing)
+[Learn more about Spacing →](/docs/theme/design-tokens/spacing)
 
 
 ### Typography
@@ -346,7 +346,7 @@ const { fontWeightNormal, fontWeightBold } = useFontWeightDesignTokens(s);
 const { lineHeightTight, lineHeightNormal } = useLineHeightDesignTokens(s);
 ```
 
-[Learn more about Typography →](/docs/design-tokens/typography)
+[Learn more about Typography →](/docs/theme/design-tokens/typography)
 
 
 ### Z-Index
@@ -370,7 +370,7 @@ const {
 } = useZIndexDesignTokens(s);
 ```
 
-[Learn more about Z-Index →](/docs/design-tokens/z-index)
+[Learn more about Z-Index →](/docs/theme/design-tokens/z-index)
 
 ## Design Token Reference
 
@@ -403,9 +403,9 @@ const {
 
 Ready to build your design system? Start with these guides:
 
-- **New to design tokens?** Begin with [Colors](/docs/design-tokens/colors) and [Spacing](/docs/design-tokens/spacing)
-- **Building a type system?** Check out [Typography](/docs/design-tokens/typography) and [Scales](/docs/design-tokens/scales)
-- **Creating visual hierarchy?** Explore [Box Shadows](/docs/design-tokens/box-shadows), [Z-Index](/docs/design-tokens/z-index), and [Borders](/docs/design-tokens/borders)
-- **Working on responsive design?** Learn about [Breakpoints](/docs/design-tokens/breakpoints)
+- **New to design tokens?** Begin with [Colors](/docs/theme/design-tokens/colors) and [Spacing](/docs/theme/design-tokens/spacing)
+- **Building a type system?** Check out [Typography](/docs/theme/design-tokens/typography) and [Scales](/docs/theme/design-tokens/scales)
+- **Creating visual hierarchy?** Explore [Box Shadows](/docs/theme/design-tokens/box-shadows), [Z-Index](/docs/theme/design-tokens/z-index), and [Borders](/docs/theme/design-tokens/borders)
+- **Working on responsive design?** Learn about [Breakpoints](/docs/theme/design-tokens/breakpoints)
 
 Each design token composable is designed to work seamlessly with the others, giving you complete flexibility to build exactly the design system your project needs.

--- a/apps/docs/content/docs/03.design-tokens/01.preset.md
+++ b/apps/docs/content/docs/03.design-tokens/01.preset.md
@@ -94,29 +94,29 @@ Each domain can be configured as:
 
 | Option | Composable | Type | Description |
 |--------|------------|------|-------------|
-| [`spacing`](/docs/design-tokens/spacing) | `useSpacingDesignTokens` | `false \| Record<string, TokenValue>` | Spacing tokens (padding, margin, gap) |
-| [`borderWidth`](/docs/design-tokens/borders) | `useBorderWidthDesignTokens` | `false \| Record<string, TokenValue>` | Border width tokens |
-| [`borderRadius`](/docs/design-tokens/border-radiuses) | `useBorderRadiusDesignTokens` | `false \| Record<string, TokenValue>` | Border radius tokens |
-| [`borderStyle`](/docs/design-tokens/borders) | `useBorderStyleDesignTokens` | `false \| Record<string, TokenValue>` | Border style tokens |
-| [`borderColor`](/docs/design-tokens/borders) | `useBorderColorDesignTokens` | `false \| Record<string, TokenValue>` | Border color tokens |
-| [`boxShadow`](/docs/design-tokens/box-shadows) | `useBoxShadowDesignTokens` | `false \| Record<string, TokenValue>` | Box shadow elevation tokens |
-| [`zIndex`](/docs/design-tokens/z-index) | `useZIndexDesignTokens` | `false \| Record<string, TokenValue>` | Z-index stacking order tokens |
-| [`colors`](/docs/design-tokens/colors) | `useColorDesignTokens` | `false \| Record<string, string>` | Semantic color tokens |
+| [`spacing`](/docs/theme/design-tokens/spacing) | `useSpacingDesignTokens` | `false \| Record<string, TokenValue>` | Spacing tokens (padding, margin, gap) |
+| [`borderWidth`](/docs/theme/design-tokens/borders) | `useBorderWidthDesignTokens` | `false \| Record<string, TokenValue>` | Border width tokens |
+| [`borderRadius`](/docs/theme/design-tokens/border-radiuses) | `useBorderRadiusDesignTokens` | `false \| Record<string, TokenValue>` | Border radius tokens |
+| [`borderStyle`](/docs/theme/design-tokens/borders) | `useBorderStyleDesignTokens` | `false \| Record<string, TokenValue>` | Border style tokens |
+| [`borderColor`](/docs/theme/design-tokens/borders) | `useBorderColorDesignTokens` | `false \| Record<string, TokenValue>` | Border color tokens |
+| [`boxShadow`](/docs/theme/design-tokens/box-shadows) | `useBoxShadowDesignTokens` | `false \| Record<string, TokenValue>` | Box shadow elevation tokens |
+| [`zIndex`](/docs/theme/design-tokens/z-index) | `useZIndexDesignTokens` | `false \| Record<string, TokenValue>` | Z-index stacking order tokens |
+| [`colors`](/docs/theme/design-tokens/colors) | `useColorDesignTokens` | `false \| Record<string, string>` | Semantic color tokens |
 | `meta.colors` | — | `ColorsMetaConfig` | Color generation options |
-| [`fontFamily`](/docs/design-tokens/typography) | `useFontFamilyDesignTokens` | `false \| Record<string, TokenValue>` | Font family tokens |
-| [`fontSize`](/docs/design-tokens/typography) | `useFontSizeDesignTokens` | `false \| Record<string, TokenValue \| [min, max]>` | Font size tokens. When `fluidFontSize` is enabled (default), overrides the fluid defaults for provided keys; tuple values `[min, max]` produce `calc()` fluid expressions (pass `fluidFontSize: false` to use purely static values) |
-| [`fontStyle`](/docs/design-tokens/typography) | `useFontStyleDesignTokens` | `false \| Record<string, TokenValue>` | Font style tokens |
-| [`fontWeight`](/docs/design-tokens/typography) | `useFontWeightDesignTokens` | `false \| Record<string, TokenValue>` | Font weight tokens |
-| [`lineHeight`](/docs/design-tokens/typography) | `useLineHeightDesignTokens` | `false \| Record<string, TokenValue>` | Line height tokens |
-| [`letterSpacing`](/docs/design-tokens/typography) | `useLetterSpacingDesignTokens` | `false \| Record<string, TokenValue>` | Letter spacing tokens |
-| [`scale`](/docs/design-tokens/scales) | `useScaleDesignTokens` | `false \| Record<string, TokenValue>` | Modular scale ratios (must include `default` key referencing `scale` for scalePowers) |
-| [`scalePowers`](/docs/design-tokens/scales) | `useScalePowersDesignTokens` | `readonly number[]` | Scale power levels |
-| [`breakpoint`](/docs/design-tokens/breakpoints) | `useBreakpointDesignTokens` | `false \| Record<string, number>` | Responsive breakpoints |
-| [`easing`](/docs/design-tokens/easing) | `useEasingDesignTokens` | `false \| Record<string, TokenValue>` | Animation easing functions |
-| [`duration`](/docs/design-tokens/duration) | `useDurationDesignTokens` | `false \| Record<string, TokenValue>` | Animation and transition duration tokens |
-| [`fluidViewport`](/docs/design-tokens/fluid-design/viewport) | `useFluidViewportDesignTokens` | `false \| true \| { minWidth?, maxWidth? }` | Fluid viewport range powering `fluid.breakpoint` (see [Fluid Typography](#fluid-typography)) |
-| [`fluidFontSize`](/docs/design-tokens/fluid-design/typography) | — | `false \| true` | Viewport-responsive font-size scale. **Enabled by default**; depends on `scale` and `fluidViewport`. Pass `false` to fall back to static `fontSize` (see [Fluid Typography](#fluid-typography)) |
-| [`fluidScale`](/docs/design-tokens/fluid-design/typography) | — | `{ min?, max? }` | Min/max scale ratios driving the default fluid font sizes (consumed when `fluidFontSize` is not disabled) |
+| [`fontFamily`](/docs/theme/design-tokens/typography) | `useFontFamilyDesignTokens` | `false \| Record<string, TokenValue>` | Font family tokens |
+| [`fontSize`](/docs/theme/design-tokens/typography) | `useFontSizeDesignTokens` | `false \| Record<string, TokenValue \| [min, max]>` | Font size tokens. When `fluidFontSize` is enabled (default), overrides the fluid defaults for provided keys; tuple values `[min, max]` produce `calc()` fluid expressions (pass `fluidFontSize: false` to use purely static values) |
+| [`fontStyle`](/docs/theme/design-tokens/typography) | `useFontStyleDesignTokens` | `false \| Record<string, TokenValue>` | Font style tokens |
+| [`fontWeight`](/docs/theme/design-tokens/typography) | `useFontWeightDesignTokens` | `false \| Record<string, TokenValue>` | Font weight tokens |
+| [`lineHeight`](/docs/theme/design-tokens/typography) | `useLineHeightDesignTokens` | `false \| Record<string, TokenValue>` | Line height tokens |
+| [`letterSpacing`](/docs/theme/design-tokens/typography) | `useLetterSpacingDesignTokens` | `false \| Record<string, TokenValue>` | Letter spacing tokens |
+| [`scale`](/docs/theme/design-tokens/scales) | `useScaleDesignTokens` | `false \| Record<string, TokenValue>` | Modular scale ratios (must include `default` key referencing `scale` for scalePowers) |
+| [`scalePowers`](/docs/theme/design-tokens/scales) | `useScalePowersDesignTokens` | `readonly number[]` | Scale power levels |
+| [`breakpoint`](/docs/theme/design-tokens/breakpoints) | `useBreakpointDesignTokens` | `false \| Record<string, number>` | Responsive breakpoints |
+| [`easing`](/docs/theme/design-tokens/easing) | `useEasingDesignTokens` | `false \| Record<string, TokenValue>` | Animation easing functions |
+| [`duration`](/docs/theme/design-tokens/duration) | `useDurationDesignTokens` | `false \| Record<string, TokenValue>` | Animation and transition duration tokens |
+| [`fluidViewport`](/docs/theme/design-tokens/fluid-design/viewport) | `useFluidViewportDesignTokens` | `false \| true \| { minWidth?, maxWidth? }` | Fluid viewport range powering `fluid.breakpoint` (see [Fluid Typography](#fluid-typography)) |
+| [`fluidFontSize`](/docs/theme/design-tokens/fluid-design/typography) | — | `false \| true` | Viewport-responsive font-size scale. **Enabled by default**; depends on `scale` and `fluidViewport`. Pass `false` to fall back to static `fontSize` (see [Fluid Typography](#fluid-typography)) |
+| [`fluidScale`](/docs/theme/design-tokens/fluid-design/typography) | — | `{ min?, max? }` | Min/max scale ratios driving the default fluid font sizes (consumed when `fluidFontSize` is not disabled) |
 | `themes` | — | `Record<string, ThemeTokenOverrides>` | Per-theme token overrides (see [Themes](#themes)) |
 
 ## Default Values

--- a/apps/docs/content/docs/03.design-tokens/02.border-radiuses.md
+++ b/apps/docs/content/docs/03.design-tokens/02.border-radiuses.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Design Tokens Preset:** `useBorderRadiusDesignTokens` is included in the [Design Tokens Preset](/docs/design-tokens/preset) (`useDesignTokensPreset`) and you can configure it through the preset's `borderRadius` option. For most projects, applying it via the preset is the recommended approach.
+**Part of the Design Tokens Preset:** `useBorderRadiusDesignTokens` is included in the [Design Tokens Preset](/docs/theme/design-tokens/preset) (`useDesignTokensPreset`) and you can configure it through the preset's `borderRadius` option. For most projects, applying it via the preset is the recommended approach.
 ::
 
 ## Overview
@@ -150,7 +150,7 @@ export default s;
 
 The `useMultiplierDesignTokens()` function multiplies your base border radius by the scale powers, creating a harmonious progression of corner radius values. This ensures consistent proportional relationships throughout your design system.
 
-[Read more about design scales](/docs/design-tokens/scales) and take advantage of the flexibility they offer.
+[Read more about design scales](/docs/theme/design-tokens/scales) and take advantage of the flexibility they offer.
 
 ::tip
 

--- a/apps/docs/content/docs/03.design-tokens/03.borders.md
+++ b/apps/docs/content/docs/03.design-tokens/03.borders.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Design Tokens Preset:** `useBorderWidthDesignTokens`, `useBorderStyleDesignTokens`, and `useBorderColorDesignTokens` are included in the [Design Tokens Preset](/docs/design-tokens/preset) (`useDesignTokensPreset`) and you can configure them through the preset's `borderWidth`, `borderStyle`, and `borderColor` options. For most projects, applying them via the preset is the recommended approach.
+**Part of the Design Tokens Preset:** `useBorderWidthDesignTokens`, `useBorderStyleDesignTokens`, and `useBorderColorDesignTokens` are included in the [Design Tokens Preset](/docs/theme/design-tokens/preset) (`useDesignTokensPreset`) and you can configure them through the preset's `borderWidth`, `borderStyle`, and `borderColor` options. For most projects, applying them via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/03.design-tokens/04.box-shadows.md
+++ b/apps/docs/content/docs/03.design-tokens/04.box-shadows.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Design Tokens Preset:** `useBoxShadowDesignTokens` is included in the [Design Tokens Preset](/docs/design-tokens/preset) (`useDesignTokensPreset`) and you can configure it through the preset's `boxShadow` option. For most projects, applying it via the preset is the recommended approach.
+**Part of the Design Tokens Preset:** `useBoxShadowDesignTokens` is included in the [Design Tokens Preset](/docs/theme/design-tokens/preset) (`useDesignTokensPreset`) and you can configure it through the preset's `boxShadow` option. For most projects, applying it via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/03.design-tokens/05.breakpoints.md
+++ b/apps/docs/content/docs/03.design-tokens/05.breakpoints.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Design Tokens Preset:** `useBreakpointDesignTokens` is included in the [Design Tokens Preset](/docs/design-tokens/preset) (`useDesignTokensPreset`) and you can configure it through the preset's `breakpoint` option. For most projects, applying it via the preset is the recommended approach.
+**Part of the Design Tokens Preset:** `useBreakpointDesignTokens` is included in the [Design Tokens Preset](/docs/theme/design-tokens/preset) (`useDesignTokensPreset`) and you can configure it through the preset's `breakpoint` option. For most projects, applying it via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/03.design-tokens/06.colors.md
+++ b/apps/docs/content/docs/03.design-tokens/06.colors.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Design Tokens Preset:** `useColorDesignTokens` is included in the [Design Tokens Preset](/docs/design-tokens/preset) (`useDesignTokensPreset`) and you can configure it through the preset's `colors` option (color level, shade, and tint variations are generated automatically). For most projects, applying it via the preset is the recommended approach.
+**Part of the Design Tokens Preset:** `useColorDesignTokens` is included in the [Design Tokens Preset](/docs/theme/design-tokens/preset) (`useDesignTokensPreset`) and you can configure it through the preset's `colors` option (color level, shade, and tint variations are generated automatically). For most projects, applying it via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/03.design-tokens/07.duration.md
+++ b/apps/docs/content/docs/03.design-tokens/07.duration.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Design Tokens Preset:** `useDurationDesignTokens` is included in the [Design Tokens Preset](/docs/design-tokens/preset) (`useDesignTokensPreset`) and you can configure it through the preset's `duration` option. For most projects, applying it via the preset is the recommended approach.
+**Part of the Design Tokens Preset:** `useDurationDesignTokens` is included in the [Design Tokens Preset](/docs/theme/design-tokens/preset) (`useDesignTokensPreset`) and you can configure it through the preset's `duration` option. For most projects, applying it via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/03.design-tokens/08.easing.md
+++ b/apps/docs/content/docs/03.design-tokens/08.easing.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Design Tokens Preset:** `useEasingDesignTokens` is included in the [Design Tokens Preset](/docs/design-tokens/preset) (`useDesignTokensPreset`) and you can configure it through the preset's `easing` option. For most projects, applying it via the preset is the recommended approach.
+**Part of the Design Tokens Preset:** `useEasingDesignTokens` is included in the [Design Tokens Preset](/docs/theme/design-tokens/preset) (`useDesignTokensPreset`) and you can configure it through the preset's `easing` option. For most projects, applying it via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/03.design-tokens/09.fluid-design/01.index.md
+++ b/apps/docs/content/docs/03.design-tokens/09.fluid-design/01.index.md
@@ -6,7 +6,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Design Tokens Preset:** Fluid responsive tokens are enabled by default in the [Design Tokens Preset](/docs/design-tokens/preset) (`useDesignTokensPreset`) and you can configure them through the preset's `fluidViewport`, `fluidFontSize`, and `fluidScale` options. For most projects, applying them via the preset is the recommended approach.
+**Part of the Design Tokens Preset:** Fluid responsive tokens are enabled by default in the [Design Tokens Preset](/docs/theme/design-tokens/preset) (`useDesignTokensPreset`) and you can configure them through the preset's `fluidViewport`, `fluidFontSize`, and `fluidScale` options. For most projects, applying them via the preset is the recommended approach.
 ::
 
 Fluid responsive design is a modern approach to creating layouts and typography that scale seamlessly across all screen sizes. Instead of jumping between fixed values at breakpoints, fluid design uses CSS calculation functions with viewport-relative units to create smooth, continuous transitions that adapt perfectly to any viewport width.
@@ -104,7 +104,7 @@ useFluidViewportDesignTokens(s, {
 });
 ```
 
-[Learn more about the Fluid Viewport →](/docs/design-tokens/fluid-design/viewport)
+[Learn more about the Fluid Viewport →](/docs/theme/design-tokens/fluid-design/viewport)
 
 ### Clamp Function
 
@@ -129,7 +129,7 @@ const { spacingLg } = useSpacingDesignTokens(s, {
 });
 ```
 
-[Learn more about Clamp Functions →](/docs/design-tokens/fluid-design/viewport)
+[Learn more about Clamp Functions →](/docs/theme/design-tokens/fluid-design/viewport)
 
 ### Fluid Typography
 
@@ -157,7 +157,7 @@ const { fontSize, fontSizeSm, fontSizeMd, fontSizeLg } = useFontSizeDesignTokens
 });
 ```
 
-[Learn more about Fluid Typography →](/docs/design-tokens/fluid-design/typography)
+[Learn more about Fluid Typography →](/docs/theme/design-tokens/fluid-design/typography)
 
 ## Fluid Design Reference
 
@@ -181,10 +181,10 @@ const { fontSize, fontSizeSm, fontSizeMd, fontSizeLg } = useFontSizeDesignTokens
 
 Ready to implement fluid design? Start with these guides:
 
-- **New to fluid design?** Begin with [Clamp Function](/docs/design-tokens/fluid-design/viewport) to understand the foundation
-- **Building fluid typography?** Check out [Fluid Typography](/docs/design-tokens/fluid-design/typography) for complete type systems
-- **Want mathematical consistency?** Learn about [Scales](/docs/design-tokens/scales) for harmonious proportions
-- **Combining with fixed tokens?** Explore [Typography](/docs/design-tokens/typography) for hybrid approaches
+- **New to fluid design?** Begin with [Clamp Function](/docs/theme/design-tokens/fluid-design/viewport) to understand the foundation
+- **Building fluid typography?** Check out [Fluid Typography](/docs/theme/design-tokens/fluid-design/typography) for complete type systems
+- **Want mathematical consistency?** Learn about [Scales](/docs/theme/design-tokens/scales) for harmonious proportions
+- **Combining with fixed tokens?** Explore [Typography](/docs/theme/design-tokens/typography) for hybrid approaches
 
 ## Resources
 

--- a/apps/docs/content/docs/03.design-tokens/09.fluid-design/02.viewport.md
+++ b/apps/docs/content/docs/03.design-tokens/09.fluid-design/02.viewport.md
@@ -6,7 +6,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Design Tokens Preset:** `useFluidViewportDesignTokens` is enabled by default in the [Design Tokens Preset](/docs/design-tokens/preset) (`useDesignTokensPreset`) and you can configure it through the preset's `fluidViewport` option. For most projects, applying it via the preset is the recommended approach.
+**Part of the Design Tokens Preset:** `useFluidViewportDesignTokens` is enabled by default in the [Design Tokens Preset](/docs/theme/design-tokens/preset) (`useDesignTokensPreset`) and you can configure it through the preset's `fluidViewport` option. For most projects, applying it via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/03.design-tokens/09.fluid-design/03.typography.md
+++ b/apps/docs/content/docs/03.design-tokens/09.fluid-design/03.typography.md
@@ -6,7 +6,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Design Tokens Preset:** Fluid font sizing is enabled by default in the [Design Tokens Preset](/docs/design-tokens/preset) (`useDesignTokensPreset`) and you can configure it through the preset's `fluidFontSize` and `fluidScale` options. For most projects, applying it via the preset is the recommended approach.
+**Part of the Design Tokens Preset:** Fluid font sizing is enabled by default in the [Design Tokens Preset](/docs/theme/design-tokens/preset) (`useDesignTokensPreset`) and you can configure it through the preset's `fluidFontSize` and `fluidScale` options. For most projects, applying it via the preset is the recommended approach.
 ::
 
 ## Overview
@@ -200,8 +200,8 @@ The default range of 320px to 1440px works well for most projects, accommodating
 
 ## Next Steps
 
-- **[Clamp Function](/docs/design-tokens/fluid-design/viewport)**: Learn about `useFluidViewportDesignTokens()` and `useFluidClamp()`
-- **[Scales](/docs/design-tokens/scales)**: Deep dive into modular scales and scale powers
-- **[Typography](/docs/design-tokens/typography)**: Explore the static font-size composable and other typography tokens
-- **[Line Height](/docs/design-tokens/typography#uselineheight)**: Create proportional line heights
+- **[Clamp Function](/docs/theme/design-tokens/fluid-design/viewport)**: Learn about `useFluidViewportDesignTokens()` and `useFluidClamp()`
+- **[Scales](/docs/theme/design-tokens/scales)**: Deep dive into modular scales and scale powers
+- **[Typography](/docs/theme/design-tokens/typography)**: Explore the static font-size composable and other typography tokens
+- **[Line Height](/docs/theme/design-tokens/typography#uselineheightdesigntokens)**: Create proportional line heights
 - **[Utopia Fluid Type Scale](https://utopia.fyi/){target="_blank"}**: Explore the mathematical foundation behind fluid typography

--- a/apps/docs/content/docs/03.design-tokens/10.scales.md
+++ b/apps/docs/content/docs/03.design-tokens/10.scales.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Design Tokens Preset:** `useScaleDesignTokens` and `useScalePowersDesignTokens` are included in the [Design Tokens Preset](/docs/design-tokens/preset) (`useDesignTokensPreset`) and you can configure them through the preset's `scale` and `scalePowers` options. For most projects, applying them via the preset is the recommended approach.
+**Part of the Design Tokens Preset:** `useScaleDesignTokens` and `useScalePowersDesignTokens` are included in the [Design Tokens Preset](/docs/theme/design-tokens/preset) (`useDesignTokensPreset`) and you can configure them through the preset's `scale` and `scalePowers` options. For most projects, applying them via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/03.design-tokens/11.spacing.md
+++ b/apps/docs/content/docs/03.design-tokens/11.spacing.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Design Tokens Preset:** `useSpacingDesignTokens` is included in the [Design Tokens Preset](/docs/design-tokens/preset) (`useDesignTokensPreset`) and you can configure it through the preset's `spacing` option. For most projects, applying it via the preset is the recommended approach.
+**Part of the Design Tokens Preset:** `useSpacingDesignTokens` is included in the [Design Tokens Preset](/docs/theme/design-tokens/preset) (`useDesignTokensPreset`) and you can configure it through the preset's `spacing` option. For most projects, applying it via the preset is the recommended approach.
 ::
 
 ## Overview
@@ -147,7 +147,7 @@ export default s;
 
 The `useMultiplierDesignTokens()` function multiplies your base spacing by the scale powers, creating a harmonious progression of spacing values. This ensures consistent proportional relationships throughout your design system.
 
-[Read more about design scales](/docs/design-tokens/scales) and take advantage of the flexibility they offer.
+[Read more about design scales](/docs/theme/design-tokens/scales) and take advantage of the flexibility they offer.
 
 ::tip
 

--- a/apps/docs/content/docs/03.design-tokens/12.typography.md
+++ b/apps/docs/content/docs/03.design-tokens/12.typography.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Design Tokens Preset:** `useFontFamilyDesignTokens`, `useFontSizeDesignTokens`, `useFontWeightDesignTokens`, `useFontStyleDesignTokens`, `useLineHeightDesignTokens`, and `useLetterSpacingDesignTokens` are included in the [Design Tokens Preset](/docs/design-tokens/preset) (`useDesignTokensPreset`) and you can configure them through the preset's `fontFamily`, `fontSize`, `fontWeight`, `fontStyle`, `lineHeight`, and `letterSpacing` options. For most projects, applying them via the preset is the recommended approach.
+**Part of the Design Tokens Preset:** `useFontFamilyDesignTokens`, `useFontSizeDesignTokens`, `useFontWeightDesignTokens`, `useFontStyleDesignTokens`, `useLineHeightDesignTokens`, and `useLetterSpacingDesignTokens` are included in the [Design Tokens Preset](/docs/theme/design-tokens/preset) (`useDesignTokensPreset`) and you can configure them through the preset's `fontFamily`, `fontSize`, `fontWeight`, `fontStyle`, `lineHeight`, and `letterSpacing` options. For most projects, applying them via the preset is the recommended approach.
 ::
 
 ## Overview
@@ -289,7 +289,7 @@ export default s;
 
 The `useMultiplierDesignTokens()` function multiplies your base font size by the scale powers, creating a harmonious progression of sizes that maintain consistent proportional relationships.
 
-[Read more about design scales](/docs/design-tokens/scales) and take advantage of the flexibility they offer.
+[Read more about design scales](/docs/theme/design-tokens/scales) and take advantage of the flexibility they offer.
 
 ::tip
 

--- a/apps/docs/content/docs/03.design-tokens/13.z-index.md
+++ b/apps/docs/content/docs/03.design-tokens/13.z-index.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Design Tokens Preset:** `useZIndexDesignTokens` is included in the [Design Tokens Preset](/docs/design-tokens/preset) (`useDesignTokensPreset`) and you can configure it through the preset's `zIndex` option. For most projects, applying it via the preset is the recommended approach.
+**Part of the Design Tokens Preset:** `useZIndexDesignTokens` is included in the [Design Tokens Preset](/docs/theme/design-tokens/preset) (`useDesignTokensPreset`) and you can configure it through the preset's `zIndex` option. For most projects, applying it via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/04.elements/00.index.md
+++ b/apps/docs/content/docs/04.elements/00.index.md
@@ -35,7 +35,7 @@ export default s;
 
 This single call registers base styles for all HTML elements, focus outlines, and text selection — with sensible defaults that reference your design tokens.
 
-[Learn more about the Global Preset →](/docs/elements/preset)
+[Learn more about the Global Preset →](/docs/theme/elements/preset)
 
 ## Composables
 
@@ -62,7 +62,7 @@ const { linkColor, linkHoverColor } = useLinkElement(s);
 export default s;
 ```
 
-[Learn more about Body →](/docs/elements/base/body) · [Headings →](/docs/elements/typography/headings) · [Paragraphs →](/docs/elements/typography/paragraphs) · [Links →](/docs/elements/typography/links)
+[Learn more about Body →](/docs/theme/elements/body) · [Headings →](/docs/theme/elements/headings) · [Paragraphs →](/docs/theme/elements/paragraphs) · [Links →](/docs/theme/elements/links)
 
 
 ### Lists
@@ -88,7 +88,7 @@ const { ulMarginBottom, ulPaddingLeft } = useUlElement(s);
 export default s;
 ```
 
-[Learn more about Lists →](/docs/elements/typography/lists) · [Definition Lists →](/docs/elements/typography/definition-lists)
+[Learn more about Lists →](/docs/theme/elements/lists) · [Definition Lists →](/docs/theme/elements/definition-lists)
 
 
 ### Code & Inline Text
@@ -115,7 +115,7 @@ const { kbdBackground, kbdColor } = useKbdElement(s);
 export default s;
 ```
 
-[Learn more about Code →](/docs/elements/inline-text/code) · [Kbd →](/docs/elements/inline-text/kbd) · [Mark →](/docs/elements/inline-text/mark) · [Abbreviation →](/docs/elements/inline-text/abbreviation) · [Sample Output →](/docs/elements/forms-tables/output)
+[Learn more about Code →](/docs/theme/elements/code) · [Kbd →](/docs/theme/elements/kbd) · [Mark →](/docs/theme/elements/mark) · [Abbreviation →](/docs/theme/elements/abbreviation) · [Sample Output →](/docs/theme/elements/output)
 
 
 ### Structural Elements
@@ -139,7 +139,7 @@ const { captionColor, captionTextAlign } = useCaptionElement(s);
 export default s;
 ```
 
-[Learn more about Horizontal Rule →](/docs/elements/structure/horizontal-rule) · [Caption →](/docs/elements/forms-tables/caption) · [Address →](/docs/elements/structure/address)
+[Learn more about Horizontal Rule →](/docs/theme/elements/horizontal-rule) · [Caption →](/docs/theme/elements/caption) · [Address →](/docs/theme/elements/address)
 
 
 ### Global States
@@ -162,7 +162,7 @@ const { selectionBackground, selectionColor } = useSelectionState(s);
 export default s;
 ```
 
-[Learn more about Focus →](/docs/elements/states/focus) · [Selection →](/docs/elements/states/selection)
+[Learn more about Focus →](/docs/theme/elements/focus) · [Selection →](/docs/theme/elements/selection)
 
 
 ### Simple Elements
@@ -176,7 +176,7 @@ These composables apply fixed styles with no configuration options.
 - **`useLegendElement()`**: Styles `legend` elements for proper form layout
 - **`useSummaryElement()`**: Sets `cursor: pointer` on `summary` elements
 
-[Learn more about Image →](/docs/elements/media/image) · [Iframe →](/docs/elements/media/iframe) · [Output →](/docs/elements/forms-tables/output) · [Legend →](/docs/elements/forms-tables/legend) · [Summary →](/docs/elements/states/summary)
+[Learn more about Image →](/docs/theme/elements/image) · [Iframe →](/docs/theme/elements/iframe) · [Output →](/docs/theme/elements/output) · [Legend →](/docs/theme/elements/legend) · [Summary →](/docs/theme/elements/summary)
 
 
 ## Element Reference
@@ -219,7 +219,7 @@ These composables apply fixed styles with no configuration options.
 
 ## Next Steps
 
-- **Quick setup?** Start with the [Global Preset](/docs/elements/preset) to apply all element styles at once
-- **Customizing text?** Check out [Body](/docs/elements/base/body), [Headings](/docs/elements/typography/headings), and [Links](/docs/elements/typography/links)
-- **Working with code?** See [Code](/docs/elements/inline-text/code) and [Kbd](/docs/elements/inline-text/kbd)
-- **Need accessible focus styles?** Learn about [Focus](/docs/elements/states/focus)
+- **Quick setup?** Start with the [Global Preset](/docs/theme/elements/preset) to apply all element styles at once
+- **Customizing text?** Check out [Body](/docs/theme/elements/body), [Headings](/docs/theme/elements/headings), and [Links](/docs/theme/elements/links)
+- **Working with code?** See [Code](/docs/theme/elements/code) and [Kbd](/docs/theme/elements/kbd)
+- **Need accessible focus styles?** Learn about [Focus](/docs/theme/elements/focus)

--- a/apps/docs/content/docs/04.elements/01.preset.md
+++ b/apps/docs/content/docs/04.elements/01.preset.md
@@ -96,31 +96,31 @@ Each element can be configured as:
 
 | Option | Composable | Type | Default | Description |
 |--------|------------|------|---------|-------------|
-| [`body`](/docs/elements/base/body) | `useBodyElement` | `WithThemes<BodyElementConfig> \| false` | Enabled | Body color, background, font family, size, line height |
-| [`heading`](/docs/elements/typography/headings) | `useHeadingElement` | `WithThemes<HeadingElementConfig> \| false` | Enabled | Heading font family, weight, line height, per-level sizes |
-| [`paragraph`](/docs/elements/typography/paragraphs) | `useParagraphElement` | `WithThemes<ParagraphElementConfig> \| false` | Enabled | Paragraph top/bottom margins |
-| [`link`](/docs/elements/typography/links) | `useLinkElement` | `WithThemes<LinkElementConfig> \| false` | Enabled | Link color, decoration, hover states |
-| [`ol`](/docs/elements/typography/lists) | `useOlElement` | `WithThemes<OlElementConfig> \| false` | Enabled | Ordered list margin and padding |
-| [`ul`](/docs/elements/typography/lists) | `useUlElement` | `WithThemes<UlElementConfig> \| false` | Enabled | Unordered list margin and padding |
-| [`dl`](/docs/elements/typography/definition-lists) | `useDlElement` | `WithThemes<DlElementConfig> \| false` | Enabled | Definition list bottom margin |
-| [`dt`](/docs/elements/typography/definition-lists) | `useDtElement` | `WithThemes<DtElementConfig> \| false` | Enabled | Definition term font weight |
-| [`dd`](/docs/elements/typography/definition-lists) | `useDdElement` | `WithThemes<DdElementConfig> \| false` | Enabled | Definition description margins |
-| [`code`](/docs/elements/inline-text/code) | `useCodeElement` | `WithThemes<CodeElementConfig> \| false` | Enabled | Code font family and size |
-| [`pre`](/docs/elements/inline-text/code) | `usePreElement` | `WithThemes<PreElementConfig> \| false` | Enabled | Pre font family, size, bottom margin |
-| [`kbd`](/docs/elements/inline-text/kbd) | `useKbdElement` | `WithThemes<KbdElementConfig> \| false` | Enabled | Keyboard input background, color, font, padding |
-| [`samp`](/docs/elements/forms-tables/output) | `useSampElement` | `WithThemes<SampElementConfig> \| false` | Enabled | Sample output font family |
-| [`abbr`](/docs/elements/inline-text/abbreviation) | `useAbbrElement` | `WithThemes<AbbrElementConfig> \| false` | Enabled | Abbreviation cursor and text decoration |
-| [`mark`](/docs/elements/inline-text/mark) | `useMarkElement` | `WithThemes<MarkElementConfig> \| false` | Enabled | Mark background, color, padding |
-| [`hr`](/docs/elements/structure/horizontal-rule) | `useHrElement` | `WithThemes<HrElementConfig> \| false` | Enabled | Horizontal rule border and margin |
-| [`caption`](/docs/elements/forms-tables/caption) | `useCaptionElement` | `WithThemes<CaptionElementConfig> \| false` | Enabled | Table caption color, padding, text alignment |
-| [`address`](/docs/elements/structure/address) | `useAddressElement` | `WithThemes<AddressElementConfig> \| false` | Enabled | Address bottom margin |
-| [`selection`](/docs/elements/states/selection) | `useSelectionState` | `WithThemes<SelectionStateConfig> \| false` | Enabled | Text selection background and color |
-| [`focus`](/docs/elements/states/focus) | `useFocusState` | `WithThemes<FocusStateConfig> \| false` | Enabled | Focus-visible outline styles |
-| [`img`](/docs/elements/media/image) | `useImgElement` | `boolean` | `true` | Image and SVG vertical alignment |
-| [`iframe`](/docs/elements/media/iframe) | `useIframeElement` | `boolean` | `true` | Iframe border removal |
-| [`output`](/docs/elements/forms-tables/output) | `useOutputElement` | `boolean` | `true` | Output display mode |
-| [`legend`](/docs/elements/forms-tables/legend) | `useLegendElement` | `boolean` | `true` | Legend form layout |
-| [`summary`](/docs/elements/states/summary) | `useSummaryElement` | `boolean` | `true` | Summary cursor style |
+| [`body`](/docs/theme/elements/body) | `useBodyElement` | `WithThemes<BodyElementConfig> \| false` | Enabled | Body color, background, font family, size, line height |
+| [`heading`](/docs/theme/elements/headings) | `useHeadingElement` | `WithThemes<HeadingElementConfig> \| false` | Enabled | Heading font family, weight, line height, per-level sizes |
+| [`paragraph`](/docs/theme/elements/paragraphs) | `useParagraphElement` | `WithThemes<ParagraphElementConfig> \| false` | Enabled | Paragraph top/bottom margins |
+| [`link`](/docs/theme/elements/links) | `useLinkElement` | `WithThemes<LinkElementConfig> \| false` | Enabled | Link color, decoration, hover states |
+| [`ol`](/docs/theme/elements/lists) | `useOlElement` | `WithThemes<OlElementConfig> \| false` | Enabled | Ordered list margin and padding |
+| [`ul`](/docs/theme/elements/lists) | `useUlElement` | `WithThemes<UlElementConfig> \| false` | Enabled | Unordered list margin and padding |
+| [`dl`](/docs/theme/elements/definition-lists) | `useDlElement` | `WithThemes<DlElementConfig> \| false` | Enabled | Definition list bottom margin |
+| [`dt`](/docs/theme/elements/definition-lists) | `useDtElement` | `WithThemes<DtElementConfig> \| false` | Enabled | Definition term font weight |
+| [`dd`](/docs/theme/elements/definition-lists) | `useDdElement` | `WithThemes<DdElementConfig> \| false` | Enabled | Definition description margins |
+| [`code`](/docs/theme/elements/code) | `useCodeElement` | `WithThemes<CodeElementConfig> \| false` | Enabled | Code font family and size |
+| [`pre`](/docs/theme/elements/code) | `usePreElement` | `WithThemes<PreElementConfig> \| false` | Enabled | Pre font family, size, bottom margin |
+| [`kbd`](/docs/theme/elements/kbd) | `useKbdElement` | `WithThemes<KbdElementConfig> \| false` | Enabled | Keyboard input background, color, font, padding |
+| [`samp`](/docs/theme/elements/output) | `useSampElement` | `WithThemes<SampElementConfig> \| false` | Enabled | Sample output font family |
+| [`abbr`](/docs/theme/elements/abbreviation) | `useAbbrElement` | `WithThemes<AbbrElementConfig> \| false` | Enabled | Abbreviation cursor and text decoration |
+| [`mark`](/docs/theme/elements/mark) | `useMarkElement` | `WithThemes<MarkElementConfig> \| false` | Enabled | Mark background, color, padding |
+| [`hr`](/docs/theme/elements/horizontal-rule) | `useHrElement` | `WithThemes<HrElementConfig> \| false` | Enabled | Horizontal rule border and margin |
+| [`caption`](/docs/theme/elements/caption) | `useCaptionElement` | `WithThemes<CaptionElementConfig> \| false` | Enabled | Table caption color, padding, text alignment |
+| [`address`](/docs/theme/elements/address) | `useAddressElement` | `WithThemes<AddressElementConfig> \| false` | Enabled | Address bottom margin |
+| [`selection`](/docs/theme/elements/selection) | `useSelectionState` | `WithThemes<SelectionStateConfig> \| false` | Enabled | Text selection background and color |
+| [`focus`](/docs/theme/elements/focus) | `useFocusState` | `WithThemes<FocusStateConfig> \| false` | Enabled | Focus-visible outline styles |
+| [`img`](/docs/theme/elements/image) | `useImgElement` | `boolean` | `true` | Image and SVG vertical alignment |
+| [`iframe`](/docs/theme/elements/iframe) | `useIframeElement` | `boolean` | `true` | Iframe border removal |
+| [`output`](/docs/theme/elements/output) | `useOutputElement` | `boolean` | `true` | Output display mode |
+| [`legend`](/docs/theme/elements/legend) | `useLegendElement` | `boolean` | `true` | Legend form layout |
+| [`summary`](/docs/theme/elements/summary) | `useSummaryElement` | `boolean` | `true` | Summary cursor style |
 | `themes` | — | `Record<string, GlobalThemeOverrides>` | — | Centralized per-theme overrides for all elements |
 
 ### Return Value

--- a/apps/docs/content/docs/04.elements/02.base/00.body.md
+++ b/apps/docs/content/docs/04.elements/02.base/00.body.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Global Preset:** `useBodyElement` is included in the [Global Preset](/docs/elements/preset) (`useGlobalPreset`) and you can configure it through the preset's `body` option. For most projects, applying it via the preset is the recommended approach.
+**Part of the Global Preset:** `useBodyElement` is included in the [Global Preset](/docs/theme/elements/preset) (`useGlobalPreset`) and you can configure it through the preset's `body` option. For most projects, applying it via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/04.elements/03.typography/01.headings.md
+++ b/apps/docs/content/docs/04.elements/03.typography/01.headings.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Global Preset:** `useHeadingElement` is included in the [Global Preset](/docs/elements/preset) (`useGlobalPreset`) and you can configure it through the preset's `heading` option. For most projects, applying it via the preset is the recommended approach.
+**Part of the Global Preset:** `useHeadingElement` is included in the [Global Preset](/docs/theme/elements/preset) (`useGlobalPreset`) and you can configure it through the preset's `heading` option. For most projects, applying it via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/04.elements/03.typography/02.paragraphs.md
+++ b/apps/docs/content/docs/04.elements/03.typography/02.paragraphs.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Global Preset:** `useParagraphElement` is included in the [Global Preset](/docs/elements/preset) (`useGlobalPreset`) and you can configure it through the preset's `paragraph` option. For most projects, applying it via the preset is the recommended approach.
+**Part of the Global Preset:** `useParagraphElement` is included in the [Global Preset](/docs/theme/elements/preset) (`useGlobalPreset`) and you can configure it through the preset's `paragraph` option. For most projects, applying it via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/04.elements/03.typography/03.links.md
+++ b/apps/docs/content/docs/04.elements/03.typography/03.links.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Global Preset:** `useLinkElement` is included in the [Global Preset](/docs/elements/preset) (`useGlobalPreset`) and you can configure it through the preset's `link` option. For most projects, applying it via the preset is the recommended approach.
+**Part of the Global Preset:** `useLinkElement` is included in the [Global Preset](/docs/theme/elements/preset) (`useGlobalPreset`) and you can configure it through the preset's `link` option. For most projects, applying it via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/04.elements/03.typography/04.lists.md
+++ b/apps/docs/content/docs/04.elements/03.typography/04.lists.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Global Preset:** `useOlElement` and `useUlElement` are included in the [Global Preset](/docs/elements/preset) (`useGlobalPreset`) and you can configure them through the preset's `ol` and `ul` options. For most projects, applying them via the preset is the recommended approach.
+**Part of the Global Preset:** `useOlElement` and `useUlElement` are included in the [Global Preset](/docs/theme/elements/preset) (`useGlobalPreset`) and you can configure them through the preset's `ol` and `ul` options. For most projects, applying them via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/04.elements/03.typography/05.definition-lists.md
+++ b/apps/docs/content/docs/04.elements/03.typography/05.definition-lists.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Global Preset:** `useDlElement`, `useDtElement`, and `useDdElement` are included in the [Global Preset](/docs/elements/preset) (`useGlobalPreset`) and you can configure them through the preset's `dl`, `dt`, and `dd` options. For most projects, applying them via the preset is the recommended approach.
+**Part of the Global Preset:** `useDlElement`, `useDtElement`, and `useDdElement` are included in the [Global Preset](/docs/theme/elements/preset) (`useGlobalPreset`) and you can configure them through the preset's `dl`, `dt`, and `dd` options. For most projects, applying them via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/04.elements/04.inline-text/00.abbreviation.md
+++ b/apps/docs/content/docs/04.elements/04.inline-text/00.abbreviation.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Global Preset:** `useAbbrElement` is included in the [Global Preset](/docs/elements/preset) (`useGlobalPreset`) and you can configure it through the preset's `abbr` option. For most projects, applying it via the preset is the recommended approach.
+**Part of the Global Preset:** `useAbbrElement` is included in the [Global Preset](/docs/theme/elements/preset) (`useGlobalPreset`) and you can configure it through the preset's `abbr` option. For most projects, applying it via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/04.elements/04.inline-text/01.code.md
+++ b/apps/docs/content/docs/04.elements/04.inline-text/01.code.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Global Preset:** `useCodeElement` and `usePreElement` are included in the [Global Preset](/docs/elements/preset) (`useGlobalPreset`) and you can configure them through the preset's `code` and `pre` options. For most projects, applying them via the preset is the recommended approach.
+**Part of the Global Preset:** `useCodeElement` and `usePreElement` are included in the [Global Preset](/docs/theme/elements/preset) (`useGlobalPreset`) and you can configure them through the preset's `code` and `pre` options. For most projects, applying them via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/04.elements/04.inline-text/02.kbd.md
+++ b/apps/docs/content/docs/04.elements/04.inline-text/02.kbd.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Global Preset:** `useKbdElement` is included in the [Global Preset](/docs/elements/preset) (`useGlobalPreset`) and you can configure it through the preset's `kbd` option. For most projects, applying it via the preset is the recommended approach.
+**Part of the Global Preset:** `useKbdElement` is included in the [Global Preset](/docs/theme/elements/preset) (`useGlobalPreset`) and you can configure it through the preset's `kbd` option. For most projects, applying it via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/04.elements/04.inline-text/03.mark.md
+++ b/apps/docs/content/docs/04.elements/04.inline-text/03.mark.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Global Preset:** `useMarkElement` is included in the [Global Preset](/docs/elements/preset) (`useGlobalPreset`) and you can configure it through the preset's `mark` option. For most projects, applying it via the preset is the recommended approach.
+**Part of the Global Preset:** `useMarkElement` is included in the [Global Preset](/docs/theme/elements/preset) (`useGlobalPreset`) and you can configure it through the preset's `mark` option. For most projects, applying it via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/04.elements/05.media/00.image.md
+++ b/apps/docs/content/docs/04.elements/05.media/00.image.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Global Preset:** `useImgElement` is included in the [Global Preset](/docs/elements/preset) (`useGlobalPreset`) and you can configure it through the preset's `img` option. For most projects, applying it via the preset is the recommended approach.
+**Part of the Global Preset:** `useImgElement` is included in the [Global Preset](/docs/theme/elements/preset) (`useGlobalPreset`) and you can configure it through the preset's `img` option. For most projects, applying it via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/04.elements/05.media/01.iframe.md
+++ b/apps/docs/content/docs/04.elements/05.media/01.iframe.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Global Preset:** `useIframeElement` is included in the [Global Preset](/docs/elements/preset) (`useGlobalPreset`) and you can configure it through the preset's `iframe` option. For most projects, applying it via the preset is the recommended approach.
+**Part of the Global Preset:** `useIframeElement` is included in the [Global Preset](/docs/theme/elements/preset) (`useGlobalPreset`) and you can configure it through the preset's `iframe` option. For most projects, applying it via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/04.elements/06.forms-tables/00.caption.md
+++ b/apps/docs/content/docs/04.elements/06.forms-tables/00.caption.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Global Preset:** `useCaptionElement` is included in the [Global Preset](/docs/elements/preset) (`useGlobalPreset`) and you can configure it through the preset's `caption` option. For most projects, applying it via the preset is the recommended approach.
+**Part of the Global Preset:** `useCaptionElement` is included in the [Global Preset](/docs/theme/elements/preset) (`useGlobalPreset`) and you can configure it through the preset's `caption` option. For most projects, applying it via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/04.elements/06.forms-tables/01.legend.md
+++ b/apps/docs/content/docs/04.elements/06.forms-tables/01.legend.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Global Preset:** `useLegendElement` is included in the [Global Preset](/docs/elements/preset) (`useGlobalPreset`) and you can configure it through the preset's `legend` option. For most projects, applying it via the preset is the recommended approach.
+**Part of the Global Preset:** `useLegendElement` is included in the [Global Preset](/docs/theme/elements/preset) (`useGlobalPreset`) and you can configure it through the preset's `legend` option. For most projects, applying it via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/04.elements/06.forms-tables/02.output.md
+++ b/apps/docs/content/docs/04.elements/06.forms-tables/02.output.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Global Preset:** `useOutputElement` and `useSampElement` are included in the [Global Preset](/docs/elements/preset) (`useGlobalPreset`) and you can configure them through the preset's `output` and `samp` options. For most projects, applying them via the preset is the recommended approach.
+**Part of the Global Preset:** `useOutputElement` and `useSampElement` are included in the [Global Preset](/docs/theme/elements/preset) (`useGlobalPreset`) and you can configure them through the preset's `output` and `samp` options. For most projects, applying them via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/04.elements/07.structure/00.address.md
+++ b/apps/docs/content/docs/04.elements/07.structure/00.address.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Global Preset:** `useAddressElement` is included in the [Global Preset](/docs/elements/preset) (`useGlobalPreset`) and you can configure it through the preset's `address` option. For most projects, applying it via the preset is the recommended approach.
+**Part of the Global Preset:** `useAddressElement` is included in the [Global Preset](/docs/theme/elements/preset) (`useGlobalPreset`) and you can configure it through the preset's `address` option. For most projects, applying it via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/04.elements/07.structure/01.horizontal-rule.md
+++ b/apps/docs/content/docs/04.elements/07.structure/01.horizontal-rule.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Global Preset:** `useHrElement` is included in the [Global Preset](/docs/elements/preset) (`useGlobalPreset`) and you can configure it through the preset's `hr` option. For most projects, applying it via the preset is the recommended approach.
+**Part of the Global Preset:** `useHrElement` is included in the [Global Preset](/docs/theme/elements/preset) (`useGlobalPreset`) and you can configure it through the preset's `hr` option. For most projects, applying it via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/04.elements/08.states/00.focus.md
+++ b/apps/docs/content/docs/04.elements/08.states/00.focus.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Global Preset:** `useFocusState` is included in the [Global Preset](/docs/elements/preset) (`useGlobalPreset`) and you can configure it through the preset's `focus` option. For most projects, applying it via the preset is the recommended approach.
+**Part of the Global Preset:** `useFocusState` is included in the [Global Preset](/docs/theme/elements/preset) (`useGlobalPreset`) and you can configure it through the preset's `focus` option. For most projects, applying it via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/04.elements/08.states/01.selection.md
+++ b/apps/docs/content/docs/04.elements/08.states/01.selection.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Global Preset:** `useSelectionState` is included in the [Global Preset](/docs/elements/preset) (`useGlobalPreset`) and you can configure it through the preset's `selection` option. For most projects, applying it via the preset is the recommended approach.
+**Part of the Global Preset:** `useSelectionState` is included in the [Global Preset](/docs/theme/elements/preset) (`useGlobalPreset`) and you can configure it through the preset's `selection` option. For most projects, applying it via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/04.elements/08.states/02.summary.md
+++ b/apps/docs/content/docs/04.elements/08.states/02.summary.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Global Preset:** `useSummaryElement` is included in the [Global Preset](/docs/elements/preset) (`useGlobalPreset`) and you can configure it through the preset's `summary` option. For most projects, applying it via the preset is the recommended approach.
+**Part of the Global Preset:** `useSummaryElement` is included in the [Global Preset](/docs/theme/elements/preset) (`useGlobalPreset`) and you can configure it through the preset's `summary` option. For most projects, applying it via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/05.components/00.index.md
+++ b/apps/docs/content/docs/05.components/00.index.md
@@ -47,4 +47,4 @@ A small labeling component for status indicators, counts, and categorization.
 
 **Variants:** 6 colors, 4 styles, 5 sizes
 
-[Learn more about Badge →](/docs/components/feedback/badge)
+[Learn more about Badge →](/docs/theme/components/badge)

--- a/apps/docs/content/docs/05.components/02.actions/00.button.md
+++ b/apps/docs/content/docs/05.components/02.actions/00.button.md
@@ -9,7 +9,7 @@ navigation:
 
 The **Button** is an interactive UI element used for triggering actions, submitting forms, and navigating between views. The `useButtonRecipe()` composable creates a fully configured [recipe](/docs/api/recipes) with color, variant, and size options &mdash; plus compound variants that handle the color-variant combinations automatically.
 
-The Button recipe integrates directly with the default [design tokens preset](/docs/design-tokens/preset) and generates type-safe utility classes at build time with zero runtime CSS.
+The Button recipe integrates directly with the default [design tokens preset](/docs/theme/design-tokens/preset) and generates type-safe utility classes at build time with zero runtime CSS.
 
 ## Why use the Button recipe?
 

--- a/apps/docs/content/docs/05.components/02.actions/01.hamburger-menu.md
+++ b/apps/docs/content/docs/05.components/02.actions/01.hamburger-menu.md
@@ -9,7 +9,7 @@ navigation:
 
 The **Hamburger Menu** is an interactive toggle button typically used in mobile navigation headers to expand or collapse a drawer or sidebar. It renders as three horizontal bars in its resting state and animates into an alternative glyph &mdash; an X, arrow, plus, or minus &mdash; when the `active` state is set to `true`. The styling is provided by `useHamburgerMenuRecipe()`, which exposes `color`, `size`, `animation`, and `active` axes.
 
-The Hamburger Menu recipe integrates directly with the default [design tokens preset](/docs/design-tokens/preset) and generates type-safe utility classes at build time with zero runtime CSS. Visual state (open/closed) is driven by modifier classes, so transitions are pure CSS.
+The Hamburger Menu recipe integrates directly with the default [design tokens preset](/docs/theme/design-tokens/preset) and generates type-safe utility classes at build time with zero runtime CSS. Visual state (open/closed) is driven by modifier classes, so transitions are pure CSS.
 
 ## Why use the Hamburger Menu recipe?
 

--- a/apps/docs/content/docs/05.components/03.navigation/00.breadcrumb.md
+++ b/apps/docs/content/docs/05.components/03.navigation/00.breadcrumb.md
@@ -9,7 +9,7 @@ navigation:
 
 The **Breadcrumb** is a navigation aid that shows the user's current location inside a site or app hierarchy. It is composed of two recipe parts: `useBreadcrumbRecipe()` for the container that controls layout and spacing, and `useBreadcrumbItemRecipe()` for individual breadcrumb links with color, size, and active/disabled state options. Each composable creates a fully configured [recipe](/docs/api/recipes) with compound variants that handle every color combination automatically.
 
-The Breadcrumb recipes integrate directly with the default [design tokens preset](/docs/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS. The separator between items is rendered via a `::after` pseudo-element on each non-last item and can be overridden through the `--breadcrumb--separator-content` CSS variable.
+The Breadcrumb recipes integrate directly with the default [design tokens preset](/docs/theme/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS. The separator between items is rendered via a `::after` pseudo-element on each non-last item and can be overridden through the `--breadcrumb--separator-content` CSS variable.
 
 ## Why use the Breadcrumb recipe?
 

--- a/apps/docs/content/docs/05.components/03.navigation/01.nav.md
+++ b/apps/docs/content/docs/05.components/03.navigation/01.nav.md
@@ -9,7 +9,7 @@ navigation:
 
 The **Nav** is a navigation component used for building horizontal and vertical link lists such as navbars, sidebars, and tab bars. It is composed of two recipe parts: `useNavRecipe()` for the container that controls layout direction and spacing, and `useNavItemRecipe()` for individual navigation links with color, variant, and interactive state options. Each composable creates a fully configured [recipe](/docs/api/recipes) with compound variants that handle the color-variant combinations automatically.
 
-The Nav recipes integrate directly with the default [design tokens preset](/docs/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
+The Nav recipes integrate directly with the default [design tokens preset](/docs/theme/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
 
 ## Why use the Nav recipe?
 

--- a/apps/docs/content/docs/05.components/03.navigation/02.pagination.md
+++ b/apps/docs/content/docs/05.components/03.navigation/02.pagination.md
@@ -9,7 +9,7 @@ navigation:
 
 The **Pagination** is a navigation component used for moving between pages of a result set such as tables, search results, and content listings. It is composed of three recipe parts: `usePaginationRecipe()` for the container that controls layout direction and spacing, `usePaginationItemRecipe()` for individual page-number buttons with color, variant, and interactive state options, and `usePaginationEllipsisRecipe()` for the non-interactive `…` element that collapses long page ranges. Each composable creates a fully configured [recipe](/docs/api/recipes) with compound variants that handle the color-variant combinations automatically.
 
-The Pagination recipes integrate directly with the default [design tokens preset](/docs/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
+The Pagination recipes integrate directly with the default [design tokens preset](/docs/theme/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
 
 ## Why use the Pagination recipe?
 

--- a/apps/docs/content/docs/05.components/03.navigation/03.sidebar.md
+++ b/apps/docs/content/docs/05.components/03.navigation/03.sidebar.md
@@ -9,7 +9,7 @@ navigation:
 
 The **Sidebar** is a layout-and-navigation component for application shells: a fixed-width, full-height panel that holds branding, grouped navigation menus, and a footer. It is composed of fifteen recipe parts that work together — `useSidebarRecipe()` for the panel surface, region recipes (`header`, `content`, `footer`, `group`, `inset`), list recipes (`menu`, `menu-sub`), the interactive `menu-button` / `menu-sub-button`, and accent parts (`group-label`, `separator`, `menu-action`, `menu-badge`, `group-action`). Each composable creates a fully configured [recipe](/docs/api/recipes) with compound variants that handle the color-style combinations automatically.
 
-The Sidebar recipes integrate directly with the default [design tokens preset](/docs/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
+The Sidebar recipes integrate directly with the default [design tokens preset](/docs/theme/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
 
 ::note
 **Styling, not behavior.** These recipes ship the visual structure and the CSS for the collapsed icon rail. State and behavior — the open/close toggle, keyboard shortcut, mobile drawer, and persistence — are left to your application. Toggling the `collapsed` state (or the `.-collapsed` class) is all the recipe needs to switch to the icon rail.

--- a/apps/docs/content/docs/05.components/03.navigation/04.tabs.md
+++ b/apps/docs/content/docs/05.components/03.navigation/04.tabs.md
@@ -9,7 +9,7 @@ navigation:
 
 The **Tabs** component organizes related content into a set of panels, one of which is visible at a time. It is composed of four recipe parts: `useTabsRecipe()` for the root wrapper that lays out the bar and the active panel, `useTabsListRecipe()` for the tab list (`role="tablist"`), `useTabsTriggerRecipe()` for each individual tab button (`role="tab"`), and `useTabsContentRecipe()` for the content panels (`role="tabpanel"`). Each composable creates a fully configured [recipe](/docs/api/recipes) with compound variants that handle the color-variant combinations &mdash; including the active-tab indicator and dark mode overrides &mdash; automatically.
 
-The active tab is matched through the `aria-selected` attribute, so the selected styling is driven by accessible markup rather than an extra class. The Tabs recipes integrate directly with the default [design tokens preset](/docs/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
+The active tab is matched through the `aria-selected` attribute, so the selected styling is driven by accessible markup rather than an extra class. The Tabs recipes integrate directly with the default [design tokens preset](/docs/theme/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
 
 ## Why use the Tabs recipe?
 

--- a/apps/docs/content/docs/05.components/04.feedback/00.badge.md
+++ b/apps/docs/content/docs/05.components/04.feedback/00.badge.md
@@ -9,7 +9,7 @@ navigation:
 
 The **Badge** is a compact UI element used for status indicators, counts, labels, and categorization. The `useBadgeRecipe()` composable creates a fully configured [recipe](/docs/api/recipes) with color, variant, and size options &mdash; plus compound variants that handle the color-variant combinations automatically.
 
-The Badge recipe integrates directly with the default [design tokens preset](/docs/design-tokens/preset) and generates type-safe utility classes at build time with zero runtime CSS.
+The Badge recipe integrates directly with the default [design tokens preset](/docs/theme/design-tokens/preset) and generates type-safe utility classes at build time with zero runtime CSS.
 
 ## Why use the Badge recipe?
 

--- a/apps/docs/content/docs/05.components/04.feedback/01.callout.md
+++ b/apps/docs/content/docs/05.components/04.feedback/01.callout.md
@@ -9,7 +9,7 @@ navigation:
 
 The **Callout** is a contextual feedback element used for alerts, notifications, status messages, and inline notices. The `useCalloutRecipe()` composable creates a fully configured [recipe](/docs/api/recipes) with color, variant, size, and orientation options &mdash; plus compound variants that handle the color-variant combinations automatically.
 
-The Callout recipe integrates directly with the default [design tokens preset](/docs/design-tokens/preset) and generates type-safe utility classes at build time with zero runtime CSS.
+The Callout recipe integrates directly with the default [design tokens preset](/docs/theme/design-tokens/preset) and generates type-safe utility classes at build time with zero runtime CSS.
 
 ## Why use the Callout recipe?
 

--- a/apps/docs/content/docs/05.components/04.feedback/02.chip.md
+++ b/apps/docs/content/docs/05.components/04.feedback/02.chip.md
@@ -9,7 +9,7 @@ navigation:
 
 The **Chip** is a small status indicator element positioned at the corner of another element, commonly used for notification badges, unread counts, and online status dots. It is composed of two recipe parts: `useChipRecipe()` for the positioning wrapper and `useChipIndicatorRecipe()` for the indicator itself. Each composable creates a fully configured [recipe](/docs/api/recipes) with color, variant, size, position, and inset options &mdash; plus compound variants that handle the color-variant combinations automatically.
 
-The Chip recipes integrate directly with the default [design tokens preset](/docs/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
+The Chip recipes integrate directly with the default [design tokens preset](/docs/theme/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
 
 ## Why use the Chip recipe?
 

--- a/apps/docs/content/docs/05.components/04.feedback/03.progress.md
+++ b/apps/docs/content/docs/05.components/04.feedback/03.progress.md
@@ -9,7 +9,7 @@ navigation:
 
 The **Progress** is a visual indicator element used to show the completion status of a task or process. It is composed of two recipe parts: `useProgressRecipe()` for the track container and `useProgressBarRecipe()` for the fill bar. Each composable creates a fully configured [recipe](/docs/api/recipes) with color, size, and orientation options &mdash; plus compound variants that handle the color-orientation combinations automatically.
 
-The Progress recipes integrate directly with the default [design tokens preset](/docs/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
+The Progress recipes integrate directly with the default [design tokens preset](/docs/theme/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
 
 ## Why use the Progress recipe?
 

--- a/apps/docs/content/docs/05.components/04.feedback/04.skeleton.md
+++ b/apps/docs/content/docs/05.components/04.feedback/04.skeleton.md
@@ -9,7 +9,7 @@ navigation:
 
 The **Skeleton** is a loading placeholder element used to indicate that content is being fetched or processed. The `useSkeletonRecipe()` composable creates a fully configured [recipe](/docs/api/recipes) with size and rounded options, plus a built-in pulse animation via keyframes &mdash; no additional CSS required.
 
-The Skeleton recipe integrates directly with the default [design tokens preset](/docs/design-tokens/preset) and generates type-safe utility classes at build time with zero runtime CSS.
+The Skeleton recipe integrates directly with the default [design tokens preset](/docs/theme/design-tokens/preset) and generates type-safe utility classes at build time with zero runtime CSS.
 
 ## Why use the Skeleton recipe?
 

--- a/apps/docs/content/docs/05.components/04.feedback/05.spinner.md
+++ b/apps/docs/content/docs/05.components/04.feedback/05.spinner.md
@@ -9,7 +9,7 @@ navigation:
 
 The **Spinner** is a visual indicator used to communicate that an action is in progress. The `useSpinnerRecipe()` composable creates a fully configured [recipe](/docs/api/recipes) with color and size options, while `useSpinnerCircleRecipe()` handles the SVG spinner animation and `useSpinnerOverlayRecipe()` provides an optional backdrop overlay.
 
-The Spinner recipe integrates directly with the default [design tokens preset](/docs/design-tokens/preset) and generates type-safe utility classes at build time with zero runtime CSS.
+The Spinner recipe integrates directly with the default [design tokens preset](/docs/theme/design-tokens/preset) and generates type-safe utility classes at build time with zero runtime CSS.
 
 ## Why use the Spinner recipe?
 

--- a/apps/docs/content/docs/05.components/05.forms/00.calendar.md
+++ b/apps/docs/content/docs/05.components/05.forms/00.calendar.md
@@ -12,9 +12,9 @@ The **Calendar** is a styling recipe for a date grid &mdash; the parts and per-c
 - **`useCalendarRecipe()`** &mdash; the `.calendar` surface that owns the border, radius, padding, the header/grid/footer layout, and the `size` axis. Each size sets the `--calendar-cell-size` and `--calendar-cell-font-size` custom properties, which cascade to every cell.
 - **`useCalendarDayRecipe()`** &mdash; the `.calendar-day` button rendered for each day. It owns the square, content-adaptive cell, the `selected`, `today`, `outside`, `disabled`, `booked` and `range` state axes, and a `variant` axis (`solid`, `outline`, `soft`, `subtle`) for the active-selection style.
 
-Everything else &mdash; the caption, navigation, weekday header, week rows, week numbers, presets sidebar and footer &mdash; is a structural class emitted by the root recipe (see [Anatomy](#anatomy)). Navigation and preset buttons reuse the [Button](/docs/components/actions/button) recipe, time fields reuse the [Input](/docs/components/forms/input) recipe, and the month/year selects reuse the Select recipe.
+Everything else &mdash; the caption, navigation, weekday header, week rows, week numbers, presets sidebar and footer &mdash; is a structural class emitted by the root recipe (see [Anatomy](#anatomy)). Navigation and preset buttons reuse the [Button](/docs/theme/components/button) recipe, time fields reuse the [Input](/docs/theme/components/input) recipe, and the month/year selects reuse the Select recipe.
 
-The Calendar recipes integrate directly with the default [design tokens preset](/docs/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
+The Calendar recipes integrate directly with the default [design tokens preset](/docs/theme/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
 
 ## Why use the Calendar recipe?
 
@@ -349,7 +349,7 @@ panel: true
 
 ## Presets
 
-Add a `.calendar-presets` sidebar beside the calendar for quick picks like "Today" or "Last 7 days". The preset buttons reuse the [Button](/docs/components/actions/button) recipe.
+Add a `.calendar-presets` sidebar beside the calendar for quick picks like "Today" or "Last 7 days". The preset buttons reuse the [Button](/docs/theme/components/button) recipe.
 
 ::story-preview
 ---
@@ -360,7 +360,7 @@ panel: true
 
 ## Date &amp; time
 
-Add a `.calendar-footer` below the grid for start/end time fields, built with the [Input](/docs/components/forms/input) recipe.
+Add a `.calendar-footer` below the grid for start/end time fields, built with the [Input](/docs/theme/components/input) recipe.
 
 ::story-preview
 ---

--- a/apps/docs/content/docs/05.components/05.forms/01.checkbox.md
+++ b/apps/docs/content/docs/05.components/05.forms/01.checkbox.md
@@ -14,9 +14,9 @@ The **Checkbox** is a binary form control that lets users toggle an option on or
 
 The field is the real native input, so every state is driven by the browser: `:checked` and `:indeterminate` fill the box with `@color.primary`, `:focus-visible` shows a focus ring, and `:disabled` dims it. The `color` axis sets the *unchecked* surface (`light`, `dark`, `neutral`) and the checked fill stays `@color.primary` across all three. 
 
-The Checkbox recipes integrate directly with the default [design tokens preset](/docs/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
+The Checkbox recipes integrate directly with the default [design tokens preset](/docs/theme/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
 
-To lay several checkboxes out as a set, see the [Checkbox Group](/docs/components/forms/checkbox-group) recipe.
+To lay several checkboxes out as a set, see the [Checkbox Group](/docs/theme/components/checkbox-group) recipe.
 
 ## Why use the Checkbox recipe?
 
@@ -197,7 +197,7 @@ panel: true
 
 ## Colors
 
-The Checkbox field includes 3 color variants: `light`, `dark`, and `neutral`. Like the [Input](/docs/components/forms/input) and Card recipes, these are neutral-spectrum surface colors rather than status colors &mdash; the color sets the *unchecked* box background and border, while the checked and indeterminate fill is always `@color.primary`.
+The Checkbox field includes 3 color variants: `light`, `dark`, and `neutral`. Like the [Input](/docs/theme/components/input) and Card recipes, these are neutral-spectrum surface colors rather than status colors &mdash; the color sets the *unchecked* box background and border, while the checked and indeterminate fill is always `@color.primary`.
 
 The `neutral` color adapts automatically: a light surface in light mode and a dark surface in dark mode, making it the safest default for general-purpose forms.
 
@@ -404,7 +404,7 @@ Creates the checkbox field recipe &mdash; the `.checkbox-field` native `<input t
 - **Pass `size` to both parts**: Spread the same `size` to the wrapper and the field so the label and box scale together.
 - **Use `neutral` for general forms**: The neutral color adapts to light and dark mode automatically, making it the safest default.
 - **Mirror state on the native input**: Set the real `disabled` attribute and the `indeterminate` DOM property in addition to styling.
-- **Group related checkboxes**: Use the [Checkbox Group](/docs/components/forms/checkbox-group) recipe to lay out a set with consistent spacing.
+- **Group related checkboxes**: Use the [Checkbox Group](/docs/theme/components/checkbox-group) recipe to lay out a set with consistent spacing.
 - **Filter what you don't need**: If your forms use only the neutral color, pass a `filter` option to reduce generated CSS.
 
 ## FAQ
@@ -420,7 +420,7 @@ Applying the recipe to the real `<input type="checkbox">` with `appearance: none
 :::
 
 :::accordion-item{label="Why is the color light/dark/neutral instead of primary/success/error?" icon="i-lucide-circle-help"}
-The `color` axis controls the *unchecked* box surface, which reflects the form's surface rather than a status. The checked and indeterminate fill is always `@color.primary`, the conventional accent for a selected control. This mirrors the [Input](/docs/components/forms/input) recipe's color model.
+The `color` axis controls the *unchecked* box surface, which reflects the form's surface rather than a status. The checked and indeterminate fill is always `@color.primary`, the conventional accent for a selected control. This mirrors the [Input](/docs/theme/components/input) recipe's color model.
 :::
 
 :::accordion-item{label="How does the checked fill stay correct in dark mode?" icon="i-lucide-circle-help"}

--- a/apps/docs/content/docs/05.components/05.forms/02.checkbox-group.md
+++ b/apps/docs/content/docs/05.components/05.forms/02.checkbox-group.md
@@ -7,9 +7,9 @@ navigation:
 
 ## Overview
 
-The **Checkbox Group** is a layout component that arranges related [checkboxes](/docs/components/forms/checkbox) into a single, consistently spaced set. The `useCheckboxGroupRecipe()` composable creates a fully configured [recipe](/docs/api/recipes) with orientation and size options &mdash; a flex container that stacks checkboxes vertically or lays them out in a wrapping row.
+The **Checkbox Group** is a layout component that arranges related [checkboxes](/docs/theme/components/checkbox) into a single, consistently spaced set. The `useCheckboxGroupRecipe()` composable creates a fully configured [recipe](/docs/api/recipes) with orientation and size options &mdash; a flex container that stacks checkboxes vertically or lays them out in a wrapping row.
 
-The Checkbox Group recipe integrates directly with the [Checkbox recipe](/docs/components/forms/checkbox) and generates type-safe utility classes at build time with zero runtime CSS.
+The Checkbox Group recipe integrates directly with the [Checkbox recipe](/docs/theme/components/checkbox) and generates type-safe utility classes at build time with zero runtime CSS.
 
 ## Why use the Checkbox Group recipe?
 
@@ -200,7 +200,7 @@ Three size variants control the gap between checkboxes, letting you tighten or l
 
 - **Group related options.** Wrap the checkboxes in an element with `role="group"` and an `aria-label` (or `aria-labelledby`) describing the set, so assistive technology announces the context.
 - **Prefer a fieldset for forms.** When the group is part of a form, a native `<fieldset>` with a `<legend>` is the most robust grouping &mdash; apply the recipe class to the fieldset.
-- **Keep each checkbox labelled.** The group provides layout only; every child still needs its own label (see the [Checkbox](/docs/components/forms/checkbox) recipe).
+- **Keep each checkbox labelled.** The group provides layout only; every child still needs its own label (see the [Checkbox](/docs/theme/components/checkbox) recipe).
 
 ## Customization
 
@@ -276,7 +276,7 @@ Creates a checkbox group recipe &mdash; a flex container with orientation and si
 
 ## Best Practices
 
-- **Pair with the Checkbox recipe**: The group handles layout; each child should use the [Checkbox](/docs/components/forms/checkbox) recipe for consistent controls.
+- **Pair with the Checkbox recipe**: The group handles layout; each child should use the [Checkbox](/docs/theme/components/checkbox) recipe for consistent controls.
 - **Match sizes**: Use the same `size` on the group and its child checkboxes so spacing and boxes scale together.
 - **Keep groups scannable**: Prefer vertical layout for longer option lists; reserve horizontal for two or three short options.
 - **Label the set**: Always describe the group's purpose with `aria-label` or a `<legend>` so screen readers communicate the relationship between options.

--- a/apps/docs/content/docs/05.components/05.forms/03.color-picker.md
+++ b/apps/docs/content/docs/05.components/05.forms/03.color-picker.md
@@ -16,7 +16,7 @@ The **Color Picker** is a control for choosing a color visually. It is composed 
 
 Unlike most recipes, the Color Picker has **no color axis** &mdash; it renders arbitrary user colors through CSS gradients and a hue variable, not theme tokens. The recipe is the **styling shell**: it draws the surfaces and the handles, while dragging, color math, and format conversion stay in your application's JavaScript (or a headless library).
 
-The Color Picker recipes integrate directly with the default [design tokens preset](/docs/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
+The Color Picker recipes integrate directly with the default [design tokens preset](/docs/theme/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
 
 ## Why use the Color Picker recipe?
 
@@ -392,7 +392,7 @@ Creates the selector recipe &mdash; the `.color-picker-selector` saturation/valu
 
 ### `useColorPickerTrackRecipe(s, options?)`
 
-Creates the track recipe &mdash; the `.color-picker-track` vertical hue slider, a pill-shaped rail modeled on the [Slider](/docs/components/forms/slider) track and filled with the rainbow. The `size` axis scales both the rail thickness (width) and the height to match the selector. Paints the fixed 0&ndash;360&deg; hue rainbow. Accepts the same parameters as `useColorPickerRecipe`.
+Creates the track recipe &mdash; the `.color-picker-track` vertical hue slider, a pill-shaped rail modeled on the [Slider](/docs/theme/components/slider) track and filled with the rainbow. The `size` axis scales both the rail thickness (width) and the height to match the selector. Paints the fixed 0&ndash;360&deg; hue rainbow. Accepts the same parameters as `useColorPickerRecipe`.
 
 **Variants:**
 

--- a/apps/docs/content/docs/05.components/05.forms/04.field-group.md
+++ b/apps/docs/content/docs/05.components/05.forms/04.field-group.md
@@ -9,7 +9,7 @@ navigation:
 
 The **Field Group** is a layout component that visually connects related controls &mdash; buttons, inputs, selects, badges &mdash; into a single, cohesive unit. The `useFieldGroupRecipe()` composable creates a fully configured [recipe](/docs/api/recipes) with orientation and block mode options, plus automatic border-radius collapsing so adjacent controls share a seamless edge.
 
-Children are placed as **direct children** of the group. The recipe targets them generically, so any bordered control works without per-component wiring &mdash; an [Input](/docs/components/forms/input) next to a [Button](/docs/components/actions/button), a [Select](/docs/components/forms/select) prefixing an Input, or a row of buttons. It generates type-safe utility classes at build time with zero runtime CSS.
+Children are placed as **direct children** of the group. The recipe targets them generically, so any bordered control works without per-component wiring &mdash; an [Input](/docs/theme/components/input) next to a [Button](/docs/theme/components/button), a [Select](/docs/theme/components/select) prefixing an Input, or a row of buttons. It generates type-safe utility classes at build time with zero runtime CSS.
 
 ## Why use the Field Group recipe?
 

--- a/apps/docs/content/docs/05.components/05.forms/05.input.md
+++ b/apps/docs/content/docs/05.components/05.forms/05.input.md
@@ -15,9 +15,9 @@ The **Input** is a text-field container used to capture single-line user input. 
 
 Each composable creates a fully configured [recipe](/docs/api/recipes) with color, variant, and size options &mdash; plus compound variants on the wrapper that handle every color-variant combination and the invalid, disabled, and readonly states automatically.
 
-To join an input with a button, select, or other bordered control as an attached block, wrap them in a [Field Group](/docs/components/forms/field-group) rather than reaching for a built-in slot.
+To join an input with a button, select, or other bordered control as an attached block, wrap them in a [Field Group](/docs/theme/components/field-group) rather than reaching for a built-in slot.
 
-The Input recipes integrate directly with the default [design tokens preset](/docs/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
+The Input recipes integrate directly with the default [design tokens preset](/docs/theme/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
 
 ## Why use the Input recipe?
 
@@ -350,7 +350,7 @@ panel: true
 
 ## Addons
 
-Input supports **inline** addons (`prefix`, `suffix`) that render inside the field and share its surface &mdash; use them for icons, currency symbols, and units. To attach an interactive block such as a button or select *outside* the field, group the controls with a [Field Group](/docs/components/forms/field-group) instead.
+Input supports **inline** addons (`prefix`, `suffix`) that render inside the field and share its surface &mdash; use them for icons, currency symbols, and units. To attach an interactive block such as a button or select *outside* the field, group the controls with a [Field Group](/docs/theme/components/field-group) instead.
 
 ### Prefix and suffix (inline)
 
@@ -379,7 +379,7 @@ panel: true
 
 ### Attached controls (field group)
 
-To attach a button, select, or other bordered control to the input, place them as direct children of a [Field Group](/docs/components/forms/field-group). The group flattens the border radius and inner border at the seams, so the controls read as one joined unit &mdash; each child keeps its own styling.
+To attach a button, select, or other bordered control to the input, place them as direct children of a [Field Group](/docs/theme/components/field-group). The group flattens the border radius and inner border at the seams, so the controls read as one joined unit &mdash; each child keeps its own styling.
 
 ::story-preview
 ---
@@ -389,7 +389,7 @@ panel: true
 ::
 
 ::tip
-**Pro tip:** Reach for `prefix`/`suffix` when the addon is decorative or informational (an icon, a unit) and lives inside the field. Reach for a [Field Group](/docs/components/forms/field-group) when the addon is an interactive control (a button, a dropdown) attached outside the field.
+**Pro tip:** Reach for `prefix`/`suffix` when the addon is decorative or informational (an icon, a unit) and lives inside the field. Reach for a [Field Group](/docs/theme/components/field-group) when the addon is an interactive control (a button, a dropdown) attached outside the field.
 ::
 
 ## Anatomy
@@ -420,7 +420,7 @@ The nested `.input-field` element is the real `<input>`: it is transparent, has 
 ```
 
 ::tip
-**Pro tip:** Use `useInputRecipe()` on its own (with optional prefix/suffix) for most inputs, and reach for a [Field Group](/docs/components/forms/field-group) only when you attach interactive blocks.
+**Pro tip:** Use `useInputRecipe()` on its own (with optional prefix/suffix) for most inputs, and reach for a [Field Group](/docs/theme/components/field-group) only when you attach interactive blocks.
 ::
 
 ## Accessibility
@@ -531,7 +531,7 @@ Creates the inline suffix recipe &mdash; a trailing addon rendered inside the fi
 |---------|---------|---------|
 | `size` | `sm`, `md`, `lg` | `md` |
 
-To attach interactive blocks outside the field, see the [Field Group recipe](/docs/components/forms/field-group).
+To attach interactive blocks outside the field, see the [Field Group recipe](/docs/theme/components/field-group).
 
 [Learn more about recipes &rarr;](/docs/api/recipes)
 
@@ -540,7 +540,7 @@ To attach interactive blocks outside the field, see the [Field Group recipe](/do
 - **Pass `size` consistently**: Spread the same `size` to the wrapper and to every prefix and suffix part so the whole field scales together.
 - **Pass states as booleans**: The `invalid`, `disabled`, and `readonly` axes accept a boolean directly &mdash; no `"true"` / `"false"` conversion needed (the string keys still work if you prefer them).
 - **Mirror states on the native input**: Always set the real `disabled` / `readonly` attributes and `aria-invalid` in addition to the recipe state.
-- **Choose the right addon kind**: Use `prefix`/`suffix` for decorative or informational content inside the field, and a [Field Group](/docs/components/forms/field-group) for interactive blocks attached to it.
+- **Choose the right addon kind**: Use `prefix`/`suffix` for decorative or informational content inside the field, and a [Field Group](/docs/theme/components/field-group) for interactive blocks attached to it.
 - **Use `neutral` for general forms**: The neutral color adapts to light and dark mode automatically, making it the safest default.
 - **Filter what you don't need**: If your forms use only one color or two variants, pass a `filter` option to reduce generated CSS.
 - **Override defaults at the recipe level**: Set your most common combination as `defaultVariants` so component consumers write less code.
@@ -554,7 +554,7 @@ The `.input` wrapper owns the visual field &mdash; border, background, padding, 
 :::
 
 :::accordion-item{label="How do I attach a button or select to the field?" icon="i-lucide-circle-help"}
-`prefix` and `suffix` render **inside** the field and share its background and focus ring &mdash; use them for icons, currency symbols, and units. To attach an interactive control such as a button or select **outside** the field, wrap the input and the control in a [Field Group](/docs/components/forms/field-group), which flattens the border radii at the seams so they read as one joined unit.
+`prefix` and `suffix` render **inside** the field and share its background and focus ring &mdash; use them for icons, currency symbols, and units. To attach an interactive control such as a button or select **outside** the field, wrap the input and the control in a [Field Group](/docs/theme/components/field-group), which flattens the border radii at the seams so they read as one joined unit.
 :::
 
 :::accordion-item{label="How do I pass the invalid, disabled, and readonly states?" icon="i-lucide-circle-help"}

--- a/apps/docs/content/docs/05.components/05.forms/06.otp.md
+++ b/apps/docs/content/docs/05.components/05.forms/06.otp.md
@@ -12,9 +12,9 @@ The **OTP** input (also called a pin input) is a row of single-character fields 
 - **`useOtpRecipe()`** &mdash; the row container that owns the layout: a horizontal flex row whose `size` axis scales the gap between cells.
 - **`useOtpCellRecipe()`** &mdash; the single-character cell that sits directly on each native `<input>`. It owns the surface (color, style, size), centered text, and the invalid, disabled, and `:focus-visible` states.
 
-Each cell is the real native `<input>`, so focus and the focus ring are driven by the browser: `:focus-visible` shows a ring in `@color.primary`, and the `invalid` state switches that ring and the border to `@color.error`. The cell shares the exact color / style / state surface as the [Input](/docs/components/forms/input) recipe, so an OTP field feels like the rest of your forms.
+Each cell is the real native `<input>`, so focus and the focus ring are driven by the browser: `:focus-visible` shows a ring in `@color.primary`, and the `invalid` state switches that ring and the border to `@color.error`. The cell shares the exact color / style / state surface as the [Input](/docs/theme/components/input) recipe, so an OTP field feels like the rest of your forms.
 
-The OTP recipes integrate directly with the default [design tokens preset](/docs/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
+The OTP recipes integrate directly with the default [design tokens preset](/docs/theme/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
 
 ::note
 **Styling, not behavior.** These recipes style the cells. Auto-advancing focus, handling paste, and masking are interaction concerns you wire up yourself (or with a headless library) &mdash; the recipe stays framework-agnostic.
@@ -201,7 +201,7 @@ panel: true
 
 ## Colors
 
-The OTP cell includes 3 color variants: `light`, `dark`, and `neutral`. Like the [Input](/docs/components/forms/input) and [Checkbox](/docs/components/forms/checkbox) recipes, these are neutral-spectrum surface colors rather than status colors &mdash; the color sets the cell background and border, while the `:focus-visible` ring stays `@color.primary`.
+The OTP cell includes 3 color variants: `light`, `dark`, and `neutral`. Like the [Input](/docs/theme/components/input) and [Checkbox](/docs/theme/components/checkbox) recipes, these are neutral-spectrum surface colors rather than status colors &mdash; the color sets the cell background and border, while the `:focus-visible` ring stays `@color.primary`.
 
 The `neutral` color adapts automatically: a light surface in light mode and a dark surface in dark mode, making it the safest default for general-purpose forms.
 
@@ -448,7 +448,7 @@ No &mdash; the recipe only styles the cells. Moving focus to the next cell as th
 :::
 
 :::accordion-item{label="Why is the color light/dark/neutral instead of primary/success/error?" icon="i-lucide-circle-help"}
-The `color` axis controls the cell surface, which reflects the form's surface rather than a status. This mirrors the [Input](/docs/components/forms/input) recipe's color model. For an error state, use the `invalid` state, which switches the border and focus ring to `@color.error`.
+The `color` axis controls the cell surface, which reflects the form's surface rather than a status. This mirrors the [Input](/docs/theme/components/input) recipe's color model. For an error state, use the `invalid` state, which switches the border and focus ring to `@color.error`.
 :::
 
 :::accordion-item{label="How is the OTP cell related to the Input recipe?" icon="i-lucide-circle-help"}

--- a/apps/docs/content/docs/05.components/05.forms/07.radio.md
+++ b/apps/docs/content/docs/05.components/05.forms/07.radio.md
@@ -16,9 +16,9 @@ The field is the real native input, so every state is driven by the browser: `:c
 
 Radios become mutually exclusive when they share a `name` attribute &mdash; the browser then allows only one selection per group and wires up arrow-key navigation. The recipe is purely presentational; grouping is native.
 
-The Radio recipes integrate directly with the default [design tokens preset](/docs/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
+The Radio recipes integrate directly with the default [design tokens preset](/docs/theme/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
 
-To lay several radios out as a set, see the [Radio Group](/docs/components/forms/radio-group) recipe.
+To lay several radios out as a set, see the [Radio Group](/docs/theme/components/radio-group) recipe.
 
 ## Why use the Radio recipe?
 
@@ -184,7 +184,7 @@ panel: true
 
 ## Colors
 
-The Radio field includes 3 color variants: `light`, `dark`, and `neutral`. Like the [Input](/docs/components/forms/input) and Card recipes, these are neutral-spectrum surface colors rather than status colors &mdash; the color sets the *unchecked* circle background and border, while the checked fill is always `@color.primary`.
+The Radio field includes 3 color variants: `light`, `dark`, and `neutral`. Like the [Input](/docs/theme/components/input) and Card recipes, these are neutral-spectrum surface colors rather than status colors &mdash; the color sets the *unchecked* circle background and border, while the checked fill is always `@color.primary`.
 
 The `neutral` color adapts automatically: a light surface in light mode and a dark surface in dark mode, making it the safest default for general-purpose forms.
 
@@ -380,7 +380,7 @@ Creates the radio field recipe &mdash; the `.radio-field` native `<input type="r
 - **Pass `size` to both parts**: Spread the same `size` to the wrapper and the field so the label and circle scale together.
 - **Use `neutral` for general forms**: The neutral color adapts to light and dark mode automatically, making it the safest default.
 - **Give grouped radios a shared `name`**: Radios only become mutually exclusive when they share a `name` attribute &mdash; set it on every option in a set.
-- **Group related radios**: Use the [Radio Group](/docs/components/forms/radio-group) recipe to lay out a set with consistent spacing.
+- **Group related radios**: Use the [Radio Group](/docs/theme/components/radio-group) recipe to lay out a set with consistent spacing.
 - **Filter what you don't need**: If your forms use only the neutral color, pass a `filter` option to reduce generated CSS.
 
 ## FAQ
@@ -396,7 +396,7 @@ Give every radio in the set the same `name` attribute. The browser then allows o
 :::
 
 :::accordion-item{label="Why is the color light/dark/neutral instead of primary/success/error?" icon="i-lucide-circle-help"}
-The `color` axis controls the *unchecked* circle surface, which reflects the form's surface rather than a status. The checked fill is always `@color.primary`, the conventional accent for a selected control. This mirrors the [Input](/docs/components/forms/input) recipe's color model.
+The `color` axis controls the *unchecked* circle surface, which reflects the form's surface rather than a status. The checked fill is always `@color.primary`, the conventional accent for a selected control. This mirrors the [Input](/docs/theme/components/input) recipe's color model.
 :::
 
 :::accordion-item{label="How does the checked fill stay correct in dark mode?" icon="i-lucide-circle-help"}

--- a/apps/docs/content/docs/05.components/05.forms/08.radio-group.md
+++ b/apps/docs/content/docs/05.components/05.forms/08.radio-group.md
@@ -7,11 +7,11 @@ navigation:
 
 ## Overview
 
-The **Radio Group** is a layout component that arranges related [radios](/docs/components/forms/radio) into a single, consistently spaced set. The `useRadioGroupRecipe()` composable creates a fully configured [recipe](/docs/api/recipes) with orientation and size options &mdash; a flex container that stacks radios vertically or lays them out in a wrapping row.
+The **Radio Group** is a layout component that arranges related [radios](/docs/theme/components/radio) into a single, consistently spaced set. The `useRadioGroupRecipe()` composable creates a fully configured [recipe](/docs/api/recipes) with orientation and size options &mdash; a flex container that stacks radios vertically or lays them out in a wrapping row.
 
 The group handles layout only. Single selection comes from the native input: give every child radio the same `name`, and the browser enforces one choice per group and wires up arrow-key navigation. Mark the container with `role="radiogroup"` (or use a `<fieldset>`) so assistive technology announces the set.
 
-The Radio Group recipe integrates directly with the [Radio recipe](/docs/components/forms/radio) and generates type-safe utility classes at build time with zero runtime CSS.
+The Radio Group recipe integrates directly with the [Radio recipe](/docs/theme/components/radio) and generates type-safe utility classes at build time with zero runtime CSS.
 
 ## Why use the Radio Group recipe?
 
@@ -203,7 +203,7 @@ Three size variants control the gap between radios, letting you tighten or loose
 - **Mark the group.** Wrap the radios in an element with `role="radiogroup"` and an `aria-label` (or `aria-labelledby`) describing the set, so assistive technology announces the context.
 - **Share a `name` across children.** Single selection and arrow-key navigation come from giving every child radio the same `name`. The group recipe only handles layout.
 - **Prefer a fieldset for forms.** When the group is part of a form, a native `<fieldset>` with a `<legend>` is the most robust grouping &mdash; apply the recipe class to the fieldset.
-- **Keep each radio labelled.** The group provides layout only; every child still needs its own label (see the [Radio](/docs/components/forms/radio) recipe).
+- **Keep each radio labelled.** The group provides layout only; every child still needs its own label (see the [Radio](/docs/theme/components/radio) recipe).
 
 ## Customization
 
@@ -279,7 +279,7 @@ Creates a radio group recipe &mdash; a flex container with orientation and size 
 
 ## Best Practices
 
-- **Pair with the Radio recipe**: The group handles layout; each child should use the [Radio](/docs/components/forms/radio) recipe for consistent controls.
+- **Pair with the Radio recipe**: The group handles layout; each child should use the [Radio](/docs/theme/components/radio) recipe for consistent controls.
 - **Share a `name`**: Give every child radio the same `name` so the set behaves as one mutually-exclusive group.
 - **Match sizes**: Use the same `size` on the group and its child radios so spacing and circles scale together.
 - **Keep groups scannable**: Prefer vertical layout for longer option lists; reserve horizontal for two or three short options.

--- a/apps/docs/content/docs/05.components/05.forms/09.select.md
+++ b/apps/docs/content/docs/05.components/05.forms/09.select.md
@@ -19,7 +19,7 @@ The **Select** is a composite form control for choosing one or many values from 
 
 Each composable creates a fully configured [recipe](/docs/api/recipes) with color and size options &mdash; plus compound variants that handle every color-variant combination, including dark mode overrides, automatically.
 
-The Select recipes integrate directly with the default [design tokens preset](/docs/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
+The Select recipes integrate directly with the default [design tokens preset](/docs/theme/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
 
 ## Why use the Select recipe?
 
@@ -299,9 +299,9 @@ Select uses **two visual-style vocabularies**, each faithful to the recipe it is
 
 | Parts | Variants | Modeled on |
 |-------|----------|------------|
-| Trigger (`useSelectRecipe`) | `solid`, `soft`, `ghost` | [Input](/docs/components/forms/input) |
-| Panel + Option (`useSelectPanelRecipe`, `useSelectOptionRecipe`) | `solid`, `soft`, `subtle` | [Dropdown](/docs/components/overlays/dropdown) |
-| Chip (`useSelectChipRecipe`) | `solid`, `outline`, `soft`, `subtle` | [Badge](/docs/components/feedback/badge) |
+| Trigger (`useSelectRecipe`) | `solid`, `soft`, `ghost` | [Input](/docs/theme/components/input) |
+| Panel + Option (`useSelectPanelRecipe`, `useSelectOptionRecipe`) | `solid`, `soft`, `subtle` | [Dropdown](/docs/theme/components/dropdown) |
+| Chip (`useSelectChipRecipe`) | `solid`, `outline`, `soft`, `subtle` | [Badge](/docs/theme/components/badge) |
 
 The stories below vary the **trigger** style. Each value is combined with the selected color through [compound variants](/docs/api/recipes#compound-variants).
 
@@ -378,7 +378,7 @@ panel: true
 
 ## Multi-selection
 
-The headline feature: render each selected value as a dismissable **chip** inside the trigger. Chips are modeled on the [Badge](/docs/components/feedback/badge) recipe but scoped to the container palette so they match the control surface. The trigger wraps its contents, so chips flow onto multiple rows as the selection grows, and the chevron stays pinned to the trailing edge.
+The headline feature: render each selected value as a dismissable **chip** inside the trigger. Chips are modeled on the [Badge](/docs/theme/components/badge) recipe but scoped to the container palette so they match the control surface. The trigger wraps its contents, so chips flow onto multiple rows as the selection grows, and the chevron stays pinned to the trailing edge.
 
 ::story-preview
 ---
@@ -656,7 +656,7 @@ Creates the separator recipe &mdash; a `.select-separator` rule for dividing opt
 ::accordion
 
 :::accordion-item{label="Why does the trigger use different variants than the panel?" icon="i-lucide-circle-help"}
-The Select is the visual union of three existing recipes. The trigger follows the [Input](/docs/components/forms/input) recipe's structure but names its opaque style `solid` (Input itself uses `default`), so the trigger axis is `solid`, `soft`, `ghost`; the panel and options mirror the [Dropdown](/docs/components/overlays/dropdown) recipe (`solid`, `soft`, `subtle`). Pass `solid` or `soft` to keep both vocabularies aligned; use `ghost` on the trigger with `subtle` on the panel for a borderless look.
+The Select is the visual union of three existing recipes. The trigger follows the [Input](/docs/theme/components/input) recipe's structure but names its opaque style `solid` (Input itself uses `default`), so the trigger axis is `solid`, `soft`, `ghost`; the panel and options mirror the [Dropdown](/docs/theme/components/dropdown) recipe (`solid`, `soft`, `subtle`). Pass `solid` or `soft` to keep both vocabularies aligned; use `ghost` on the trigger with `subtle` on the panel for a borderless look.
 :::
 
 :::accordion-item{label="How do I render selected values as chips?" icon="i-lucide-circle-help"}

--- a/apps/docs/content/docs/05.components/05.forms/10.slider.md
+++ b/apps/docs/content/docs/05.components/05.forms/10.slider.md
@@ -7,9 +7,9 @@ navigation:
 
 ## Overview
 
-The **Slider** is an interactive form control used to select a numeric value from a continuous range. It is composed of four recipe parts: `useSliderRecipe()` for the positioning root, `useSliderTrackRecipe()` for the neutral rail, `useSliderRangeRecipe()` for the colored fill, and `useSliderThumbRecipe()` for the draggable handle. Each composable creates a fully configured [recipe](/docs/api/recipes) &mdash; the colored parts share the full palette, while the track stays neutral, mirroring the [Progress](/docs/components/feedback/progress) recipe with an added handle.
+The **Slider** is an interactive form control used to select a numeric value from a continuous range. It is composed of four recipe parts: `useSliderRecipe()` for the positioning root, `useSliderTrackRecipe()` for the neutral rail, `useSliderRangeRecipe()` for the colored fill, and `useSliderThumbRecipe()` for the draggable handle. Each composable creates a fully configured [recipe](/docs/api/recipes) &mdash; the colored parts share the full palette, while the track stays neutral, mirroring the [Progress](/docs/theme/components/progress) recipe with an added handle.
 
-The Slider recipes integrate directly with the default [design tokens preset](/docs/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
+The Slider recipes integrate directly with the default [design tokens preset](/docs/theme/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
 
 ## Why use the Slider recipe?
 

--- a/apps/docs/content/docs/05.components/05.forms/11.switch.md
+++ b/apps/docs/content/docs/05.components/05.forms/11.switch.md
@@ -14,7 +14,7 @@ The **Switch** is a binary form control that lets users switch an option on or o
 
 The field is the real native `<input type="checkbox" role="switch">`, so every state is driven by the browser: `:checked` recolors the track to `@color.primary` and slides the knob to the right, `:focus-visible` shows a focus ring, and `:disabled` dims it. The `color` axis sets the *off* track surface (`light`, `dark`, `neutral`) and the on-track fill stays `@color.primary` across all three.
 
-The Switch recipes integrate directly with the default [design tokens preset](/docs/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
+The Switch recipes integrate directly with the default [design tokens preset](/docs/theme/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
 
 ## Why use the Switch recipe?
 
@@ -176,7 +176,7 @@ panel: true
 
 ## Colors
 
-The Switch field includes 3 color variants: `light`, `dark`, and `neutral`. Like the [Checkbox](/docs/components/forms/checkbox) and [Input](/docs/components/forms/input) recipes, these are neutral-spectrum surface colors rather than status colors &mdash; the color sets the *off* track background, while the white knob and the on-track fill (`@color.primary`) stay the same across all three.
+The Switch field includes 3 color variants: `light`, `dark`, and `neutral`. Like the [Checkbox](/docs/theme/components/checkbox) and [Input](/docs/theme/components/input) recipes, these are neutral-spectrum surface colors rather than status colors &mdash; the color sets the *off* track background, while the white knob and the on-track fill (`@color.primary`) stay the same across all three.
 
 The `neutral` color adapts automatically: a light track in light mode and a dark track in dark mode, making it the safest default for general-purpose forms.
 
@@ -368,7 +368,7 @@ Creates the switch field recipe &mdash; the `.switch-field` native `<input type=
 
 - **Pass `size` to both parts**: Spread the same `size` to the wrapper and the field so the label and switch scale together.
 - **Use `neutral` for general forms**: The neutral color adapts to light and dark mode automatically, making it the safest default.
-- **Reach for a switch, not a checkbox, for instant actions**: Use a switch when flipping it takes effect immediately (settings); use a [Checkbox](/docs/components/forms/checkbox) when the choice is submitted with a form.
+- **Reach for a switch, not a checkbox, for instant actions**: Use a switch when flipping it takes effect immediately (settings); use a [Checkbox](/docs/theme/components/checkbox) when the choice is submitted with a form.
 - **Mirror state on the native input**: Set the real `disabled` attribute in addition to styling.
 
 ## FAQ
@@ -380,11 +380,11 @@ Applying the recipe to the real `<input type="checkbox" role="switch">` with `ap
 :::
 
 :::accordion-item{label="When should I use a Switch instead of a Checkbox?" icon="i-lucide-circle-help"}
-Use a Switch for a setting that takes effect immediately, like turning a feature on or off. Use a [Checkbox](/docs/components/forms/checkbox) for a choice that is submitted with a form, or when you need an indeterminate "mixed" state &mdash; switches are strictly on or off.
+Use a Switch for a setting that takes effect immediately, like turning a feature on or off. Use a [Checkbox](/docs/theme/components/checkbox) for a choice that is submitted with a form, or when you need an indeterminate "mixed" state &mdash; switches are strictly on or off.
 :::
 
 :::accordion-item{label="Why is the color light/dark/neutral instead of primary/success/error?" icon="i-lucide-circle-help"}
-The `color` axis controls the *off* track surface, which reflects the form's surface rather than a status. The on-track fill is always `@color.primary`, the conventional accent for an active control. This mirrors the [Checkbox](/docs/components/forms/checkbox) and [Input](/docs/components/forms/input) recipes' color model.
+The `color` axis controls the *off* track surface, which reflects the form's surface rather than a status. The on-track fill is always `@color.primary`, the conventional accent for an active control. This mirrors the [Checkbox](/docs/theme/components/checkbox) and [Input](/docs/theme/components/input) recipes' color model.
 :::
 
 :::accordion-item{label="How does the on-fill stay correct in dark mode?" icon="i-lucide-circle-help"}

--- a/apps/docs/content/docs/05.components/05.forms/12.textarea.md
+++ b/apps/docs/content/docs/05.components/05.forms/12.textarea.md
@@ -7,7 +7,7 @@ navigation:
 
 ## Overview
 
-The **Textarea** is a multi-line text-field container used to capture longer user input. It mirrors the [Input](/docs/components/forms/input) recipe and is composed of three recipe parts:
+The **Textarea** is a multi-line text-field container used to capture longer user input. It mirrors the [Input](/docs/theme/components/input) recipe and is composed of three recipe parts:
 
 - **`useTextareaRecipe()`** &mdash; the wrapper that owns the visual field: border, background, padding, and the `:focus-within` ring. It also carries the `resize` axis.
 - **`useTextareaPrefixRecipe()`** &mdash; an inline leading addon that sits inside the field, sharing its surface.
@@ -15,9 +15,9 @@ The **Textarea** is a multi-line text-field container used to capture longer use
 
 Each composable creates a fully configured [recipe](/docs/api/recipes) with color, variant, and size options &mdash; plus compound variants on the wrapper that handle every color-variant combination and the invalid, disabled, and readonly states automatically.
 
-To join a textarea with a button or other bordered control as an attached block, wrap them in a [Field Group](/docs/components/forms/field-group) rather than reaching for a built-in slot.
+To join a textarea with a button or other bordered control as an attached block, wrap them in a [Field Group](/docs/theme/components/field-group) rather than reaching for a built-in slot.
 
-The Textarea recipes integrate directly with the default [design tokens preset](/docs/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
+The Textarea recipes integrate directly with the default [design tokens preset](/docs/theme/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
 
 ## Why use the Textarea recipe?
 
@@ -380,7 +380,7 @@ panel: true
 
 ## Addons
 
-Textarea supports **inline** addons (`prefix`, `suffix`) that render inside the field and share its surface &mdash; with the wrapper top-aligned, they anchor to the top of the field. Use them for icons or character counters. To attach an interactive block such as a button outside the field, group the controls with a [Field Group](/docs/components/forms/field-group) instead.
+Textarea supports **inline** addons (`prefix`, `suffix`) that render inside the field and share its surface &mdash; with the wrapper top-aligned, they anchor to the top of the field. Use them for icons or character counters. To attach an interactive block such as a button outside the field, group the controls with a [Field Group](/docs/theme/components/field-group) instead.
 
 ### Prefix and suffix (inline)
 
@@ -409,7 +409,7 @@ panel: true
 
 ### Attached controls (field group)
 
-To attach a button, select, or other bordered control to the textarea, place them as direct children of a [Field Group](/docs/components/forms/field-group). A vertical group stacks the action beneath the field; the group flattens the border radius and inner border at the seam so they read as one joined unit. Set `resize="none"` on the textarea so the joined edge stays tidy.
+To attach a button, select, or other bordered control to the textarea, place them as direct children of a [Field Group](/docs/theme/components/field-group). A vertical group stacks the action beneath the field; the group flattens the border radius and inner border at the seam so they read as one joined unit. Set `resize="none"` on the textarea so the joined edge stays tidy.
 
 ::story-preview
 ---
@@ -419,7 +419,7 @@ panel: true
 ::
 
 ::tip
-**Pro tip:** Reach for `prefix`/`suffix` when the addon is decorative or informational (an icon, a counter) and lives inside the field. Reach for a [Field Group](/docs/components/forms/field-group) when the addon is an interactive control (a button, a dropdown) attached outside the field.
+**Pro tip:** Reach for `prefix`/`suffix` when the addon is decorative or informational (an icon, a counter) and lives inside the field. Reach for a [Field Group](/docs/theme/components/field-group) when the addon is an interactive control (a button, a dropdown) attached outside the field.
 ::
 
 ## Anatomy
@@ -450,7 +450,7 @@ The nested `.textarea-field` element is the real `<textarea>`: it is transparent
 ```
 
 ::tip
-**Pro tip:** Use `useTextareaRecipe()` on its own (with optional prefix/suffix) for most textareas, and reach for a [Field Group](/docs/components/forms/field-group) only when you attach interactive blocks.
+**Pro tip:** Use `useTextareaRecipe()` on its own (with optional prefix/suffix) for most textareas, and reach for a [Field Group](/docs/theme/components/field-group) only when you attach interactive blocks.
 ::
 
 ## Accessibility
@@ -563,7 +563,7 @@ Creates the inline suffix recipe &mdash; a trailing addon rendered inside the fi
 |---------|---------|---------|
 | `size` | `sm`, `md`, `lg` | `md` |
 
-To attach interactive blocks outside the field, see the [Field Group recipe](/docs/components/forms/field-group).
+To attach interactive blocks outside the field, see the [Field Group recipe](/docs/theme/components/field-group).
 
 [Learn more about recipes &rarr;](/docs/api/recipes)
 
@@ -590,7 +590,7 @@ The `resize` property has to live on the real `<textarea>`, not the wrapper. So 
 :::
 
 :::accordion-item{label="How do I attach a button to the textarea?" icon="i-lucide-circle-help"}
-`prefix` and `suffix` render **inside** the field and share its background and focus ring &mdash; use them for icons and character counters. To attach an interactive control such as a button **outside** the field, wrap the textarea and the control in a [Field Group](/docs/components/forms/field-group) (a vertical group stacks the action beneath the field), which flattens the border radii at the seams so they read as one joined unit.
+`prefix` and `suffix` render **inside** the field and share its background and focus ring &mdash; use them for icons and character counters. To attach an interactive control such as a button **outside** the field, wrap the textarea and the control in a [Field Group](/docs/theme/components/field-group) (a vertical group stacks the action beneath the field), which flattens the border radii at the seams so they read as one joined unit.
 :::
 
 :::accordion-item{label="How do I pass the invalid, disabled, and readonly states?" icon="i-lucide-circle-help"}

--- a/apps/docs/content/docs/05.components/05.forms/13.toggle.md
+++ b/apps/docs/content/docs/05.components/05.forms/13.toggle.md
@@ -11,7 +11,7 @@ The **Toggle** is a two-state button &mdash; pressed or not pressed &mdash; the 
 
 The on state rides on `aria-pressed`: render the control as a native `<button>`, flip `aria-pressed` in your handler, and the recipe's `&:aria-pressed` rule styles the result. There is no `pressed` recipe argument &mdash; it is runtime DOM state, exactly as `:hover` is not an argument.
 
-The Toggle recipe integrates directly with the default [design tokens preset](/docs/design-tokens/preset) and generates type-safe utility classes at build time with zero runtime CSS.
+The Toggle recipe integrates directly with the default [design tokens preset](/docs/theme/design-tokens/preset) and generates type-safe utility classes at build time with zero runtime CSS.
 
 ## Why use the Toggle recipe?
 
@@ -163,7 +163,7 @@ panel: true
 
 ## Colors
 
-The Toggle includes 3 color variants: `light`, `dark`, and `neutral`. Like the [Checkbox](/docs/components/forms/checkbox) and [Switch](/docs/components/forms/switch) recipes, these are neutral-spectrum surface colors rather than status colors &mdash; the color sets the toggle's surface and text, matching the [Button](/docs/components/actions/button) recipe. The `solid` variant is a filled surface with a subtle border; `outline` and `ghost` stay transparent and fill on hover, focus, and when pressed.
+The Toggle includes 3 color variants: `light`, `dark`, and `neutral`. Like the [Checkbox](/docs/theme/components/checkbox) and [Switch](/docs/theme/components/switch) recipes, these are neutral-spectrum surface colors rather than status colors &mdash; the color sets the toggle's surface and text, matching the [Button](/docs/theme/components/button) recipe. The `solid` variant is a filled surface with a subtle border; `outline` and `ghost` stay transparent and fill on hover, focus, and when pressed.
 
 The `neutral` color adapts automatically: dark text on a light surface in light mode, and light text on a dark surface in dark mode, making it the safest default for general-purpose toolbars.
 
@@ -195,11 +195,11 @@ height: 680
 
 ## Variants
 
-The Toggle ships 3 visual styles that mirror the [Button](/docs/components/actions/button) recipe's `solid`, `outline`, and `ghost` variants. Each gives hover, focus, and active feedback, and its on state reuses the hover fill; the difference is the resting surface.
+The Toggle ships 3 visual styles that mirror the [Button](/docs/theme/components/button) recipe's `solid`, `outline`, and `ghost` variants. Each gives hover, focus, and active feedback, and its on state reuses the hover fill; the difference is the resting surface.
 
 ### Solid
 
-The default. A filled surface with a subtle border &mdash; identical to a `solid` [Button](/docs/components/actions/button) at rest &mdash; so it reads as clearly clickable. It shifts to a soft gray on hover and focus &mdash; the same fill it carries when on. The safe choice for standalone toggles.
+The default. A filled surface with a subtle border &mdash; identical to a `solid` [Button](/docs/theme/components/button) at rest &mdash; so it reads as clearly clickable. It shifts to a soft gray on hover and focus &mdash; the same fill it carries when on. The safe choice for standalone toggles.
 
 ::story-preview
 ---
@@ -362,8 +362,8 @@ Creates the toggle recipe &mdash; a `<button>` with color, variant, and size axe
 
 - **Render a real button**: Use `<button type="button">` with `aria-pressed` so the control is keyboard-accessible and screen readers announce its on/off state.
 - **Use `neutral` for general use**: The neutral color adapts to light and dark mode automatically, making it the safest default.
-- **Reach for a toggle, not a checkbox, for instant on/off**: Use a toggle for toolbar actions and formatting that apply immediately; use a [Checkbox](/docs/components/forms/checkbox) when the choice is submitted with a form.
-- **Group related toggles**: Lay out a set with the [Toggle Group](/docs/components/forms/toggle-group) recipe, or join them into a connected segmented control with [Field Group](/docs/components/forms/field-group).
+- **Reach for a toggle, not a checkbox, for instant on/off**: Use a toggle for toolbar actions and formatting that apply immediately; use a [Checkbox](/docs/theme/components/checkbox) when the choice is submitted with a form.
+- **Group related toggles**: Lay out a set with the [Toggle Group](/docs/theme/components/toggle-group) recipe, or join them into a connected segmented control with [Field Group](/docs/theme/components/field-group).
 - **Reinforce critical states**: When the pressed state matters, pair it with an icon change so it doesn't rely on the background fill alone.
 
 ## FAQ
@@ -380,15 +380,15 @@ These three cover the common cases: `solid` (filled) for standalone toggles that
 :::
 
 :::accordion-item{label="Why is the color light/dark/neutral instead of primary/success/error?" icon="i-lucide-circle-help"}
-The `color` axis controls a neutral surface, not a status, mirroring the [Checkbox](/docs/components/forms/checkbox), [Switch](/docs/components/forms/switch), and [Input](/docs/components/forms/input) recipes. The on appearance is the `:hover` gray step of that surface rather than a separate accent fill.
+The `color` axis controls a neutral surface, not a status, mirroring the [Checkbox](/docs/theme/components/checkbox), [Switch](/docs/theme/components/switch), and [Input](/docs/theme/components/input) recipes. The on appearance is the `:hover` gray step of that surface rather than a separate accent fill.
 :::
 
 :::accordion-item{label="When should I use a Toggle instead of a Switch or Checkbox?" icon="i-lucide-circle-help"}
-Use a Toggle for a button-styled on/off control &mdash; toolbar formatting, view switches, segmented controls. Use a [Switch](/docs/components/forms/switch) for an instant setting rendered as a sliding control, and a [Checkbox](/docs/components/forms/checkbox) for a choice submitted with a form.
+Use a Toggle for a button-styled on/off control &mdash; toolbar formatting, view switches, segmented controls. Use a [Switch](/docs/theme/components/switch) for an instant setting rendered as a sliding control, and a [Checkbox](/docs/theme/components/checkbox) for a choice submitted with a form.
 :::
 
 :::accordion-item{label="How do I build a connected segmented control?" icon="i-lucide-circle-help"}
-Wrap your toggles in the [Field Group](/docs/components/forms/field-group) recipe. It merges adjacent border radii and inner borders on any bordered child, so a row of `outline` toggles reads as one joined control. For spaced (non-joined) layouts, use the [Toggle Group](/docs/components/forms/toggle-group) recipe instead.
+Wrap your toggles in the [Field Group](/docs/theme/components/field-group) recipe. It merges adjacent border radii and inner borders on any bordered child, so a row of `outline` toggles reads as one joined control. For spaced (non-joined) layouts, use the [Toggle Group](/docs/theme/components/toggle-group) recipe instead.
 :::
 
 ::

--- a/apps/docs/content/docs/05.components/05.forms/14.toggle-group.md
+++ b/apps/docs/content/docs/05.components/05.forms/14.toggle-group.md
@@ -7,9 +7,9 @@ navigation:
 
 ## Overview
 
-The **Toggle Group** is a layout component that arranges related [toggles](/docs/components/forms/toggle) into a single, consistently spaced set &mdash; the foundation of a toolbar or a segmented control. The `useToggleGroupRecipe()` composable creates a fully configured [recipe](/docs/api/recipes) with orientation and size options &mdash; a flex container that lays toggles out in a wrapping row or stacks them in a column.
+The **Toggle Group** is a layout component that arranges related [toggles](/docs/theme/components/toggle) into a single, consistently spaced set &mdash; the foundation of a toolbar or a segmented control. The `useToggleGroupRecipe()` composable creates a fully configured [recipe](/docs/api/recipes) with orientation and size options &mdash; a flex container that lays toggles out in a wrapping row or stacks them in a column.
 
-The Toggle Group recipe integrates directly with the [Toggle recipe](/docs/components/forms/toggle) and generates type-safe utility classes at build time with zero runtime CSS.
+The Toggle Group recipe integrates directly with the [Toggle recipe](/docs/theme/components/toggle) and generates type-safe utility classes at build time with zero runtime CSS.
 
 ## Why use the Toggle Group recipe?
 
@@ -193,7 +193,7 @@ Three size variants control the gap between toggles, letting you tighten or loos
 
 ## Connected segmented control
 
-The Toggle Group spaces its toggles apart. For a *connected* segmented control &mdash; toggles joined at the seams with no gap &mdash; wrap them in the [Field Group](/docs/components/forms/field-group) recipe instead. It merges adjacent border radii and inner borders on any bordered child, so a row of `outline` toggles reads as one continuous control. There is no `attached` axis on the Toggle Group; the two layouts are separate, composable tools.
+The Toggle Group spaces its toggles apart. For a *connected* segmented control &mdash; toggles joined at the seams with no gap &mdash; wrap them in the [Field Group](/docs/theme/components/field-group) recipe instead. It merges adjacent border radii and inner borders on any bordered child, so a row of `outline` toggles reads as one continuous control. There is no `attached` axis on the Toggle Group; the two layouts are separate, composable tools.
 
 ::story-preview
 ---
@@ -231,7 +231,7 @@ panel: true
 
 - **Group related toggles.** Wrap the toggles in an element with `role="group"` and an `aria-label` (or `aria-labelledby`) describing the set, so assistive technology announces the context.
 - **Choose single or multiple in your logic.** The group is layout only; whether one toggle stays pressed (a segmented, radio-like control) or several can be pressed at once (a checkbox-like set) is behavior you implement, reflected through each toggle's `aria-pressed`.
-- **Keep each toggle labelled.** Every child still needs its own accessible name (see the [Toggle](/docs/components/forms/toggle) recipe).
+- **Keep each toggle labelled.** Every child still needs its own accessible name (see the [Toggle](/docs/theme/components/toggle) recipe).
 
 ## Customization
 
@@ -307,9 +307,9 @@ Creates a toggle group recipe &mdash; a flex container with orientation and size
 
 ## Best Practices
 
-- **Pair with the Toggle recipe**: The group handles layout; each child should use the [Toggle](/docs/components/forms/toggle) recipe for consistent controls.
+- **Pair with the Toggle recipe**: The group handles layout; each child should use the [Toggle](/docs/theme/components/toggle) recipe for consistent controls.
 - **Match sizes**: Use the same `size` on the group and its child toggles so spacing and buttons scale together.
-- **Reach for Field Group when segments should touch**: Use the [Field Group](/docs/components/forms/field-group) recipe for a connected segmented control; use the Toggle Group when the toggles should stay spaced apart.
+- **Reach for Field Group when segments should touch**: Use the [Field Group](/docs/theme/components/field-group) recipe for a connected segmented control; use the Toggle Group when the toggles should stay spaced apart.
 - **Label the set**: Always describe the group's purpose with `aria-label` so screen readers communicate the relationship between options.
 
 ## FAQ
@@ -321,7 +321,7 @@ No. The group is a pure layout container &mdash; it sets the flex direction and 
 :::
 
 :::accordion-item{label="How do I make the toggles touch (a segmented control)?" icon="i-lucide-circle-help"}
-The Toggle Group always spaces its items apart. For a connected segmented control, wrap `outline` toggles in the [Field Group](/docs/components/forms/field-group) recipe instead &mdash; it flattens adjacent radii and inner borders so the segments read as one control.
+The Toggle Group always spaces its items apart. For a connected segmented control, wrap `outline` toggles in the [Field Group](/docs/theme/components/field-group) recipe instead &mdash; it flattens adjacent radii and inner borders so the segments read as one control.
 :::
 
 :::accordion-item{label="How do I make it single-select like a radio group?" icon="i-lucide-circle-help"}

--- a/apps/docs/content/docs/05.components/06.overlays/00.context-menu.md
+++ b/apps/docs/content/docs/05.components/06.overlays/00.context-menu.md
@@ -7,11 +7,11 @@ navigation:
 
 ## Overview
 
-The **ContextMenu** is a floating menu surface opened on right-click (or long-press) to present actions relevant to the element under the cursor. It shares the same menu surface as the [Dropdown](/docs/components/overlays/dropdown) and [Select](/docs/components/forms/select) panels, and adds the parts a contextual menu needs: keyboard-shortcut hints, checkbox & radio rows, a destructive action style, and submenu triggers.
+The **ContextMenu** is a floating menu surface opened on right-click (or long-press) to present actions relevant to the element under the cursor. It shares the same menu surface as the [Dropdown](/docs/theme/components/dropdown) and [Select](/docs/theme/components/select) panels, and adds the parts a contextual menu needs: keyboard-shortcut hints, checkbox & radio rows, a destructive action style, and submenu triggers.
 
 It is composed of six recipe parts: `useContextMenuRecipe()` for the panel container, `useContextMenuItemRecipe()` for clickable rows (with `inset` and `destructive` options), `useContextMenuSeparatorRecipe()` for dividers, `useContextMenuLabelRecipe()` for group headings, `useContextMenuShortcutRecipe()` for trailing keyboard hints, and `useContextMenuSubTriggerRecipe()` for rows that open a submenu. Each composable creates a fully configured [recipe](/docs/api/recipes) with color, variant (where applicable), and size options &mdash; plus compound variants that handle the color-variant combinations and interactive states automatically.
 
-The ContextMenu recipes integrate directly with the default [design tokens preset](/docs/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
+The ContextMenu recipes integrate directly with the default [design tokens preset](/docs/theme/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
 
 ## Why use the ContextMenu recipe?
 

--- a/apps/docs/content/docs/05.components/06.overlays/01.drawer.md
+++ b/apps/docs/content/docs/05.components/06.overlays/01.drawer.md
@@ -9,7 +9,7 @@ navigation:
 
 The **Drawer** is an edge-anchored, slide-out panel &mdash; often called a *sheet* &mdash; used for navigation, filters, detail views, and secondary forms that slide in from the side of the screen. It is composed of five recipe parts: `useDrawerRecipe()` for the container, `useDrawerHeaderRecipe()` for the top section with a bottom separator, `useDrawerBodyRecipe()` for the main content area, `useDrawerFooterRecipe()` for the bottom section with right-aligned actions, and `useDrawerOverlayRecipe()` for the full-screen backdrop. Each composable creates a fully configured [recipe](/docs/api/recipes) with color, variant, size, and `side` options &mdash; plus compound variants that handle the color-variant combinations and per-side dimensions automatically.
 
-A Drawer is essentially a [Modal](/docs/components/overlays/modal) anchored to a screen edge: it shares the same neutral surface colors, visual styles, and section structure, but instead of centering, the panel pins itself to the `top`, `right`, `bottom`, or `left` of the viewport. The Drawer recipes integrate directly with the default [design tokens preset](/docs/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
+A Drawer is essentially a [Modal](/docs/theme/components/modal) anchored to a screen edge: it shares the same neutral surface colors, visual styles, and section structure, but instead of centering, the panel pins itself to the `top`, `right`, `bottom`, or `left` of the viewport. The Drawer recipes integrate directly with the default [design tokens preset](/docs/theme/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
 
 ## Why use the Drawer recipe?
 
@@ -360,7 +360,7 @@ Each part is a standalone recipe with its own set of variants. The `color` and `
 ```
 
 ::tip
-**Pro tip:** The Drawer shares its header, body, footer, and overlay recipes with the [Modal](/docs/components/overlays/modal) &mdash; they are built from the same internal builders. You don't have to use all five parts. A drawer with only a body is valid for simple content.
+**Pro tip:** The Drawer shares its header, body, footer, and overlay recipes with the [Modal](/docs/theme/components/modal) &mdash; they are built from the same internal builders. You don't have to use all five parts. A drawer with only a body is valid for simple content.
 ::
 
 ## Accessibility

--- a/apps/docs/content/docs/05.components/06.overlays/02.dropdown.md
+++ b/apps/docs/content/docs/05.components/06.overlays/02.dropdown.md
@@ -9,7 +9,7 @@ navigation:
 
 The **Dropdown** is a menu-shaped floating surface that groups clickable actions, navigation links, or option lists. It is composed of five recipe parts: `useDropdownRecipe()` for the panel container, `useDropdownItemRecipe()` for clickable menu options, `useDropdownSeparatorRecipe()` for visual dividers between groups, `useDropdownLabelRecipe()` for group headings, and `useDropdownArrowRecipe()` for an optional directional indicator pointing back to the trigger. Each composable creates a fully configured [recipe](/docs/api/recipes) with color, variant (where applicable), and size options &mdash; plus compound variants that handle the color-variant combinations and interactive states automatically.
 
-The Dropdown recipes integrate directly with the default [design tokens preset](/docs/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
+The Dropdown recipes integrate directly with the default [design tokens preset](/docs/theme/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
 
 ## Why use the Dropdown recipe?
 

--- a/apps/docs/content/docs/05.components/06.overlays/03.modal.md
+++ b/apps/docs/content/docs/05.components/06.overlays/03.modal.md
@@ -9,7 +9,7 @@ navigation:
 
 The **Modal** is a dialog component used for focused interactions that require the user's attention, such as confirmations, forms, and detail views. It is composed of five recipe parts: `useModalRecipe()` for the container, `useModalHeaderRecipe()` for the top section with a bottom separator, `useModalBodyRecipe()` for the main content area, `useModalFooterRecipe()` for the bottom section with right-aligned actions, and `useModalOverlayRecipe()` for the full-screen backdrop. Each composable creates a fully configured [recipe](/docs/api/recipes) with color, variant, and size options &mdash; plus compound variants that handle the color-variant combinations automatically.
 
-The Modal recipes integrate directly with the default [design tokens preset](/docs/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
+The Modal recipes integrate directly with the default [design tokens preset](/docs/theme/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
 
 ## Why use the Modal recipe?
 

--- a/apps/docs/content/docs/05.components/06.overlays/04.popover.md
+++ b/apps/docs/content/docs/05.components/06.overlays/04.popover.md
@@ -9,7 +9,7 @@ navigation:
 
 The **Popover** is a floating container element used for contextual content triggered by user interaction. It is composed of five recipe parts: `usePopoverRecipe()` for the container, `usePopoverHeaderRecipe()` for the top section with a separator, `usePopoverBodyRecipe()` for the main content area, `usePopoverFooterRecipe()` for the bottom section with a separator, and `usePopoverArrowRecipe()` for the directional arrow. Each composable creates a fully configured [recipe](/docs/api/recipes) with color, variant, and size options &mdash; plus compound variants that handle the color-variant combinations automatically.
 
-The Popover combines the structured layout of a [Card](/docs/components/layout/card) (header, body, footer sections) with the directional arrow of a [Tooltip](/docs/components/overlays/tooltip). The recipes integrate directly with the default [design tokens preset](/docs/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
+The Popover combines the structured layout of a [Card](/docs/theme/components/card) (header, body, footer sections) with the directional arrow of a [Tooltip](/docs/theme/components/tooltip). The recipes integrate directly with the default [design tokens preset](/docs/theme/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
 
 ## Why use the Popover recipe?
 

--- a/apps/docs/content/docs/05.components/06.overlays/05.tooltip.md
+++ b/apps/docs/content/docs/05.components/06.overlays/05.tooltip.md
@@ -9,7 +9,7 @@ navigation:
 
 The **Tooltip** is a floating label element used for supplementary context shown on hover or focus. It is composed of two recipe parts: `useTooltipRecipe()` for the content bubble and `useTooltipArrowRecipe()` for the directional arrow. Each composable creates a fully configured [recipe](/docs/api/recipes) with color and variant options &mdash; plus compound variants that handle the color-variant combinations automatically. The content recipe adds a size axis for font size and padding control, while the arrow recipe uses a CSS variable for dimension control.
 
-The Tooltip recipes integrate directly with the default [design tokens preset](/docs/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
+The Tooltip recipes integrate directly with the default [design tokens preset](/docs/theme/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
 
 ## Why use the Tooltip recipe?
 
@@ -316,7 +316,7 @@ The `color` and `variant` props should be passed consistently to both recipes so
 ```
 
 - **Allow dismissal with Escape.** Users should be able to dismiss the tooltip by pressing Escape without moving focus ([WCAG 1.4.13](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html)).
-- **Keep content concise.** Tooltips are for supplementary information, not essential content. If the information is critical, use an inline label or a [callout](/docs/components/feedback/callout) instead.
+- **Keep content concise.** Tooltips are for supplementary information, not essential content. If the information is critical, use an inline label or a [callout](/docs/theme/components/callout) instead.
 - **Verify contrast ratios.** The `solid` variant with `dark` color places light text on a dark background. Default tokens meet WCAG AA 4.5:1 contrast. If you override colors, verify with the [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/).
 
 ## Customization

--- a/apps/docs/content/docs/05.components/07.layout/00.accordion.md
+++ b/apps/docs/content/docs/05.components/07.layout/00.accordion.md
@@ -9,7 +9,7 @@ navigation:
 
 The **Accordion** is a vertically stacked set of disclosure panels &mdash; each one expands to reveal its content and collapses to hide it. It is composed of five recipe parts: `useAccordionRecipe()` for the root container, `useAccordionItemRecipe()` for each panel and its divider, `useAccordionTriggerRecipe()` for the clickable header button, `useAccordionContentRecipe()` for the animated height wrapper, and `useAccordionBodyRecipe()` for the padded inner content. Each composable creates a fully configured [recipe](/docs/api/recipes) with color, variant, and size options &mdash; plus compound variants that handle the color-variant combinations automatically.
 
-The Accordion recipes integrate directly with the default [design tokens preset](/docs/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS. The open/close animation is pure CSS &mdash; the content wrapper animates `grid-template-rows` from `0fr` to `1fr` based on a `data-state` attribute, so there is no JavaScript height measurement.
+The Accordion recipes integrate directly with the default [design tokens preset](/docs/theme/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS. The open/close animation is pure CSS &mdash; the content wrapper animates `grid-template-rows` from `0fr` to `1fr` based on a `data-state` attribute, so there is no JavaScript height measurement.
 
 ## Why use the Accordion recipe?
 

--- a/apps/docs/content/docs/05.components/07.layout/01.avatar.md
+++ b/apps/docs/content/docs/05.components/07.layout/01.avatar.md
@@ -7,9 +7,9 @@ navigation:
 
 ## Overview
 
-The **Avatar** represents a user or entity with an image, falling back to initials when no image is available or the image fails to load. The `useAvatarRecipe()` composable creates a fully configured [recipe](/docs/api/recipes) with color, variant, shape, and size options, while `useAvatarBadgeRecipe()` adds a small status dot for presence indicators. For stacked, overlapping avatars, see the [Avatar Group](/docs/components/layout/avatar-group) recipe.
+The **Avatar** represents a user or entity with an image, falling back to initials when no image is available or the image fails to load. The `useAvatarRecipe()` composable creates a fully configured [recipe](/docs/api/recipes) with color, variant, shape, and size options, while `useAvatarBadgeRecipe()` adds a small status dot for presence indicators. For stacked, overlapping avatars, see the [Avatar Group](/docs/theme/components/avatar-group) recipe.
 
-The Avatar recipe integrates directly with the default [design tokens preset](/docs/design-tokens/preset) and generates type-safe utility classes at build time with zero runtime CSS.
+The Avatar recipe integrates directly with the default [design tokens preset](/docs/theme/design-tokens/preset) and generates type-safe utility classes at build time with zero runtime CSS.
 
 ## Why use the Avatar recipe?
 
@@ -370,7 +370,7 @@ Yes. Pick a `color` per user (e.g. derive it from a hash of their name) and pass
 :::
 
 :::accordion-item{label="How do I stack multiple avatars?" icon="i-lucide-circle-help"}
-Use the [Avatar Group](/docs/components/layout/avatar-group) recipe, which overlaps avatars, adds a ring to separate them, and supports a "+N" overflow count.
+Use the [Avatar Group](/docs/theme/components/avatar-group) recipe, which overlaps avatars, adds a ring to separate them, and supports a "+N" overflow count.
 :::
 
 ::

--- a/apps/docs/content/docs/05.components/07.layout/02.avatar-group.md
+++ b/apps/docs/content/docs/05.components/07.layout/02.avatar-group.md
@@ -7,9 +7,9 @@ navigation:
 
 ## Overview
 
-The **Avatar Group** lays out multiple [Avatar](/docs/components/layout/avatar) items in an overlapping stack — useful for showing the members of a team, project, or conversation in a compact space. The `useAvatarGroupRecipe()` composable creates a [recipe](/docs/api/recipes) that overlaps its avatar children, draws a ring (in the page background color) around each so they read as separate, and exposes a size axis that controls the overlap amount.
+The **Avatar Group** lays out multiple [Avatar](/docs/theme/components/avatar) items in an overlapping stack — useful for showing the members of a team, project, or conversation in a compact space. The `useAvatarGroupRecipe()` composable creates a [recipe](/docs/api/recipes) that overlaps its avatar children, draws a ring (in the page background color) around each so they read as separate, and exposes a size axis that controls the overlap amount.
 
-The recipe coordinates its children with CSS only — it targets `> .avatar` items directly, so any standard [Avatar](/docs/components/layout/avatar) becomes a stack member with no extra wiring. A trailing "+N" overflow indicator is simply another avatar.
+The recipe coordinates its children with CSS only — it targets `> .avatar` items directly, so any standard [Avatar](/docs/theme/components/avatar) becomes a stack member with no extra wiring. A trailing "+N" overflow indicator is simply another avatar.
 
 ## Why use the Avatar Group recipe?
 

--- a/apps/docs/content/docs/05.components/07.layout/03.card.md
+++ b/apps/docs/content/docs/05.components/07.layout/03.card.md
@@ -9,7 +9,7 @@ navigation:
 
 The **Card** is a structured container element used for grouping related content into a visually distinct surface. It is composed of four recipe parts: `useCardRecipe()` for the container, `useCardHeaderRecipe()` for the top section with a bottom separator, `useCardBodyRecipe()` for the main content area, and `useCardFooterRecipe()` for the bottom section with a top separator. Each composable creates a fully configured [recipe](/docs/api/recipes) with color, variant, and size options &mdash; plus compound variants that handle the color-variant combinations automatically.
 
-The Card recipes integrate directly with the default [design tokens preset](/docs/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
+The Card recipes integrate directly with the default [design tokens preset](/docs/theme/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
 
 ## Why use the Card recipe?
 

--- a/apps/docs/content/docs/05.components/07.layout/04.media.md
+++ b/apps/docs/content/docs/05.components/07.layout/04.media.md
@@ -9,7 +9,7 @@ navigation:
 
 The **Media** is a layout primitive used to align visual content (image, avatar, icon) with adjacent text content &mdash; the canonical "media object" pattern popularized by Bootstrap. It is composed of four recipe parts: `useMediaRecipe()` for the flex container, `useMediaFigureRecipe()` for the visual holder, `useMediaBodyRecipe()` for the text container, and `useMediaTitleRecipe()` for the heading. Each composable creates a fully configured [recipe](/docs/api/recipes) with its own variant axes &mdash; no color or surface styling, so the Media composes cleanly inside other containers like Card or Callout.
 
-The Media recipes integrate directly with the default [design tokens preset](/docs/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
+The Media recipes integrate directly with the default [design tokens preset](/docs/theme/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
 
 ## Why use the Media recipe?
 
@@ -453,7 +453,7 @@ Creates the media title recipe for heading typography. The base styles set semib
 - **Pass `size` to every part**: The container, figure, body, and title each control their own size-scaled property. Pass the same `size` value to all four for visually consistent results.
 - **Use `align: "start"` for comments and posts**: Top-aligning the avatar with the title is the most readable pattern when the body has multiple lines of text. Reserve `center` for single-line list items.
 - **Pick a meaningful heading element**: `useMediaTitleRecipe` only styles typography &mdash; choose `<h3>` or `<h4>` based on where the media sits in your document outline.
-- **Use `vertical` orientation sparingly**: Vertical media is essentially a card-like figure-on-top layout. If your design needs that pattern, also consider whether [`useCardRecipe`](/docs/components/layout/card) is a better fit.
+- **Use `vertical` orientation sparingly**: Vertical media is essentially a card-like figure-on-top layout. If your design needs that pattern, also consider whether [`useCardRecipe`](/docs/theme/components/card) is a better fit.
 - **Don't add background or border to the Media root**: Media is layout-only by design. Wrap it inside a Card, Callout, or other container if you need surface styling &mdash; this keeps composition predictable.
 - **Filter what you don't need**: If your component only uses one orientation or alignment, pass a `filter` option to reduce generated CSS.
 - **Reduce `size` for nested replies**: When nesting Media inside Media (comment threads, reply chains), drop the nested media's `size` to `sm` so the indentation hierarchy reads at a glance.

--- a/apps/docs/content/docs/05.components/07.layout/05.page-hero.md
+++ b/apps/docs/content/docs/05.components/07.layout/05.page-hero.md
@@ -9,7 +9,7 @@ navigation:
 
 The **PageHero** is a multi-part landing-section primitive used for the introduction at the top of a marketing or product page. It is composed of eight recipe parts: `usePageHeroRecipe()` for the `<section>` container, `usePageHeroBodyRecipe()` for the flex column that groups the headline, actions, and links, `usePageHeroHeadlineRecipe()` for the wrapper around eyebrow/title/description, `usePageHeroTitleRecipe()` and `usePageHeroDescriptionRecipe()` for the typography, `usePageHeroActionsRecipe()` and `usePageHeroLinksRecipe()` for the call-to-action groups, and `usePageHeroImageRecipe()` for the media slot. Each composable creates a fully configured [recipe](/docs/api/recipes) with its own variant axes &mdash; the container exposes color, size, orientation, and alignment, while sub-parts inherit a focused subset.
 
-The PageHero recipes integrate directly with the default [design tokens preset](/docs/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
+The PageHero recipes integrate directly with the default [design tokens preset](/docs/theme/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
 
 ## Why use the PageHero recipe?
 
@@ -212,7 +212,7 @@ panel: true
 
 ## Colors
 
-The PageHero recipe includes 3 color variants: `light`, `dark`, and `neutral`. Like the [Card](/docs/components/layout/card) recipe, the PageHero uses neutral-spectrum colors designed for full-bleed content surfaces rather than status communication. Color is applied via compound variants on the root container and inherited by sub-parts through CSS `color: inherit`.
+The PageHero recipe includes 3 color variants: `light`, `dark`, and `neutral`. Like the [Card](/docs/theme/components/card) recipe, the PageHero uses neutral-spectrum colors designed for full-bleed content surfaces rather than status communication. Color is applied via compound variants on the root container and inherited by sub-parts through CSS `color: inherit`.
 
 The `neutral` color adapts automatically: it uses a light appearance in light mode and a dark appearance in dark mode, making it the safest default for general-purpose hero sections.
 
@@ -337,7 +337,7 @@ The PageHero recipe is composed of eight independent recipes that work together 
 ```
 
 ::tip
-**Pro tip:** No dedicated eyebrow recipe is shipped because the existing [Badge](/docs/components/feedback/badge) recipe already covers that use case. Drop a `<Badge color="primary" variant="soft" size="sm">` inside the headline above the title for the "What's new" pattern.
+**Pro tip:** No dedicated eyebrow recipe is shipped because the existing [Badge](/docs/theme/components/badge) recipe already covers that use case. Drop a `<Badge color="primary" variant="soft" size="sm">` inside the headline above the title for the "What's new" pattern.
 ::
 
 ## Accessibility
@@ -537,7 +537,7 @@ Hero sections are layout-driven, not surface-driven. The visual style of a hero 
 :::
 
 :::accordion-item{label="Where does the eyebrow / 'What's new' tag come from?" icon="i-lucide-circle-help"}
-The PageHero family does not ship a dedicated eyebrow recipe. Use the existing [Badge](/docs/components/feedback/badge) recipe and place it inside the `Headline` above the `Title`. This avoids duplicating Badge's full color and variant matrix in a single-purpose sub-recipe.
+The PageHero family does not ship a dedicated eyebrow recipe. Use the existing [Badge](/docs/theme/components/badge) recipe and place it inside the `Headline` above the `Title`. This avoids duplicating Badge's full color and variant matrix in a single-purpose sub-recipe.
 :::
 
 :::accordion-item{label="How do compound variants work in the PageHero recipe?" icon="i-lucide-circle-help"}

--- a/apps/docs/content/docs/05.components/07.layout/06.placeholder.md
+++ b/apps/docs/content/docs/05.components/07.layout/06.placeholder.md
@@ -9,7 +9,7 @@ navigation:
 
 The **Placeholder** is a visual container element used for layout prototyping, wireframing, and representing areas where content will eventually appear. It uses a single recipe: `usePlaceholderRecipe()` which creates a centered flex container with a dashed border and a subtle hatch background pattern. The recipe has no variant axes &mdash; it provides a single, consistent appearance with automatic dark mode support.
 
-The Placeholder recipe integrates directly with the default [design tokens preset](/docs/design-tokens/preset) and generates type-safe utility classes at build time with zero runtime CSS.
+The Placeholder recipe integrates directly with the default [design tokens preset](/docs/theme/design-tokens/preset) and generates type-safe utility classes at build time with zero runtime CSS.
 
 ## Why use the Placeholder recipe?
 

--- a/apps/docs/content/docs/05.components/08.ai-chat/00.chat-message.md
+++ b/apps/docs/content/docs/05.components/08.ai-chat/00.chat-message.md
@@ -9,7 +9,7 @@ navigation:
 
 The **ChatMessage** is a chat-bubble container used to render a single turn in an AI chat transcript. It is composed of four recipe parts: `useChatMessageRecipe()` for the side-aware root wrapper, `useChatMessageAvatarRecipe()` for the leading avatar slot, `useChatMessageContentRecipe()` for the bubble itself, and `useChatMessageActionsRecipe()` for the hover-revealed action row beneath the bubble. Each composable creates a fully configured [recipe](/docs/api/recipes) with color, variant, and size options &mdash; plus compound variants on the content recipe that handle every color-variant combination automatically.
 
-The ChatMessage recipes integrate directly with the default [design tokens preset](/docs/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
+The ChatMessage recipes integrate directly with the default [design tokens preset](/docs/theme/design-tokens/preset) and generate type-safe utility classes at build time with zero runtime CSS.
 
 ## Why use the ChatMessage recipe?
 

--- a/apps/docs/content/docs/06.utilities/00.index.md
+++ b/apps/docs/content/docs/06.utilities/00.index.md
@@ -134,7 +134,7 @@ export default s;
 
 The preset enables recipe auto-generation and returns creator functions for defining specific utility values when needed.
 
-[Learn more about Utility Presets →](/docs/utilities/preset)
+[Learn more about Utility Presets →](/docs/theme/utilities/preset)
 
 ## Utilities
 
@@ -149,7 +149,7 @@ Utilities for accessibility features like screen reader visibility and forced co
 - **`useSrOnlyUtility()`**: Visually hide content while keeping it accessible
 - **`useNotSrOnlyUtility()`**: Undo screen-reader-only styles
 
-[Learn more about Accessibility Utilities →](/docs/utilities/accessibility)
+[Learn more about Accessibility Utilities →](/docs/theme/utilities/accessibility)
 
 ### Animations
 
@@ -158,7 +158,7 @@ Utilities for CSS animations.
 **Available composables:**
 - **`useAnimationUtility()`**: Apply CSS animations
 
-[Learn more about Animations Utilities →](/docs/utilities/animations)
+[Learn more about Animations Utilities →](/docs/theme/utilities/animations)
 
 ### Backgrounds
 
@@ -174,7 +174,7 @@ Utilities for controlling background properties.
 - **`useBackgroundClipUtility()`**: Control background clipping
 - **`useBackgroundOriginUtility()`**: Set background origin
 
-[Learn more about Background Utilities →](/docs/utilities/backgrounds)
+[Learn more about Background Utilities →](/docs/theme/utilities/backgrounds)
 
 ### Borders
 
@@ -189,7 +189,7 @@ Utilities for borders, outlines, dividers, and focus rings.
 - **`useOutlineUtility()`**: Control outline styles
 - **`useRingUtility()`**: Create focus rings
 
-[Learn more about Border Utilities →](/docs/utilities/borders)
+[Learn more about Border Utilities →](/docs/theme/utilities/borders)
 
 ### Effects
 
@@ -203,7 +203,7 @@ Utilities for visual effects like shadows, opacity, and blend modes.
 - **`useMixBlendModeUtility()`**: Set blend modes
 - **`useBackgroundBlendModeUtility()`**: Control background blending
 
-[Learn more about Effect Utilities →](/docs/utilities/effects)
+[Learn more about Effect Utilities →](/docs/theme/utilities/effects)
 
 ### Filters
 
@@ -221,7 +221,7 @@ Utilities for CSS filter effects and backdrop filters.
 - **`useDropShadowUtility()`**: Add drop shadows
 - **`useBackdropBlurUtility()`**: Blur backdrop (+ other backdrop filters)
 
-[Learn more about Filter Utilities →](/docs/utilities/filters)
+[Learn more about Filter Utilities →](/docs/theme/utilities/filters)
 
 ### Flexbox & Grid
 
@@ -237,7 +237,7 @@ Utilities for flexbox and grid layout systems.
 - **`useAlignUtility()`**, **`useJustifyUtility()`**, **`usePlaceUtility()`**: Alignment utilities
 - **`useOrderUtility()`**: Control item order
 
-[Learn more about Flexbox & Grid Utilities →](/docs/utilities/flexbox-grid)
+[Learn more about Flexbox & Grid Utilities →](/docs/theme/utilities/flexbox-grid)
 
 ### Interactivity
 
@@ -252,7 +252,7 @@ Utilities for user interaction properties.
 - **`useResizeUtility()`**: Enable element resizing
 - **`useAccentColorUtility()`**, **`useCaretColorUtility()`**: Form element colors
 
-[Learn more about Interactivity Utilities →](/docs/utilities/interactivity)
+[Learn more about Interactivity Utilities →](/docs/theme/utilities/interactivity)
 
 ### Layout
 
@@ -268,7 +268,7 @@ Utilities for element layout and positioning.
 - **`useAspectRatioUtility()`**: Set aspect ratios
 - **`useColumnsUtility()`**: Multi-column layouts
 
-[Learn more about Layout Utilities →](/docs/utilities/layout)
+[Learn more about Layout Utilities →](/docs/theme/utilities/layout)
 
 ### Sizing
 
@@ -279,7 +279,7 @@ Utilities for width and height properties.
 - **`useHeightUtility()`**, **`useMinHeightUtility()`**, **`useMaxHeightUtility()`**: Height control
 - **`useSizeUtility()`**: Set both dimensions at once
 
-[Learn more about Sizing Utilities →](/docs/utilities/sizing)
+[Learn more about Sizing Utilities →](/docs/theme/utilities/sizing)
 
 ### Spacing
 
@@ -290,7 +290,7 @@ Utilities for margin and padding.
 - **`usePaddingUtility()`**: Set padding (+ directional variants like `-x`, `-y`, `-inline`, `-block`)
 - **`useSpaceUtility()`**: Space between children
 
-[Learn more about Spacing Utilities →](/docs/utilities/spacing)
+[Learn more about Spacing Utilities →](/docs/theme/utilities/spacing)
 
 ### SVG
 
@@ -301,7 +301,7 @@ Utilities for SVG-specific properties.
 - **`useStrokeUtility()`**: Set SVG stroke color
 - **`useStrokeWidthUtility()`**: Control stroke width
 
-[Learn more about SVG Utilities →](/docs/utilities/svg)
+[Learn more about SVG Utilities →](/docs/theme/utilities/svg)
 
 ### Tables
 
@@ -313,7 +313,7 @@ Utilities for table layout properties.
 - **`useTableLayoutUtility()`**: Set table layout algorithm
 - **`useCaptionSideUtility()`**: Position table captions
 
-[Learn more about Table Utilities →](/docs/utilities/tables)
+[Learn more about Table Utilities →](/docs/theme/utilities/tables)
 
 ### Transforms
 
@@ -327,7 +327,7 @@ Utilities for CSS transforms.
 - **`useTransformOriginUtility()`**: Set transform origin
 - **`usePerspectiveUtility()`**: Set 3D perspective
 
-[Learn more about Transform Utilities →](/docs/utilities/transforms)
+[Learn more about Transform Utilities →](/docs/theme/utilities/transforms)
 
 ### Transitions
 
@@ -339,7 +339,7 @@ Utilities for transitions.
 - **`useTransitionTimingFunctionUtility()`**: Set easing functions
 - **`useTransitionDelayUtility()`**: Set transition delays
 
-[Learn more about Transitions Utilities →](/docs/utilities/transitions)
+[Learn more about Transitions Utilities →](/docs/theme/utilities/transitions)
 
 ### Typography
 
@@ -354,7 +354,7 @@ Utilities for text and font styling.
 - **`useTextTransformUtility()`**: Transform text case
 - **`useLineClampUtility()`**: Truncate text with ellipsis
 
-[Learn more about Typography Utilities →](/docs/utilities/typography)
+[Learn more about Typography Utilities →](/docs/theme/utilities/typography)
 
 ## Utility Reference
 
@@ -390,11 +390,11 @@ Utilities for text and font styling.
 
 Ready to start using utilities? Begin with these common categories:
 
-- **Building layouts?** Start with [Layout](/docs/utilities/layout) and [Flexbox & Grid](/docs/utilities/flexbox-grid)
-- **Styling text?** Check out [Typography](/docs/utilities/typography)
-- **Adding spacing?** Explore [Spacing](/docs/utilities/spacing) and [Sizing](/docs/utilities/sizing)
-- **Creating effects?** Look at [Effects](/docs/utilities/effects) and [Filters](/docs/utilities/filters)
-- **Adding interactivity?** Explore [Modifiers](/docs/modifiers) for hover, focus, and more
-- **Auto-generating CSS?** Learn how the [Scanner](/docs/tooling/scanner) detects classes in your source files
+- **Building layouts?** Start with [Layout](/docs/theme/utilities/layout) and [Flexbox & Grid](/docs/theme/utilities/flexbox-grid)
+- **Styling text?** Check out [Typography](/docs/theme/utilities/typography)
+- **Adding spacing?** Explore [Spacing](/docs/theme/utilities/spacing) and [Sizing](/docs/theme/utilities/sizing)
+- **Creating effects?** Look at [Effects](/docs/theme/utilities/effects) and [Filters](/docs/theme/utilities/filters)
+- **Adding interactivity?** Explore [Modifiers](/docs/theme/modifiers) for hover, focus, and more
+- **Auto-generating CSS?** Learn how the [Scanner](/docs/getting-started/tooling/scanner) detects classes in your source files
 
 Each utility composable is designed to work seamlessly with Styleframe's design tokens and theming system.

--- a/apps/docs/content/docs/06.utilities/01.preset.md
+++ b/apps/docs/content/docs/06.utilities/01.preset.md
@@ -327,7 +327,7 @@ This generates utility classes like `_margin:sm`, `_padding:md`, `_gap:lg` that 
 
 The preset registers utility factories for all CSS property categories. Here's a complete breakdown:
 
-### [Accessibility](/docs/utilities/accessibility)
+### [Accessibility](/docs/theme/utilities/accessibility)
 
 | Creator Function | CSS Property | Class Pattern |
 |-----------------|--------------|---------------|
@@ -335,7 +335,7 @@ The preset registers utility factories for all CSS property categories. Here's a
 | `createSrOnlyUtility` | (multiple) | `_sr-only:*` |
 | `createNotSrOnlyUtility` | (multiple) | `_not-sr-only:*` |
 
-### [Backgrounds](/docs/utilities/backgrounds)
+### [Backgrounds](/docs/theme/utilities/backgrounds)
 
 | Creator Function | CSS Property | Class Pattern |
 |-----------------|--------------|---------------|
@@ -352,7 +352,7 @@ The preset registers utility factories for all CSS property categories. Here's a
 | `createGradientToUtility` | `gradient-to` | `_gradient-to:*` |
 | `createGradientViaUtility` | `gradient-via` | `_gradient-via:*` |
 
-### [Borders](/docs/utilities/borders)
+### [Borders](/docs/theme/utilities/borders)
 
 | Creator Function | CSS Property | Class Pattern |
 |-----------------|--------------|---------------|
@@ -406,7 +406,7 @@ The preset registers utility factories for all CSS property categories. Here's a
 | `createRingOffsetWidthUtility` | `ring-offset-width` | `_ring-offset-width:*` |
 | `createRingWidthUtility` | `box-shadow` (ring) | `_ring-width:*` |
 
-### [Effects](/docs/utilities/effects)
+### [Effects](/docs/theme/utilities/effects)
 
 | Creator Function | CSS Property | Class Pattern |
 |-----------------|--------------|---------------|
@@ -418,7 +418,7 @@ The preset registers utility factories for all CSS property categories. Here's a
 | `createTextShadowUtility` | `text-shadow` | `_text-shadow:*` |
 | `createTextShadowColorUtility` | `text-shadow-color` | `_text-shadow-color:*` |
 
-### [Filters](/docs/utilities/filters)
+### [Filters](/docs/theme/utilities/filters)
 
 | Creator Function | CSS Property | Class Pattern |
 |-----------------|--------------|---------------|
@@ -441,7 +441,7 @@ The preset registers utility factories for all CSS property categories. Here's a
 | `createSaturateUtility` | `filter: saturate()` | `_saturate:*` |
 | `createSepiaUtility` | `filter: sepia()` | `_sepia:*` |
 
-### [Flexbox & Grid](/docs/utilities/flexbox-grid)
+### [Flexbox & Grid](/docs/theme/utilities/flexbox-grid)
 
 | Creator Function | CSS Property | Class Pattern |
 |-----------------|--------------|---------------|
@@ -476,7 +476,7 @@ The preset registers utility factories for all CSS property categories. Here's a
 | `createPlaceItemsUtility` | `place-items` | `_place-items:*` |
 | `createPlaceSelfUtility` | `place-self` | `_place-self:*` |
 
-### [Interactivity](/docs/utilities/interactivity)
+### [Interactivity](/docs/theme/utilities/interactivity)
 
 | Creator Function | CSS Property | Class Pattern |
 |-----------------|--------------|---------------|
@@ -513,7 +513,7 @@ The preset registers utility factories for all CSS property categories. Here's a
 | `createUserSelectUtility` | `user-select` | `_user-select:*` |
 | `createWillChangeUtility` | `will-change` | `_will-change:*` |
 
-### [Layout](/docs/utilities/layout)
+### [Layout](/docs/theme/utilities/layout)
 
 | Creator Function | CSS Property | Class Pattern |
 |-----------------|--------------|---------------|
@@ -549,7 +549,7 @@ The preset registers utility factories for all CSS property categories. Here's a
 | `createVisibilityUtility` | `visibility` | `_visibility:*` |
 | `createZIndexUtility` | `z-index` | `_z-index:*` |
 
-### [Sizing](/docs/utilities/sizing)
+### [Sizing](/docs/theme/utilities/sizing)
 
 | Creator Function | CSS Property | Class Pattern |
 |-----------------|--------------|---------------|
@@ -561,7 +561,7 @@ The preset registers utility factories for all CSS property categories. Here's a
 | `createSizeUtility` | `width` + `height` | `_size:*` |
 | `createWidthUtility` | `width` | `_width:*` |
 
-### [Spacing](/docs/utilities/spacing)
+### [Spacing](/docs/theme/utilities/spacing)
 
 | Creator Function | CSS Property | Class Pattern |
 |-----------------|--------------|---------------|
@@ -592,7 +592,7 @@ The preset registers utility factories for all CSS property categories. Here's a
 | `createSpaceYUtility` | `margin-top` (children) | `_space-y:*` |
 | `createSpaceYReverseUtility` | `space-y-reverse` | `_space-y-reverse:*` |
 
-### [SVG](/docs/utilities/svg)
+### [SVG](/docs/theme/utilities/svg)
 
 | Creator Function | CSS Property | Class Pattern |
 |-----------------|--------------|---------------|
@@ -600,7 +600,7 @@ The preset registers utility factories for all CSS property categories. Here's a
 | `createStrokeUtility` | `stroke` | `_stroke:*` |
 | `createStrokeWidthUtility` | `stroke-width` | `_stroke-width:*` |
 
-### [Tables](/docs/utilities/tables)
+### [Tables](/docs/theme/utilities/tables)
 
 | Creator Function | CSS Property | Class Pattern |
 |-----------------|--------------|---------------|
@@ -611,7 +611,7 @@ The preset registers utility factories for all CSS property categories. Here's a
 | `createCaptionSideUtility` | `caption-side` | `_caption-side:*` |
 | `createTableLayoutUtility` | `table-layout` | `_table-layout:*` |
 
-### [Transforms](/docs/utilities/transforms)
+### [Transforms](/docs/theme/utilities/transforms)
 
 | Creator Function | CSS Property | Class Pattern |
 |-----------------|--------------|---------------|
@@ -633,7 +633,7 @@ The preset registers utility factories for all CSS property categories. Here's a
 | `createTranslateYUtility` | `translate-y` | `_translate-y:*` |
 | `createTranslateZUtility` | `translate-z` | `_translate-z:*` |
 
-### [Transitions](/docs/utilities/transitions) & [Animation](/docs/utilities/animations)
+### [Transitions](/docs/theme/utilities/transitions) & [Animation](/docs/theme/utilities/animations)
 
 | Creator Function | CSS Property | Class Pattern |
 |-----------------|--------------|---------------|
@@ -644,7 +644,7 @@ The preset registers utility factories for all CSS property categories. Here's a
 | `createTransitionPropertyUtility` | `transition-property` | `_transition-property:*` |
 | `createTransitionTimingFunctionUtility` | `transition-timing-function` | `_transition-timing-function:*` |
 
-### [Typography](/docs/utilities/typography)
+### [Typography](/docs/theme/utilities/typography)
 
 | Creator Function | CSS Property | Class Pattern |
 |-----------------|--------------|---------------|

--- a/apps/docs/content/docs/06.utilities/02.accessibility.md
+++ b/apps/docs/content/docs/06.utilities/02.accessibility.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Utilities Preset:** The utilities on this page are registered by the [Utilities Preset](/docs/utilities/preset) (`useUtilitiesPreset`). For most projects, applying them via the preset is the recommended approach.
+**Part of the Utilities Preset:** The utilities on this page are registered by the [Utilities Preset](/docs/theme/utilities/preset) (`useUtilitiesPreset`). For most projects, applying them via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/06.utilities/03.animations.md
+++ b/apps/docs/content/docs/06.utilities/03.animations.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Utilities Preset:** The utilities on this page are registered by the [Utilities Preset](/docs/utilities/preset) (`useUtilitiesPreset`). For most projects, applying them via the preset is the recommended approach.
+**Part of the Utilities Preset:** The utilities on this page are registered by the [Utilities Preset](/docs/theme/utilities/preset) (`useUtilitiesPreset`). For most projects, applying them via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/06.utilities/04.backgrounds.md
+++ b/apps/docs/content/docs/06.utilities/04.backgrounds.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Utilities Preset:** The utilities on this page are registered by the [Utilities Preset](/docs/utilities/preset) (`useUtilitiesPreset`). For most projects, applying them via the preset is the recommended approach.
+**Part of the Utilities Preset:** The utilities on this page are registered by the [Utilities Preset](/docs/theme/utilities/preset) (`useUtilitiesPreset`). For most projects, applying them via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/06.utilities/05.borders.md
+++ b/apps/docs/content/docs/06.utilities/05.borders.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Utilities Preset:** The utilities on this page are registered by the [Utilities Preset](/docs/utilities/preset) (`useUtilitiesPreset`). For most projects, applying them via the preset is the recommended approach.
+**Part of the Utilities Preset:** The utilities on this page are registered by the [Utilities Preset](/docs/theme/utilities/preset) (`useUtilitiesPreset`). For most projects, applying them via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/06.utilities/06.effects.md
+++ b/apps/docs/content/docs/06.utilities/06.effects.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Utilities Preset:** The utilities on this page are registered by the [Utilities Preset](/docs/utilities/preset) (`useUtilitiesPreset`). For most projects, applying them via the preset is the recommended approach.
+**Part of the Utilities Preset:** The utilities on this page are registered by the [Utilities Preset](/docs/theme/utilities/preset) (`useUtilitiesPreset`). For most projects, applying them via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/06.utilities/07.filters.md
+++ b/apps/docs/content/docs/06.utilities/07.filters.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Utilities Preset:** The utilities on this page are registered by the [Utilities Preset](/docs/utilities/preset) (`useUtilitiesPreset`). For most projects, applying them via the preset is the recommended approach.
+**Part of the Utilities Preset:** The utilities on this page are registered by the [Utilities Preset](/docs/theme/utilities/preset) (`useUtilitiesPreset`). For most projects, applying them via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/06.utilities/08.flexbox-grid.md
+++ b/apps/docs/content/docs/06.utilities/08.flexbox-grid.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Utilities Preset:** The utilities on this page are registered by the [Utilities Preset](/docs/utilities/preset) (`useUtilitiesPreset`). For most projects, applying them via the preset is the recommended approach.
+**Part of the Utilities Preset:** The utilities on this page are registered by the [Utilities Preset](/docs/theme/utilities/preset) (`useUtilitiesPreset`). For most projects, applying them via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/06.utilities/09.interactivity.md
+++ b/apps/docs/content/docs/06.utilities/09.interactivity.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Utilities Preset:** The utilities on this page are registered by the [Utilities Preset](/docs/utilities/preset) (`useUtilitiesPreset`). For most projects, applying them via the preset is the recommended approach.
+**Part of the Utilities Preset:** The utilities on this page are registered by the [Utilities Preset](/docs/theme/utilities/preset) (`useUtilitiesPreset`). For most projects, applying them via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/06.utilities/10.layout.md
+++ b/apps/docs/content/docs/06.utilities/10.layout.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Utilities Preset:** The utilities on this page are registered by the [Utilities Preset](/docs/utilities/preset) (`useUtilitiesPreset`). For most projects, applying them via the preset is the recommended approach.
+**Part of the Utilities Preset:** The utilities on this page are registered by the [Utilities Preset](/docs/theme/utilities/preset) (`useUtilitiesPreset`). For most projects, applying them via the preset is the recommended approach.
 ::
 
 ## Overview
@@ -199,7 +199,7 @@ export default s;
 
 ## `useZIndexUtility`
 
-Control the stacking order of elements. For a consistent stacking scale, use the [z-index design tokens](/docs/design-tokens/z-index) which provide semantic names like `dropdown`, `modal`, and `toast`.
+Control the stacking order of elements. For a consistent stacking scale, use the [z-index design tokens](/docs/theme/design-tokens/z-index) which provide semantic names like `dropdown`, `modal`, and `toast`.
 
 ::tabs
 :::tabs-item{icon="i-lucide-code" label="Code"}

--- a/apps/docs/content/docs/06.utilities/11.sizing.md
+++ b/apps/docs/content/docs/06.utilities/11.sizing.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Utilities Preset:** The utilities on this page are registered by the [Utilities Preset](/docs/utilities/preset) (`useUtilitiesPreset`). For most projects, applying them via the preset is the recommended approach.
+**Part of the Utilities Preset:** The utilities on this page are registered by the [Utilities Preset](/docs/theme/utilities/preset) (`useUtilitiesPreset`). For most projects, applying them via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/06.utilities/12.spacing.md
+++ b/apps/docs/content/docs/06.utilities/12.spacing.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Utilities Preset:** The utilities on this page are registered by the [Utilities Preset](/docs/utilities/preset) (`useUtilitiesPreset`). For most projects, applying them via the preset is the recommended approach.
+**Part of the Utilities Preset:** The utilities on this page are registered by the [Utilities Preset](/docs/theme/utilities/preset) (`useUtilitiesPreset`). For most projects, applying them via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/06.utilities/13.svg.md
+++ b/apps/docs/content/docs/06.utilities/13.svg.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Utilities Preset:** The utilities on this page are registered by the [Utilities Preset](/docs/utilities/preset) (`useUtilitiesPreset`). For most projects, applying them via the preset is the recommended approach.
+**Part of the Utilities Preset:** The utilities on this page are registered by the [Utilities Preset](/docs/theme/utilities/preset) (`useUtilitiesPreset`). For most projects, applying them via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/06.utilities/14.tables.md
+++ b/apps/docs/content/docs/06.utilities/14.tables.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Utilities Preset:** The utilities on this page are registered by the [Utilities Preset](/docs/utilities/preset) (`useUtilitiesPreset`). For most projects, applying them via the preset is the recommended approach.
+**Part of the Utilities Preset:** The utilities on this page are registered by the [Utilities Preset](/docs/theme/utilities/preset) (`useUtilitiesPreset`). For most projects, applying them via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/06.utilities/15.transforms.md
+++ b/apps/docs/content/docs/06.utilities/15.transforms.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Utilities Preset:** The utilities on this page are registered by the [Utilities Preset](/docs/utilities/preset) (`useUtilitiesPreset`). For most projects, applying them via the preset is the recommended approach.
+**Part of the Utilities Preset:** The utilities on this page are registered by the [Utilities Preset](/docs/theme/utilities/preset) (`useUtilitiesPreset`). For most projects, applying them via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/06.utilities/16.transitions.md
+++ b/apps/docs/content/docs/06.utilities/16.transitions.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Utilities Preset:** The utilities on this page are registered by the [Utilities Preset](/docs/utilities/preset) (`useUtilitiesPreset`). For most projects, applying them via the preset is the recommended approach.
+**Part of the Utilities Preset:** The utilities on this page are registered by the [Utilities Preset](/docs/theme/utilities/preset) (`useUtilitiesPreset`). For most projects, applying them via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/06.utilities/17.typography.md
+++ b/apps/docs/content/docs/06.utilities/17.typography.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Utilities Preset:** The utilities on this page are registered by the [Utilities Preset](/docs/utilities/preset) (`useUtilitiesPreset`). For most projects, applying them via the preset is the recommended approach.
+**Part of the Utilities Preset:** The utilities on this page are registered by the [Utilities Preset](/docs/theme/utilities/preset) (`useUtilitiesPreset`). For most projects, applying them via the preset is the recommended approach.
 ::
 
 ## Overview
@@ -148,7 +148,7 @@ export default s;
 ::
 
 ::tip
-See [Fluid Typography](/docs/design-tokens/fluid-design/typography) for pairing fluid ranges with modular scales and the full `useFontSizeDesignTokens()` API.
+See [Fluid Typography](/docs/theme/design-tokens/fluid-design/typography) for pairing fluid ranges with modular scales and the full `useFontSizeDesignTokens()` API.
 ::
 
 ## `useFontFamilyUtility`

--- a/apps/docs/content/docs/07.modifiers/00.index.md
+++ b/apps/docs/content/docs/07.modifiers/00.index.md
@@ -101,7 +101,7 @@ export default s;
 
 The preset returns a flat object containing all registered modifier instances from every category.
 
-[Learn more about Modifier Presets →](/docs/modifiers/preset)
+[Learn more about Modifier Presets →](/docs/theme/modifiers/preset)
 
 ## Modifiers
 
@@ -122,7 +122,7 @@ Modifiers for targeting elements by their ARIA attribute values.
 - **`useAriaRequiredModifier()`**: Apply styles when `aria-required="true"`
 - **`useAriaSelectedModifier()`**: Apply styles when `aria-selected="true"`
 
-[Learn more about ARIA State Modifiers →](/docs/modifiers/aria-state)
+[Learn more about ARIA State Modifiers →](/docs/theme/modifiers/aria-state)
 
 ### Directional
 
@@ -132,7 +132,7 @@ Modifiers for targeting elements based on text direction (RTL/LTR).
 - **`useRtlModifier()`**: Apply styles in right-to-left contexts
 - **`useLtrModifier()`**: Apply styles in left-to-right contexts
 
-[Learn more about Directional Modifiers →](/docs/modifiers/directional)
+[Learn more about Directional Modifiers →](/docs/theme/modifiers/directional)
 
 ### Form State
 
@@ -151,7 +151,7 @@ Modifiers for form element pseudo-class states like disabled, checked, and valid
 - **`useAutofillModifier()`**: Apply styles on `:autofill`
 - **`useReadOnlyModifier()`**: Apply styles on `:read-only`
 
-[Learn more about Form State Modifiers →](/docs/modifiers/form-state)
+[Learn more about Form State Modifiers →](/docs/theme/modifiers/form-state)
 
 ### Media & Preferences
 
@@ -168,7 +168,7 @@ Modifiers for targeting user preferences and media conditions like dark mode and
 - **`usePrintModifier()`**: Apply styles for print media
 - **`useForcedColorsModifier()`**: Apply styles in forced-colors mode
 
-[Learn more about Media & Preference Modifiers →](/docs/modifiers/media-preferences)
+[Learn more about Media & Preference Modifiers →](/docs/theme/modifiers/media-preferences)
 
 ### Other State
 
@@ -178,7 +178,7 @@ Modifiers for targeting miscellaneous element states.
 - **`useOpenModifier()`**: Apply styles to open `<details>` or popover elements
 - **`useInertModifier()`**: Apply styles to inert elements and their descendants
 
-[Learn more about Other State Modifiers →](/docs/modifiers/other-state)
+[Learn more about Other State Modifiers →](/docs/theme/modifiers/other-state)
 
 ### Pseudo-Elements
 
@@ -195,7 +195,7 @@ Modifiers for targeting element sub-parts like `::before`, `::after`, and `::pla
 - **`useBackdropModifier()`**: Apply styles to `::backdrop`
 - **`useFileModifier()`**: Apply styles to `::file-selector-button`
 
-[Learn more about Pseudo-Element Modifiers →](/docs/modifiers/pseudo-elements)
+[Learn more about Pseudo-Element Modifiers →](/docs/theme/modifiers/pseudo-elements)
 
 ### Pseudo-State
 
@@ -210,7 +210,7 @@ Modifiers for interactive pseudo-class states like hover, focus, and active.
 - **`useVisitedModifier()`**: Apply styles on `:visited`
 - **`useTargetModifier()`**: Apply styles on `:target`
 
-[Learn more about Pseudo-State Modifiers →](/docs/modifiers/pseudo-state)
+[Learn more about Pseudo-State Modifiers →](/docs/theme/modifiers/pseudo-state)
 
 ### Structural
 
@@ -227,7 +227,7 @@ Modifiers for targeting elements by their position in the DOM tree.
 - **`useOnlyOfTypeModifier()`**: Apply styles to `:only-of-type`
 - **`useEmptyModifier()`**: Apply styles to `:empty`
 
-[Learn more about Structural Modifiers →](/docs/modifiers/structural)
+[Learn more about Structural Modifiers →](/docs/theme/modifiers/structural)
 
 ## Modifier Reference
 
@@ -254,10 +254,10 @@ Modifiers for targeting elements by their position in the DOM tree.
 
 Ready to start using modifiers? Begin with these common categories:
 
-- **Adding interactivity?** Start with [Pseudo-State](/docs/modifiers/pseudo-state) for hover, focus, and active states
-- **Building forms?** Check out [Form State](/docs/modifiers/form-state) for disabled, checked, and validation states
-- **Supporting dark mode?** Explore [Media & Preferences](/docs/modifiers/media-preferences) for color scheme and motion preferences
-- **Styling sub-elements?** Look at [Pseudo-Elements](/docs/modifiers/pseudo-elements) for before, after, and placeholder
-- **Building lists?** Explore [Structural](/docs/modifiers/structural) for first, last, odd, and even
+- **Adding interactivity?** Start with [Pseudo-State](/docs/theme/modifiers/pseudo-state) for hover, focus, and active states
+- **Building forms?** Check out [Form State](/docs/theme/modifiers/form-state) for disabled, checked, and validation states
+- **Supporting dark mode?** Explore [Media & Preferences](/docs/theme/modifiers/media-preferences) for color scheme and motion preferences
+- **Styling sub-elements?** Look at [Pseudo-Elements](/docs/theme/modifiers/pseudo-elements) for before, after, and placeholder
+- **Building lists?** Explore [Structural](/docs/theme/modifiers/structural) for first, last, odd, and even
 
 Each modifier composable is designed to work seamlessly with Styleframe's utility system and theming.

--- a/apps/docs/content/docs/07.modifiers/01.preset.md
+++ b/apps/docs/content/docs/07.modifiers/01.preset.md
@@ -104,14 +104,14 @@ Each modifier category can be configured as:
 
 | Option | Composable | Type | Default | Description |
 |--------|------------|------|---------|-------------|
-| [`pseudoStates`](/docs/modifiers/pseudo-state) | `usePseudoStateModifiers` | `boolean` | `true` | Pseudo-class state modifiers (`hover`, `focus`, `active`, etc.) |
-| [`formStates`](/docs/modifiers/form-state) | `useFormStateModifiers` | `boolean` | `true` | Form state modifiers (`disabled`, `checked`, `valid`, etc.) |
-| [`structural`](/docs/modifiers/structural) | `useStructuralModifiers` | `boolean` | `true` | Structural pseudo-class modifiers (`first`, `last`, `odd`, `even`, etc.) |
-| [`pseudoElements`](/docs/modifiers/pseudo-elements) | `usePseudoElementModifiers` | `boolean` | `true` | Pseudo-element modifiers (`before`, `after`, `placeholder`, etc.) |
-| [`mediaPreferences`](/docs/modifiers/media-preferences) | `useMediaPreferenceModifiers` | `boolean` | `true` | Media/preference query modifiers (`dark`, `motionSafe`, `print`, etc.) |
-| [`ariaStates`](/docs/modifiers/aria-state) | `useAriaStateModifiers` | `boolean` | `true` | ARIA state modifiers (`ariaExpanded`, `ariaDisabled`, etc.) |
-| [`directional`](/docs/modifiers/directional) | `useDirectionalModifiers` | `boolean` | `true` | Directional modifiers (`rtl`, `ltr`) |
-| [`otherStates`](/docs/modifiers/other-state) | `useOtherStateModifiers` | `boolean` | `true` | Other state modifiers (`open`, `inert`) |
+| [`pseudoStates`](/docs/theme/modifiers/pseudo-state) | `usePseudoStateModifiers` | `boolean` | `true` | Pseudo-class state modifiers (`hover`, `focus`, `active`, etc.) |
+| [`formStates`](/docs/theme/modifiers/form-state) | `useFormStateModifiers` | `boolean` | `true` | Form state modifiers (`disabled`, `checked`, `valid`, etc.) |
+| [`structural`](/docs/theme/modifiers/structural) | `useStructuralModifiers` | `boolean` | `true` | Structural pseudo-class modifiers (`first`, `last`, `odd`, `even`, etc.) |
+| [`pseudoElements`](/docs/theme/modifiers/pseudo-elements) | `usePseudoElementModifiers` | `boolean` | `true` | Pseudo-element modifiers (`before`, `after`, `placeholder`, etc.) |
+| [`mediaPreferences`](/docs/theme/modifiers/media-preferences) | `useMediaPreferenceModifiers` | `boolean` | `true` | Media/preference query modifiers (`dark`, `motionSafe`, `print`, etc.) |
+| [`ariaStates`](/docs/theme/modifiers/aria-state) | `useAriaStateModifiers` | `boolean` | `true` | ARIA state modifiers (`ariaExpanded`, `ariaDisabled`, etc.) |
+| [`directional`](/docs/theme/modifiers/directional) | `useDirectionalModifiers` | `boolean` | `true` | Directional modifiers (`rtl`, `ltr`) |
+| [`otherStates`](/docs/theme/modifiers/other-state) | `useOtherStateModifiers` | `boolean` | `true` | Other state modifiers (`open`, `inert`) |
 
 ### Return Value
 

--- a/apps/docs/content/docs/07.modifiers/02.aria-state.md
+++ b/apps/docs/content/docs/07.modifiers/02.aria-state.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Modifiers Preset:** `useAriaStateModifiers` is included in the [Modifiers Preset](/docs/modifiers/preset) (`useModifiersPreset`) and you can configure it through the preset's `ariaStates` option. For most projects, applying it via the preset is the recommended approach.
+**Part of the Modifiers Preset:** `useAriaStateModifiers` is included in the [Modifiers Preset](/docs/theme/modifiers/preset) (`useModifiersPreset`) and you can configure it through the preset's `ariaStates` option. For most projects, applying it via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/07.modifiers/03.directional.md
+++ b/apps/docs/content/docs/07.modifiers/03.directional.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Modifiers Preset:** `useDirectionalModifiers` is included in the [Modifiers Preset](/docs/modifiers/preset) (`useModifiersPreset`) and you can configure it through the preset's `directional` option. For most projects, applying it via the preset is the recommended approach.
+**Part of the Modifiers Preset:** `useDirectionalModifiers` is included in the [Modifiers Preset](/docs/theme/modifiers/preset) (`useModifiersPreset`) and you can configure it through the preset's `directional` option. For most projects, applying it via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/07.modifiers/04.form-state.md
+++ b/apps/docs/content/docs/07.modifiers/04.form-state.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Modifiers Preset:** `useFormStateModifiers` is included in the [Modifiers Preset](/docs/modifiers/preset) (`useModifiersPreset`) and you can configure it through the preset's `formStates` option. For most projects, applying it via the preset is the recommended approach.
+**Part of the Modifiers Preset:** `useFormStateModifiers` is included in the [Modifiers Preset](/docs/theme/modifiers/preset) (`useModifiersPreset`) and you can configure it through the preset's `formStates` option. For most projects, applying it via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/07.modifiers/05.media-preferences.md
+++ b/apps/docs/content/docs/07.modifiers/05.media-preferences.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Modifiers Preset:** `useMediaPreferenceModifiers` is included in the [Modifiers Preset](/docs/modifiers/preset) (`useModifiersPreset`) and you can configure it through the preset's `mediaPreferences` option. For most projects, applying it via the preset is the recommended approach.
+**Part of the Modifiers Preset:** `useMediaPreferenceModifiers` is included in the [Modifiers Preset](/docs/theme/modifiers/preset) (`useModifiersPreset`) and you can configure it through the preset's `mediaPreferences` option. For most projects, applying it via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/07.modifiers/06.other-state.md
+++ b/apps/docs/content/docs/07.modifiers/06.other-state.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Modifiers Preset:** `useOtherStateModifiers` is included in the [Modifiers Preset](/docs/modifiers/preset) (`useModifiersPreset`) and you can configure it through the preset's `otherStates` option. For most projects, applying it via the preset is the recommended approach.
+**Part of the Modifiers Preset:** `useOtherStateModifiers` is included in the [Modifiers Preset](/docs/theme/modifiers/preset) (`useModifiersPreset`) and you can configure it through the preset's `otherStates` option. For most projects, applying it via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/07.modifiers/07.pseudo-elements.md
+++ b/apps/docs/content/docs/07.modifiers/07.pseudo-elements.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Modifiers Preset:** `usePseudoElementModifiers` is included in the [Modifiers Preset](/docs/modifiers/preset) (`useModifiersPreset`) and you can configure it through the preset's `pseudoElements` option. For most projects, applying it via the preset is the recommended approach.
+**Part of the Modifiers Preset:** `usePseudoElementModifiers` is included in the [Modifiers Preset](/docs/theme/modifiers/preset) (`useModifiersPreset`) and you can configure it through the preset's `pseudoElements` option. For most projects, applying it via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/07.modifiers/08.pseudo-state.md
+++ b/apps/docs/content/docs/07.modifiers/08.pseudo-state.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Modifiers Preset:** `usePseudoStateModifiers` is included in the [Modifiers Preset](/docs/modifiers/preset) (`useModifiersPreset`) and you can configure it through the preset's `pseudoStates` option. For most projects, applying it via the preset is the recommended approach.
+**Part of the Modifiers Preset:** `usePseudoStateModifiers` is included in the [Modifiers Preset](/docs/theme/modifiers/preset) (`useModifiersPreset`) and you can configure it through the preset's `pseudoStates` option. For most projects, applying it via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/07.modifiers/09.structural.md
+++ b/apps/docs/content/docs/07.modifiers/09.structural.md
@@ -7,7 +7,7 @@ navigation:
 ---
 
 ::note{icon="i-lucide-package"}
-**Part of the Modifiers Preset:** `useStructuralModifiers` is included in the [Modifiers Preset](/docs/modifiers/preset) (`useModifiersPreset`) and you can configure it through the preset's `structural` option. For most projects, applying it via the preset is the recommended approach.
+**Part of the Modifiers Preset:** `useStructuralModifiers` is included in the [Modifiers Preset](/docs/theme/modifiers/preset) (`useModifiersPreset`) and you can configure it through the preset's `structural` option. For most projects, applying it via the preset is the recommended approach.
 ::
 
 ## Overview

--- a/apps/docs/content/docs/08.tooling/01.cli.md
+++ b/apps/docs/content/docs/08.tooling/01.cli.md
@@ -343,7 +343,7 @@ styleframe dtcg import -i tokens/ --composables false
 styleframe figma <subcommand> [options]
 ```
 
-Export and import Figma-compatible DTCG per-mode files. Unlike the spec-conformant `dtcg` commands, `figma` uses only the three types Figma supports (`number`, `color`, `string`), flattens structured values to primitives, and writes one complete `.tokens.json` file per mode — ready for direct import into Figma via the [Styleframe Figma Plugin](/docs/integrations/figma-plugin).
+Export and import Figma-compatible DTCG per-mode files. Unlike the spec-conformant `dtcg` commands, `figma` uses only the three types Figma supports (`number`, `color`, `string`), flattens structured values to primitives, and writes one complete `.tokens.json` file per mode — ready for direct import into Figma via the [Styleframe Figma Plugin](/docs/getting-started/integrations/figma-plugin).
 ::
 ::
 

--- a/apps/docs/content/docs/09.integrations/01.dtcg.md
+++ b/apps/docs/content/docs/09.integrations/01.dtcg.md
@@ -95,7 +95,7 @@ Each value type ships parse / format / convert helpers under its own namespace:
 
 ## CLI integration
 
-The [`styleframe dtcg export`](/docs/tooling/cli#dtcg) command is the primary consumer of this package. The flow is:
+The [`styleframe dtcg export`](/docs/getting-started/tooling/cli#dtcg) command is the primary consumer of this package. The flow is:
 
 1. Load your Styleframe configuration via `@styleframe/loader`.
 2. Evaluate every variable to a primitive or CSS expression.
@@ -110,7 +110,7 @@ styleframe dtcg export -o tokens/
 The output is consumable by any DTCG-compatible tool — including Tokens Studio, Style Dictionary, and the Styleframe Figma plugin.
 
 ::tip{icon="i-lucide-figma"}
-**Importing into Figma?** Use `styleframe figma export` instead — it flattens rich DTCG types to Figma's 3-type model (`number`, `color`, `string`) and writes one complete `.tokens.json` per mode. See the [Figma Plugin](/docs/integrations/figma-plugin) page for the full workflow.
+**Importing into Figma?** Use `styleframe figma export` instead — it flattens rich DTCG types to Figma's 3-type model (`number`, `color`, `string`) and writes one complete `.tokens.json` per mode. See the [Figma Plugin](/docs/getting-started/integrations/figma-plugin) page for the full workflow.
 ::
 
 ::note{icon="i-lucide-info"}
@@ -181,6 +181,6 @@ Downstream tools that don't recognise these extensions ignore them safely. Tools
 - [W3C DTCG Format Module](https://www.designtokens.org/format/){target="_blank" rel="noopener"}
 - [W3C DTCG Color Module](https://www.designtokens.org/color/){target="_blank" rel="noopener"}
 - [W3C DTCG Resolver Module](https://www.designtokens.org/resolver/){target="_blank" rel="noopener"}
-- [CLI Reference — `dtcg export`](/docs/tooling/cli#dtcg)
-- [Figma Plugin — end-to-end Figma sync](/docs/integrations/figma-plugin)
+- [CLI Reference — `dtcg export`](/docs/getting-started/tooling/cli#dtcg)
+- [Figma Plugin — end-to-end Figma sync](/docs/getting-started/integrations/figma-plugin)
 - [GitHub — `@styleframe/dtcg`](https://github.com/styleframe-dev/styleframe/tree/main/tooling/dtcg){target="_blank"}

--- a/apps/docs/content/docs/09.integrations/01.dtcg.md
+++ b/apps/docs/content/docs/09.integrations/01.dtcg.md
@@ -17,7 +17,7 @@ The package is **runtime-agnostic** — no filesystem, no DOM, no framework assu
 DTCG is a portable JSON format for design tokens, standardised by the W3C Design Tokens Community Group. It defines how colours, dimensions, typography, shadows, and other design primitives should be represented so they can flow between tools — Figma, Tokens Studio, Style Dictionary, and any other DTCG-compatible system.
 
 ::tip{icon="i-lucide-book-open"}
-**Learn more**: Read the [Design Tokens Format Module](https://www.designtokens.org/format/){target="_blank"}, [Color Module](https://www.designtokens.org/color/){target="_blank"}, and [Resolver Module](https://www.designtokens.org/resolver/){target="_blank"} specifications.
+**Learn more**: Read the [Design Tokens Format Module](https://www.designtokens.org/tr/2025.10/format/){target="_blank"}, [Color Module](https://www.designtokens.org/tr/2025.10/color/){target="_blank"}, and [Resolver Module](https://www.designtokens.org/tr/2025.10/resolver/){target="_blank"} specifications.
 ::
 
 ## Why a dedicated package?
@@ -178,9 +178,9 @@ Downstream tools that don't recognise these extensions ignore them safely. Tools
 
 ## Resources
 
-- [W3C DTCG Format Module](https://www.designtokens.org/format/){target="_blank" rel="noopener"}
-- [W3C DTCG Color Module](https://www.designtokens.org/color/){target="_blank" rel="noopener"}
-- [W3C DTCG Resolver Module](https://www.designtokens.org/resolver/){target="_blank" rel="noopener"}
+- [W3C DTCG Format Module](https://www.designtokens.org/tr/2025.10/format/){target="_blank" rel="noopener"}
+- [W3C DTCG Color Module](https://www.designtokens.org/tr/2025.10/color/){target="_blank" rel="noopener"}
+- [W3C DTCG Resolver Module](https://www.designtokens.org/tr/2025.10/resolver/){target="_blank" rel="noopener"}
 - [CLI Reference — `dtcg export`](/docs/getting-started/tooling/cli#dtcg)
 - [Figma Plugin — end-to-end Figma sync](/docs/getting-started/integrations/figma-plugin)
 - [GitHub — `@styleframe/dtcg`](https://github.com/styleframe-dev/styleframe/tree/main/tooling/dtcg){target="_blank"}

--- a/apps/docs/content/docs/09.integrations/02.figma-plugin.md
+++ b/apps/docs/content/docs/09.integrations/02.figma-plugin.md
@@ -59,7 +59,7 @@ The plugin has two tabs: **Import** for bringing tokens into Figma, and **Export
 
 Import your Styleframe design tokens into Figma as native Figma Variables:
 
-1. **Export your tokens** using the CLI (see [CLI Export](#exporting-tokens-code--figma) below)
+1. **Export your tokens** using the CLI (see [CLI Export](#exporting-tokens-code-figma) below)
 2. **Open the plugin** in Figma and select the **Import** tab
 3. **Drag and drop** your `tokens.json` file into the drop zone (or click to browse)
 4. **Preview** the variables that will be created
@@ -85,7 +85,7 @@ Export Figma Variables to the DTCG format for use in your codebase:
 2. **Select a collection** from the dropdown menu
 3. Click **Export** to generate the DTCG JSON
 4. **Copy** the JSON to your clipboard or **Download** as a file
-5. **Import into Styleframe** using the CLI (see [CLI Import](#importing-tokens-figma--code) below)
+5. **Import into Styleframe** using the CLI (see [CLI Import](#importing-tokens-figma-code) below)
 
 The export preserves:
 - All variable values across modes


### PR DESCRIPTION
## Description

Fixes 311 broken internal links across 109 documentation pages. Links were updated to use correct paths after the docs restructuring that introduced numeric prefixes to directories and files.

## Related issue

<!-- e.g. "Closes #123" or "Relates to #123". -->

## Type of change

- [x] 📖 Documentation

## Checklist

- [x] My commits follow Conventional Commits with a package scope (e.g. `feat(theme): …`)
- [x] I ran `pnpm build:nodocs && pnpm lint && pnpm typecheck && pnpm test` and everything passes
- [x] I added a changeset (`pnpm changeset`) for changes to publishable packages, or this change only touches docs/storybook/app/playground/tests
- [x] I added or updated tests where relevant
- [x] I updated documentation where relevant
- [x] I did **not** edit generated files (`dist/`, `.styleframe/`)
- [x] My PR targets `main` and stays focused in scope

## Notes / screenshots

All 338 link changes are mechanical find-and-replace fixes (no content changes). No publishable packages were modified, so no changeset is required.