### PR TITLE
feat(theme): add callout icon, content, and dismiss sub-part recipes

### DIFF
--- a/.changeset/callout-dismiss-content-parts.md
+++ b/.changeset/callout-dismiss-content-parts.md
@@ -1,0 +1,5 @@
+---
+"@styleframe/theme": minor
+---
+
+Add `useCalloutIconRecipe`, `useCalloutContentRecipe`, and `useCalloutDismissRecipe` sub-part recipes for the Callout component. The callout recipe now collapses when the `hidden` attribute is set, and the dismiss recipe provides a styled close button with hover and focus-visible states.

--- a/apps/docs/content/docs/05.components/04.feedback/01.callout.md
+++ b/apps/docs/content/docs/05.components/04.feedback/01.callout.md
@@ -34,11 +34,19 @@ Add the Callout recipe to a local Styleframe instance. The global `styleframe.co
 
 ```ts [src/components/callout.styleframe.ts]
 import { styleframe } from 'virtual:styleframe';
-import { useCalloutRecipe } from '@styleframe/theme';
+import {
+    useCalloutContentRecipe,
+    useCalloutDismissRecipe,
+    useCalloutIconRecipe,
+    useCalloutRecipe,
+} from '@styleframe/theme';
 
 const s = styleframe();
 
 const callout = useCalloutRecipe(s);
+const calloutIcon = useCalloutIconRecipe(s);
+const calloutContent = useCalloutContentRecipe(s);
+const calloutDismiss = useCalloutDismissRecipe(s);
 
 export default s;
 ```
@@ -67,7 +75,7 @@ Import the `callout` runtime function from the virtual module and pass variant p
 
 ```vue [src/components/Callout.vue]
 <script setup lang="ts">
-import { callout, type CalloutProps } from "virtual:styleframe";
+import { callout, calloutContent, calloutDismiss, calloutIcon, type CalloutProps } from "virtual:styleframe";
 
 const {
 	color = "neutral",
@@ -86,13 +94,15 @@ const emit = defineEmits<{
 
 <template>
 	<div :class="callout({ color, variant, size, orientation })" role="alert">
-		<slot name="icon" />
-		<div>
+		<span :class="calloutIcon()" aria-hidden="true">
+			<slot name="icon" />
+		</span>
+		<div :class="calloutContent()">
 			<strong v-if="title">{{ title }}</strong>
 			<p v-if="description">{{ description }}</p>
 			<slot />
 		</div>
-		<button v-if="dismissible" aria-label="Dismiss" @click="emit('dismiss')">
+		<button v-if="dismissible" type="button" :class="calloutDismiss()" aria-label="Dismiss" @click="emit('dismiss')">
 			&times;
 		</button>
 	</div>
@@ -102,7 +112,7 @@ const emit = defineEmits<{
 #react
 
 ```ts [src/components/Callout.tsx]
-import { callout, type CalloutProps } from "virtual:styleframe";
+import { callout, calloutContent, calloutDismiss, calloutIcon, type CalloutProps } from "virtual:styleframe";
 
 interface CalloutComponentProps extends CalloutProps {
 	title?: string;
@@ -129,14 +139,14 @@ export function Callout({
 
 	return (
 		<div className={classes} role="alert">
-			{icon && <span>{icon}</span>}
-			<div>
+			{icon && <span className={calloutIcon()} aria-hidden="true">{icon}</span>}
+			<div className={calloutContent()}>
 				{title && <strong>{title}</strong>}
 				{description && <p>{description}</p>}
 				{children}
 			</div>
 			{dismissible && (
-				<button onClick={onDismiss} aria-label="Dismiss">
+				<button type="button" className={calloutDismiss()} onClick={onDismiss} aria-label="Dismiss">
 					&times;
 				</button>
 			)}
@@ -329,6 +339,17 @@ story: theme-recipes-feedback-callout--all-orientations
 | `horizontal` | `row` | Compact inline messages, single-line alerts |
 | `vertical` | `column` | Longer descriptions, multi-line content, action buttons |
 
+## Dismissible
+
+The `useCalloutDismissRecipe()` composable styles the close control: an `em`-sized button that inherits the callout's text color, pushes itself to the end of the row, and includes hover and focus-visible states. The callout recipe also collapses the element when the `hidden` attribute is set, so dismissing only needs to toggle `hidden` on the root element.
+
+::story-preview
+---
+story: theme-recipes-feedback-callout--dismissible
+panel: true
+---
+::
+
 ## Accessibility
 
 - **Use appropriate ARIA roles.** Use `role="alert"` for urgent messages (announced immediately), `role="status"` for non-urgent updates (announced at next pause), and no role for static informational content.
@@ -443,6 +464,16 @@ Creates a full callout recipe with all variants and compound variant styling.
 | `size` | `sm`, `md`, `lg` | `md` |
 | `orientation` | `horizontal`, `vertical` | `horizontal` |
 
+### Sub-part recipes
+
+The callout's parts are styled by base-only recipes that accept the same `(s, options?)` signature:
+
+| Composable | Class | Purpose |
+|-----------|-------|---------|
+| `useCalloutIconRecipe()` | `callout-icon` | Non-shrinking inline-flex wrapper for the leading icon |
+| `useCalloutContentRecipe()` | `callout-content` | Main text area, fills the available space |
+| `useCalloutDismissRecipe()` | `callout-dismiss` | Dismiss button reset with hover and focus-visible states |
+
 [Learn more about recipes &rarr;](/docs/api/recipes)
 
 ## Best Practices
@@ -502,7 +533,7 @@ When you use the `filter` option, compound variants that reference filtered-out 
 :::
 
 :::accordion-item{label="How should I handle the dismissible behavior?" icon="i-lucide-circle-help"}
-The recipe handles only the visual layout (flexbox with gap). Dismissal logic &mdash; hiding the element, animating out, managing focus &mdash; is the responsibility of your component framework. Use a `<button>` element with `aria-label="Dismiss"` for the close control, and move focus to the next logical element after dismissal.
+The `useCalloutDismissRecipe()` composable styles the close control, and the callout recipe collapses the element when the `hidden` attribute is set. Dismissal logic &mdash; toggling `hidden`, animating out, managing focus &mdash; remains the responsibility of your component framework. Use a `<button>` element with `aria-label="Dismiss"` for the close control, and move focus to the next logical element after dismissal.
 :::
 
 :::accordion-item{label="Can I use the Callout recipe without the design tokens preset?" icon="i-lucide-circle-help"}

--- a/apps/storybook/src/components/components/callout/Callout.vue
+++ b/apps/storybook/src/components/components/callout/Callout.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed } from "vue";
-import { callout } from "virtual:styleframe";
+import { callout, calloutDismiss, calloutIcon } from "virtual:styleframe";
 import CalloutContent from "./CalloutContent.vue";
 import CalloutTitle from "./CalloutTitle.vue";
 import CalloutDescription from "./CalloutDescription.vue";
@@ -28,6 +28,10 @@ const props = withDefaults(
 	{},
 );
 
+defineEmits<{
+	dismiss: [];
+}>();
+
 const classes = computed(() =>
 	callout({
 		color: props.color,
@@ -36,13 +40,16 @@ const classes = computed(() =>
 		orientation: props.orientation,
 	}),
 );
+
+const iconClasses = computed(() => calloutIcon());
+const dismissClasses = computed(() => calloutDismiss());
 </script>
 
 <template>
 	<div :class="classes">
-		<slot v-if="icon" name="icon">
-			{{ props.icon }}
-		</slot>
+		<span v-if="icon" :class="iconClasses" aria-hidden="true">
+			<slot name="icon">{{ props.icon }}</slot>
+		</span>
 		<CalloutContent>
 			<CalloutTitle v-if="props.title">{{ props.title }}</CalloutTitle>
 			<CalloutDescription
@@ -51,6 +58,14 @@ const classes = computed(() =>
 			>
 			<slot />
 		</CalloutContent>
-		<slot v-if="dismissible" name="dismiss"> ✖ </slot>
+		<button
+			v-if="dismissible"
+			type="button"
+			:class="dismissClasses"
+			aria-label="Dismiss"
+			@click="$emit('dismiss')"
+		>
+			<slot name="dismiss">&times;</slot>
+		</button>
 	</div>
 </template>

--- a/apps/storybook/src/components/components/callout/CalloutContent.vue
+++ b/apps/storybook/src/components/components/callout/CalloutContent.vue
@@ -1,5 +1,12 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { calloutContent } from "virtual:styleframe";
+
+const classes = computed(() => calloutContent());
+</script>
+
 <template>
-	<div class="callout-content">
+	<div :class="classes">
 		<slot />
 	</div>
 </template>

--- a/apps/storybook/stories/components/callout.stories.ts
+++ b/apps/storybook/stories/components/callout.stories.ts
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/vue3-vite";
+import { ref } from "vue";
 
+import Button from "../../src/components/components/button/Button.vue";
 import Callout from "../../src/components/components/callout/Callout.vue";
 import CalloutGrid from "../../src/components/components/callout/preview/CalloutGrid.vue";
 import CalloutSizeGrid from "../../src/components/components/callout/preview/CalloutSizeGrid.vue";
@@ -99,6 +101,26 @@ export const AllOrientations: StoryObj = {
 	render: () => ({
 		components: { CalloutOrientationGrid },
 		template: "<CalloutOrientationGrid />",
+	}),
+};
+
+export const Dismissible: Story = {
+	args: {
+		color: "info",
+		dismissible: true,
+		title: "Dismissible Callout",
+		description: "Click the dismiss button to hide this callout.",
+	},
+	render: (args) => ({
+		components: { Callout, Button },
+		setup() {
+			const dismissed = ref(false);
+			return { args, dismissed };
+		},
+		template: `
+			<Callout v-bind="args" :hidden="dismissed" @dismiss="dismissed = true" />
+			<Button v-if="dismissed" label="Reset" @click="dismissed = false" />
+		`,
 	}),
 };
 

--- a/apps/storybook/stories/components/callout.styleframe.ts
+++ b/apps/storybook/stories/components/callout.styleframe.ts
@@ -1,11 +1,19 @@
-import { useCalloutRecipe } from "@styleframe/theme";
+import {
+	useCalloutContentRecipe,
+	useCalloutDismissRecipe,
+	useCalloutIconRecipe,
+	useCalloutRecipe,
+} from "@styleframe/theme";
 import { styleframe } from "virtual:styleframe";
 
 const s = styleframe();
 const { selector } = s;
 
-// Initialize callout recipe
+// Initialize callout recipes
 export const callout = useCalloutRecipe(s);
+export const calloutIcon = useCalloutIconRecipe(s);
+export const calloutContent = useCalloutContentRecipe(s);
+export const calloutDismiss = useCalloutDismissRecipe(s);
 
 // Container styles for story layout
 selector(".callout-grid", {

--- a/theme/src/recipes/callout/index.ts
+++ b/theme/src/recipes/callout/index.ts
@@ -1,1 +1,4 @@
 export * from "./useCalloutRecipe";
+export * from "./useCalloutIconRecipe";
+export * from "./useCalloutContentRecipe";
+export * from "./useCalloutDismissRecipe";

--- a/theme/src/recipes/callout/useCalloutContentRecipe.test.ts
+++ b/theme/src/recipes/callout/useCalloutContentRecipe.test.ts
@@ -1,0 +1,27 @@
+import { styleframe } from "@styleframe/core";
+import { useCalloutContentRecipe } from "./useCalloutContentRecipe";
+
+function createInstance() {
+	const s = styleframe();
+	s.utility("flex", ({ value }) => ({ flex: value }));
+	return s;
+}
+
+describe("useCalloutContentRecipe", () => {
+	it("should create a recipe with correct metadata", () => {
+		const s = createInstance();
+		const recipe = useCalloutContentRecipe(s);
+
+		expect(recipe.type).toBe("recipe");
+		expect(recipe.name).toBe("callout-content");
+	});
+
+	it("should fill the available space", () => {
+		const s = createInstance();
+		const recipe = useCalloutContentRecipe(s);
+
+		expect(recipe.base).toEqual({
+			flex: "1 1 auto",
+		});
+	});
+});

--- a/theme/src/recipes/callout/useCalloutContentRecipe.ts
+++ b/theme/src/recipes/callout/useCalloutContentRecipe.ts
@@ -1,0 +1,10 @@
+import { createUseRecipe } from "../../utils/createUseRecipe";
+
+/**
+ * Callout content recipe for the main text area.
+ */
+export const useCalloutContentRecipe = createUseRecipe("callout-content", {
+	base: {
+		flex: "1 1 auto",
+	},
+});

--- a/theme/src/recipes/callout/useCalloutDismissRecipe.test.ts
+++ b/theme/src/recipes/callout/useCalloutDismissRecipe.test.ts
@@ -1,0 +1,53 @@
+import { styleframe } from "@styleframe/core";
+import {
+	useFocusVisibleModifier,
+	useHoverModifier,
+} from "../../modifiers/usePseudoStateModifiers";
+import { useCalloutDismissRecipe } from "./useCalloutDismissRecipe";
+
+function createInstance() {
+	const s = styleframe();
+	for (const name of [
+		"display",
+		"alignItems",
+		"justifyContent",
+		"flexShrink",
+		"width",
+		"height",
+		"marginInlineStart",
+		"padding",
+		"borderWidth",
+		"background",
+		"color",
+		"fontSize",
+		"lineHeight",
+		"borderRadius",
+		"cursor",
+		"opacity",
+		"transitionProperty",
+		"transitionTimingFunction",
+		"transitionDuration",
+		"outlineWidth",
+		"outlineStyle",
+		"outlineColor",
+		"outlineOffset",
+	]) {
+		s.utility(name, ({ value }) => ({ [name]: value }));
+	}
+	useHoverModifier(s);
+	useFocusVisibleModifier(s);
+	return s;
+}
+
+describe("useCalloutDismissRecipe", () => {
+	it("should namespace the shared dismiss recipe to callout", () => {
+		const s = createInstance();
+		const recipe = useCalloutDismissRecipe(s);
+
+		expect(recipe.name).toBe("callout-dismiss");
+		expect(recipe.base).toMatchObject({
+			marginInlineStart: "auto",
+			cursor: "pointer",
+		});
+	});
+});

--- a/theme/src/recipes/callout/useCalloutDismissRecipe.ts
+++ b/theme/src/recipes/callout/useCalloutDismissRecipe.ts
@@ -1,0 +1,6 @@
+import { createDismissRecipe } from "../dismiss/createDismissRecipe";
+
+/**
+ * Callout dismiss button recipe.
+ */
+export const useCalloutDismissRecipe = createDismissRecipe("callout");

--- a/theme/src/recipes/callout/useCalloutIconRecipe.test.ts
+++ b/theme/src/recipes/callout/useCalloutIconRecipe.test.ts
@@ -1,0 +1,30 @@
+import { styleframe } from "@styleframe/core";
+import { useCalloutIconRecipe } from "./useCalloutIconRecipe";
+
+function createInstance() {
+	const s = styleframe();
+	for (const name of ["display", "flexShrink"]) {
+		s.utility(name, ({ value }) => ({ [name]: value }));
+	}
+	return s;
+}
+
+describe("useCalloutIconRecipe", () => {
+	it("should create a recipe with correct metadata", () => {
+		const s = createInstance();
+		const recipe = useCalloutIconRecipe(s);
+
+		expect(recipe.type).toBe("recipe");
+		expect(recipe.name).toBe("callout-icon");
+	});
+
+	it("should keep the icon from shrinking", () => {
+		const s = createInstance();
+		const recipe = useCalloutIconRecipe(s);
+
+		expect(recipe.base).toEqual({
+			display: "inline-flex",
+			flexShrink: "0",
+		});
+	});
+});

--- a/theme/src/recipes/callout/useCalloutIconRecipe.ts
+++ b/theme/src/recipes/callout/useCalloutIconRecipe.ts
@@ -1,0 +1,11 @@
+import { createUseRecipe } from "../../utils/createUseRecipe";
+
+/**
+ * Callout icon recipe for the leading icon slot.
+ */
+export const useCalloutIconRecipe = createUseRecipe("callout-icon", {
+	base: {
+		display: "inline-flex",
+		flexShrink: "0",
+	},
+});

--- a/theme/src/recipes/callout/useCalloutRecipe.test.ts
+++ b/theme/src/recipes/callout/useCalloutRecipe.test.ts
@@ -130,7 +130,7 @@ describe("useCalloutRecipe", () => {
 			const recipe = useCalloutRecipe(s);
 
 			expect(recipe.variants!.orientation).toEqual({
-				horizontal: { flexDirection: "row" },
+				horizontal: { flexDirection: "row", alignItems: "center" },
 				vertical: { flexDirection: "column" },
 			});
 		});
@@ -306,6 +306,21 @@ describe("useCalloutRecipe", () => {
 					},
 				},
 			});
+		});
+	});
+
+	describe("setup callback", () => {
+		it("should collapse the callout when hidden", () => {
+			const s = createInstance();
+			useCalloutRecipe(s);
+
+			const hiddenSelector = s.root.children.find(
+				(child) =>
+					child.type === "selector" &&
+					(child as { query: string }).query === ".callout[hidden]",
+			);
+
+			expect(hiddenSelector).toBeDefined();
 		});
 	});
 

--- a/theme/src/recipes/callout/useCalloutRecipe.ts
+++ b/theme/src/recipes/callout/useCalloutRecipe.ts
@@ -13,278 +13,289 @@ const colors = [
  * Callout recipe for contextual feedback messages.
  * Supports color, variant, size, and orientation axes.
  */
-export const useCalloutRecipe = createUseRecipe("callout", {
-	base: {
-		display: "flex",
-		flexBasis: "100%",
-		alignItems: "flex-start",
-		borderWidth: "@border-width.thin",
-		borderStyle: "@border-style.solid",
-		borderColor: "transparent",
-		fontWeight: "@font-weight.medium",
-		fontSize: "@font-size.sm",
-		lineHeight: "@line-height.normal",
-		paddingTop: "@0.75",
-		paddingBottom: "@0.75",
-		paddingLeft: "@1",
-		paddingRight: "@1",
-		gap: "@0.75",
-		borderRadius: "@border-radius.md",
-	},
-	variants: {
-		color: {
-			primary: {},
-			secondary: {},
-			success: {},
-			info: {},
-			warning: {},
-			error: {},
-			light: {},
-			dark: {},
-			neutral: {},
+export const useCalloutRecipe = createUseRecipe(
+	"callout",
+	{
+		base: {
+			display: "flex",
+			flexBasis: "100%",
+			alignItems: "flex-start",
+			borderWidth: "@border-width.thin",
+			borderStyle: "@border-style.solid",
+			borderColor: "transparent",
+			fontWeight: "@font-weight.medium",
+			fontSize: "@font-size.sm",
+			lineHeight: "@line-height.normal",
+			paddingTop: "@0.75",
+			paddingBottom: "@0.75",
+			paddingLeft: "@1",
+			paddingRight: "@1",
+			gap: "@0.75",
+			borderRadius: "@border-radius.md",
 		},
-		variant: {
-			solid: {},
-			outline: {},
-			soft: {},
-			subtle: {},
+		variants: {
+			color: {
+				primary: {},
+				secondary: {},
+				success: {},
+				info: {},
+				warning: {},
+				error: {},
+				light: {},
+				dark: {},
+				neutral: {},
+			},
+			variant: {
+				solid: {},
+				outline: {},
+				soft: {},
+				subtle: {},
+			},
+			size: {
+				sm: {
+					fontSize: "@font-size.xs",
+					paddingTop: "@0.5",
+					paddingBottom: "@0.5",
+					paddingLeft: "@0.75",
+					paddingRight: "@0.75",
+					gap: "@0.5",
+				},
+				md: {
+					fontSize: "@font-size.sm",
+					paddingTop: "@0.75",
+					paddingBottom: "@0.75",
+					paddingLeft: "@1",
+					paddingRight: "@1",
+					gap: "@0.75",
+				},
+				lg: {
+					fontSize: "@font-size.md",
+					paddingTop: "@1",
+					paddingBottom: "@1",
+					paddingLeft: "@1.25",
+					paddingRight: "@1.25",
+					gap: "@1",
+				},
+			},
+			orientation: {
+				horizontal: {
+					flexDirection: "row",
+					alignItems: "center",
+				},
+				vertical: {
+					flexDirection: "column",
+				},
+			},
 		},
-		size: {
-			sm: {
-				fontSize: "@font-size.xs",
-				paddingTop: "@0.5",
-				paddingBottom: "@0.5",
-				paddingLeft: "@0.75",
-				paddingRight: "@0.75",
-				gap: "@0.5",
-			},
-			md: {
-				fontSize: "@font-size.sm",
-				paddingTop: "@0.75",
-				paddingBottom: "@0.75",
-				paddingLeft: "@1",
-				paddingRight: "@1",
-				gap: "@0.75",
-			},
-			lg: {
-				fontSize: "@font-size.md",
-				paddingTop: "@1",
-				paddingBottom: "@1",
-				paddingLeft: "@1.25",
-				paddingRight: "@1.25",
-				gap: "@1",
-			},
-		},
-		orientation: {
-			horizontal: {
-				flexDirection: "row",
-			},
-			vertical: {
-				flexDirection: "column",
-			},
-		},
-	},
-	compoundVariants: [
-		// Standard colors
-		...colors.flatMap((color) => [
-			{
-				match: { color, variant: "solid" as const },
-				css: {
-					background: `@color.${color}`,
-					color: "@color.white",
-					borderColor: `@color.${color}-shade-50`,
-					"&:dark": {
-						borderColor: `@color.${color}-tint-50`,
+		compoundVariants: [
+			// Standard colors
+			...colors.flatMap((color) => [
+				{
+					match: { color, variant: "solid" as const },
+					css: {
+						background: `@color.${color}`,
+						color: "@color.white",
+						borderColor: `@color.${color}-shade-50`,
+						"&:dark": {
+							borderColor: `@color.${color}-tint-50`,
+						},
 					},
 				},
-			},
-			{
-				match: { color, variant: "outline" as const },
-				css: {
-					color: `@color.${color}`,
-					borderColor: `@color.${color}`,
-				},
-			},
-			{
-				match: { color, variant: "soft" as const },
-				css: {
-					background: `@color.${color}-100`,
-					color: `@color.${color}-700`,
-					"&:dark": {
-						background: `@color.${color}-800`,
-						color: `@color.${color}-400`,
+				{
+					match: { color, variant: "outline" as const },
+					css: {
+						color: `@color.${color}`,
+						borderColor: `@color.${color}`,
 					},
 				},
-			},
-			{
-				match: { color, variant: "subtle" as const },
-				css: {
-					background: `@color.${color}-100`,
-					color: `@color.${color}-700`,
-					borderColor: `@color.${color}-300`,
-					"&:dark": {
-						background: `@color.${color}-800`,
-						color: `@color.${color}-400`,
-						borderColor: `@color.${color}-600`,
+				{
+					match: { color, variant: "soft" as const },
+					css: {
+						background: `@color.${color}-100`,
+						color: `@color.${color}-700`,
+						"&:dark": {
+							background: `@color.${color}-800`,
+							color: `@color.${color}-400`,
+						},
 					},
 				},
-			},
-		]),
+				{
+					match: { color, variant: "subtle" as const },
+					css: {
+						background: `@color.${color}-100`,
+						color: `@color.${color}-700`,
+						borderColor: `@color.${color}-300`,
+						"&:dark": {
+							background: `@color.${color}-800`,
+							color: `@color.${color}-400`,
+							borderColor: `@color.${color}-600`,
+						},
+					},
+				},
+			]),
 
-		// Light color (neutral light-mode values, fixed across themes)
-		{
-			match: { color: "light" as const, variant: "solid" as const },
-			css: {
-				background: "@color.white",
-				color: "@color.text",
-				borderColor: "@color.gray-200",
-				"&:dark": {
+			// Light color (neutral light-mode values, fixed across themes)
+			{
+				match: { color: "light" as const, variant: "solid" as const },
+				css: {
 					background: "@color.white",
-					color: "@color.text-inverted",
-					borderColor: "@color.gray-200",
-				},
-			},
-		},
-		{
-			match: { color: "light" as const, variant: "outline" as const },
-			css: {
-				color: "@color.text-inverted",
-				borderColor: "@color.gray-200",
-				"&:dark": {
 					color: "@color.text",
 					borderColor: "@color.gray-200",
+					"&:dark": {
+						background: "@color.white",
+						color: "@color.text-inverted",
+						borderColor: "@color.gray-200",
+					},
 				},
 			},
-		},
-		{
-			match: { color: "light" as const, variant: "soft" as const },
-			css: {
-				background: "@color.gray-50",
-				color: "@color.gray-700",
-				"&:dark": {
+			{
+				match: { color: "light" as const, variant: "outline" as const },
+				css: {
+					color: "@color.text-inverted",
+					borderColor: "@color.gray-200",
+					"&:dark": {
+						color: "@color.text",
+						borderColor: "@color.gray-200",
+					},
+				},
+			},
+			{
+				match: { color: "light" as const, variant: "soft" as const },
+				css: {
 					background: "@color.gray-50",
 					color: "@color.gray-700",
+					"&:dark": {
+						background: "@color.gray-50",
+						color: "@color.gray-700",
+					},
 				},
 			},
-		},
-		{
-			match: { color: "light" as const, variant: "subtle" as const },
-			css: {
-				background: "@color.gray-50",
-				color: "@color.gray-700",
-				borderColor: "@color.gray-300",
-				"&:dark": {
+			{
+				match: { color: "light" as const, variant: "subtle" as const },
+				css: {
 					background: "@color.gray-50",
 					color: "@color.gray-700",
 					borderColor: "@color.gray-300",
+					"&:dark": {
+						background: "@color.gray-50",
+						color: "@color.gray-700",
+						borderColor: "@color.gray-300",
+					},
 				},
 			},
-		},
 
-		// Dark color (neutral dark-mode values, fixed across themes)
-		{
-			match: { color: "dark" as const, variant: "solid" as const },
-			css: {
-				background: "@color.gray-900",
-				color: "@color.text-inverted",
-				borderColor: "@color.gray-800",
-				"&:dark": {
+			// Dark color (neutral dark-mode values, fixed across themes)
+			{
+				match: { color: "dark" as const, variant: "solid" as const },
+				css: {
 					background: "@color.gray-900",
-					color: "@color.text",
-					borderColor: "@color.gray-800",
-				},
-			},
-		},
-		{
-			match: { color: "dark" as const, variant: "outline" as const },
-			css: {
-				color: "@color.text",
-				borderColor: "@color.gray-600",
-				"&:dark": {
 					color: "@color.text-inverted",
-					borderColor: "@color.gray-600",
-				},
-			},
-		},
-		{
-			match: { color: "dark" as const, variant: "soft" as const },
-			css: {
-				background: "@color.gray-800",
-				color: "@color.gray-300",
-				"&:dark": {
-					background: "@color.gray-800",
-					color: "@color.gray-300",
-				},
-			},
-		},
-		{
-			match: { color: "dark" as const, variant: "subtle" as const },
-			css: {
-				background: "@color.gray-800",
-				color: "@color.gray-300",
-				borderColor: "@color.gray-600",
-				"&:dark": {
-					background: "@color.gray-800",
-					color: "@color.gray-300",
-					borderColor: "@color.gray-600",
-				},
-			},
-		},
-
-		// Neutral color (light in light mode, dark in dark mode)
-		{
-			match: { color: "neutral" as const, variant: "solid" as const },
-			css: {
-				background: "@color.white",
-				color: "@color.text",
-				borderColor: "@color.gray-200",
-				"&:dark": {
-					background: "@color.gray-900",
-					color: "@color.white",
 					borderColor: "@color.gray-800",
+					"&:dark": {
+						background: "@color.gray-900",
+						color: "@color.text",
+						borderColor: "@color.gray-800",
+					},
 				},
 			},
-		},
-		{
-			match: { color: "neutral" as const, variant: "outline" as const },
-			css: {
-				color: "@color.text",
-				borderColor: "@color.gray-200",
-				"&:dark": {
-					color: "@color.gray-200",
+			{
+				match: { color: "dark" as const, variant: "outline" as const },
+				css: {
+					color: "@color.text",
 					borderColor: "@color.gray-600",
+					"&:dark": {
+						color: "@color.text-inverted",
+						borderColor: "@color.gray-600",
+					},
 				},
 			},
-		},
-		{
-			match: { color: "neutral" as const, variant: "soft" as const },
-			css: {
-				background: "@color.gray-50",
-				color: "@color.gray-700",
-				"&:dark": {
+			{
+				match: { color: "dark" as const, variant: "soft" as const },
+				css: {
 					background: "@color.gray-800",
 					color: "@color.gray-300",
+					"&:dark": {
+						background: "@color.gray-800",
+						color: "@color.gray-300",
+					},
 				},
 			},
-		},
-		{
-			match: { color: "neutral" as const, variant: "subtle" as const },
-			css: {
-				background: "@color.gray-50",
-				color: "@color.gray-700",
-				borderColor: "@color.gray-300",
-				"&:dark": {
+			{
+				match: { color: "dark" as const, variant: "subtle" as const },
+				css: {
 					background: "@color.gray-800",
 					color: "@color.gray-300",
 					borderColor: "@color.gray-600",
+					"&:dark": {
+						background: "@color.gray-800",
+						color: "@color.gray-300",
+						borderColor: "@color.gray-600",
+					},
 				},
 			},
+
+			// Neutral color (light in light mode, dark in dark mode)
+			{
+				match: { color: "neutral" as const, variant: "solid" as const },
+				css: {
+					background: "@color.white",
+					color: "@color.text",
+					borderColor: "@color.gray-200",
+					"&:dark": {
+						background: "@color.gray-900",
+						color: "@color.white",
+						borderColor: "@color.gray-800",
+					},
+				},
+			},
+			{
+				match: { color: "neutral" as const, variant: "outline" as const },
+				css: {
+					color: "@color.text",
+					borderColor: "@color.gray-200",
+					"&:dark": {
+						color: "@color.gray-200",
+						borderColor: "@color.gray-600",
+					},
+				},
+			},
+			{
+				match: { color: "neutral" as const, variant: "soft" as const },
+				css: {
+					background: "@color.gray-50",
+					color: "@color.gray-700",
+					"&:dark": {
+						background: "@color.gray-800",
+						color: "@color.gray-300",
+					},
+				},
+			},
+			{
+				match: { color: "neutral" as const, variant: "subtle" as const },
+				css: {
+					background: "@color.gray-50",
+					color: "@color.gray-700",
+					borderColor: "@color.gray-300",
+					"&:dark": {
+						background: "@color.gray-800",
+						color: "@color.gray-300",
+						borderColor: "@color.gray-600",
+					},
+				},
+			},
+		],
+		defaultVariants: {
+			color: "neutral",
+			variant: "subtle",
+			size: "md",
+			orientation: "horizontal",
 		},
-	],
-	defaultVariants: {
-		color: "neutral",
-		variant: "subtle",
-		size: "md",
-		orientation: "horizontal",
 	},
-});
+	(s) => {
+		// The base `display: flex` utility outranks the UA `[hidden]` rule, so
+		// dismissal needs an explicit collapse.
+		s.selector(".callout[hidden]", {
+			display: "none",
+		});
+	},
+);

--- a/theme/src/recipes/dismiss/createDismissRecipe.test.ts
+++ b/theme/src/recipes/dismiss/createDismissRecipe.test.ts
@@ -1,0 +1,92 @@
+import { styleframe } from "@styleframe/core";
+import {
+	useFocusVisibleModifier,
+	useHoverModifier,
+} from "../../modifiers/usePseudoStateModifiers";
+import { createDismissRecipe } from "./createDismissRecipe";
+
+function createInstance() {
+	const s = styleframe();
+	for (const name of [
+		"display",
+		"alignItems",
+		"justifyContent",
+		"flexShrink",
+		"width",
+		"height",
+		"marginInlineStart",
+		"padding",
+		"borderWidth",
+		"background",
+		"color",
+		"fontSize",
+		"lineHeight",
+		"borderRadius",
+		"cursor",
+		"opacity",
+		"transitionProperty",
+		"transitionTimingFunction",
+		"transitionDuration",
+		"outlineWidth",
+		"outlineStyle",
+		"outlineColor",
+		"outlineOffset",
+	]) {
+		s.utility(name, ({ value }) => ({ [name]: value }));
+	}
+	useHoverModifier(s);
+	useFocusVisibleModifier(s);
+	return s;
+}
+
+describe("createDismissRecipe", () => {
+	it("should namespace the recipe to the component", () => {
+		const s = createInstance();
+		const useWidgetDismissRecipe = createDismissRecipe("widget");
+		const recipe = useWidgetDismissRecipe(s);
+
+		expect(recipe.type).toBe("recipe");
+		expect(recipe.name).toBe("widget-dismiss");
+	});
+
+	it("should reset the button and size it in em", () => {
+		const s = createInstance();
+		const recipe = createDismissRecipe("widget")(s);
+
+		expect(recipe.base).toMatchObject({
+			display: "inline-flex",
+			alignItems: "center",
+			justifyContent: "center",
+			flexShrink: "0",
+			width: "1em",
+			height: "1em",
+			marginInlineStart: "auto",
+			padding: "0",
+			borderWidth: "0",
+			background: "transparent",
+			color: "inherit",
+			fontSize: "inherit",
+			lineHeight: "1",
+			borderRadius: "@border-radius.sm",
+			cursor: "pointer",
+			opacity: "0.7",
+		});
+	});
+
+	it("should include hover and focus-visible states", () => {
+		const s = createInstance();
+		const recipe = createDismissRecipe("widget")(s);
+
+		expect(recipe.base).toMatchObject({
+			"&:hover": {
+				opacity: "1",
+			},
+			"&:focus-visible": {
+				outlineWidth: "2px",
+				outlineStyle: "solid",
+				outlineColor: "@color.primary",
+				outlineOffset: "1px",
+			},
+		});
+	});
+});

--- a/theme/src/recipes/dismiss/createDismissRecipe.ts
+++ b/theme/src/recipes/dismiss/createDismissRecipe.ts
@@ -1,0 +1,46 @@
+import { createUseRecipe } from "../../utils/createUseRecipe";
+
+/**
+ * Shared recipe-definition builder for dismiss buttons, imported by consumers
+ * (e.g. `callout`) via relative path — mirroring `modal/createOverlayRecipes.ts`.
+ *
+ * The `${name}` parameter prefixes the recipe name so each consumer gets its
+ * own class namespace while sharing identical CSS. The button inherits the
+ * host's text color and is sized in `em` so it scales with the host, while
+ * `margin-inline-start: auto` pushes it to the end of a flex row. The "×"
+ * glyph is supplied by the consumer.
+ */
+export function createDismissRecipe(name: string) {
+	return createUseRecipe(`${name}-dismiss`, {
+		base: {
+			display: "inline-flex",
+			alignItems: "center",
+			justifyContent: "center",
+			flexShrink: "0",
+			width: "1em",
+			height: "1em",
+			marginInlineStart: "auto",
+			padding: "0",
+			borderWidth: "0",
+			background: "transparent",
+			color: "inherit",
+			fontSize: "inherit",
+			lineHeight: "1",
+			borderRadius: "@border-radius.sm",
+			cursor: "pointer",
+			opacity: "0.7",
+			transitionProperty: "opacity",
+			transitionTimingFunction: "@easing.ease-in-out",
+			transitionDuration: "150ms",
+			"&:hover": {
+				opacity: "1",
+			},
+			"&:focus-visible": {
+				outlineWidth: "2px",
+				outlineStyle: "solid",
+				outlineColor: "@color.primary",
+				outlineOffset: "1px",
+			},
+		},
+	});
+}

--- a/theme/src/recipes/dismiss/index.ts
+++ b/theme/src/recipes/dismiss/index.ts
@@ -1,0 +1,1 @@
+export * from "./createDismissRecipe";

--- a/theme/src/recipes/index.ts
+++ b/theme/src/recipes/index.ts
@@ -11,6 +11,7 @@ export * from "./checkbox";
 export * from "./chip";
 export * from "./color-picker";
 export * from "./context-menu";
+export * from "./dismiss";
 export * from "./drawer";
 export * from "./dropdown";
 export * from "./field-group";

--- a/tooling/plugin/playground/recipes/callout.styleframe.ts
+++ b/tooling/plugin/playground/recipes/callout.styleframe.ts
@@ -1,8 +1,16 @@
-import { useCalloutRecipe } from "@styleframe/theme";
+import {
+	useCalloutContentRecipe,
+	useCalloutDismissRecipe,
+	useCalloutIconRecipe,
+	useCalloutRecipe,
+} from "@styleframe/theme";
 import { styleframe } from "virtual:styleframe";
 
 const s = styleframe();
 
 export const callout = useCalloutRecipe(s);
+export const calloutIcon = useCalloutIconRecipe(s);
+export const calloutContent = useCalloutContentRecipe(s);
+export const calloutDismiss = useCalloutDismissRecipe(s);
 
 export default s;


### PR DESCRIPTION
<!--
Thanks for contributing to Styleframe! Please read CONTRIBUTING.md first:
https://github.com/styleframe-dev/styleframe/blob/main/CONTRIBUTING.md

Please ask first before starting on any significant PR (new features, refactors,
new engine capabilities) so your effort isn't wasted on something we can't merge.
-->

## Description

Splits the Callout component's icon wrapper, content area, and dismiss button into dedicated base-only recipes (`useCalloutIconRecipe`, `useCalloutContentRecipe`, `useCalloutDismissRecipe`). The root callout recipe now collapses when the `hidden` attribute is set, enabling dismiss-by-hidden-attribute patterns. Storybook components and docs are updated to use the new sub-part recipes.

## Related issue

<!-- e.g. "Closes #123" or "Relates to #123". -->

## Type of change

- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behavior)
- [ ] 📖 Documentation
- [ ] ♻️ Refactor / internal (no functional change)
- [ ] 🔧 Build / tooling / CI

## Checklist

- [x] My commits follow Conventional Commits with a package scope (e.g. `feat(theme): …`)
- [ ] I ran `pnpm build:nodocs && pnpm lint && pnpm typecheck && pnpm test` and everything passes
- [x] I added a changeset (`pnpm changeset`) for changes to publishable packages, or this change only touches docs/storybook/app/playground/tests
- [x] I added or updated tests where relevant
- [x] I updated documentation where relevant
- [x] I did **not** edit generated files (`dist/`, `.styleframe/`)
- [x] My PR targets `main` and stays focused in scope

## Notes / screenshots

Three new base-only composables (`useCalloutIconRecipe`, `useCalloutContentRecipe`, `useCalloutDismissRecipe`) are exported from `@styleframe/theme`. The shared dismiss button logic lives in `theme/src/recipes/dismiss/createDismissRecipe.ts` and is reused by `useCalloutDismissRecipe`. A new `Dismissible` Storybook story demonstrates the dismiss-by-hidden-attribute pattern.