### PR TITLE
docs: test PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 **Type-safe Composable CSS in TypeScript**
 
-From simple UI styles to full Design Systems, write code using Styleframe's powerful TypeScript CSS API.
+From simple UI styles to full Design Systems, write code using Styleframe's powerful TypeScript CSS API — AI-ready by design.
 
 [![npm version](https://img.shields.io/npm/v/styleframe.svg)](https://www.npmjs.com/package/styleframe)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/styleframe-dev/styleframe/blob/main/LICENSE)

--- a/apps/docs/content/index.md
+++ b/apps/docs/content/index.md
@@ -43,7 +43,7 @@ export default s;
 Type-safe Composable CSS 
 
 #description
-From simple UI styles to full Design Systems, write code using Styleframe’s powerful TypeScript CSS API.
+From simple UI styles to full Design Systems, write code using Styleframe’s powerful TypeScript CSS API — AI-ready by design.
 
 #links
     :::u-button


### PR DESCRIPTION
## Summary

Small copy tweak to the hero tagline so it matches the page metadata description.

Appends `— AI-ready by design.` to the one-line description in two places:
- `README.md` (repo hero copy)
- `apps/docs/content/index.md` (docs landing hero `#description`)

## Changes

- 2 files changed, 2 insertions(+), 2 deletions(-)

## Context

Requested via Multica issue UXF-12 to produce a reviewable diff. Opened as a draft.
