### PR TITLE
fix(ci): bump Node.js to 22 in changesets workflow

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -40,7 +40,7 @@ jobs:
             - name: Setup node.js
               uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 22
                   cache: "pnpm"
                   registry-url: "https://registry.npmjs.org"
 


### PR DESCRIPTION
## Description

Bumps the Node.js version from 20 to 22 in the changesets CI workflow to match the project's current Node.js requirement.

## Related issue

<!-- N/A -->

## Type of change

- [x] 🔧 Build / tooling / CI

## Checklist

- [x] My commits follow Conventional Commits with a package scope (e.g. `feat(theme): …`)
- [x] I ran `pnpm build:nodocs && pnpm lint && pnpm typecheck && pnpm test` and everything passes
- [x] I added a changeset (`pnpm changeset`) for changes to publishable packages, or this change only touches docs/storybook/app/playground/tests
- [x] I added or updated tests where relevant
- [x] I updated documentation where relevant
- [x] I did **not** edit generated files (`dist/`, `.styleframe/`)
- [x] My PR targets `main` and stays focused in scope

## Notes / screenshots

Single-line CI fix — no functional or publishable package changes.