### PR TITLE
fix(plugin): publish types entrypoint

### DIFF
--- a/.changeset/tidy-foxes-build.md
+++ b/.changeset/tidy-foxes-build.md
@@ -1,0 +1,5 @@
+---
+"@styleframe/plugin": patch
+---
+
+Publish the `@styleframe/plugin/types` entry point.

--- a/tooling/plugin/src/types.ts
+++ b/tooling/plugin/src/types.ts
@@ -1,0 +1,1 @@
+export type * from "./plugin/types";


### PR DESCRIPTION
## Summary

- add the missing `src/types.ts` build entry for the existing `@styleframe/plugin/types` export
- preserve the public subpath while generating both `dist/types.js` and `dist/types.d.ts`
- add a patch changeset

## Reproduction

`@styleframe/plugin@3.4.0` publishes `./types: ./dist/types.js`, but its npm tarball does not contain that file. A clean `import(@styleframe/plugin/types)` fails with `ERR_MODULE_NOT_FOUND`.

## Verification

- `pnpm --filter @styleframe/plugin build`
- local `pnpm pack` contains `dist/types.js` and `dist/types.d.ts`
- clean tarball install: `import(@styleframe/plugin/types)` passes
- clean TypeScript consumer resolves `Options` from `@styleframe/plugin/types`
- `oxfmt --check tooling/plugin/src/types.ts`
- `git diff --check`

The package test/typecheck commands require built workspace dependencies. On Windows, the dependency build currently stops in `@styleframe/core` with the pre-existing `styleframe:dual-declarations` `dist` ENOENT; the plugin build itself completes successfully.