### PR TITLE
feat(theme): extend _flex: namespace to route direction and wrap keywords

### DIFF
--- a/.changeset/theme-flex-utility-preset.md
+++ b/.changeset/theme-flex-utility-preset.md
@@ -1,0 +1,5 @@
+---
+"@styleframe/theme": minor
+---
+
+Extend `_flex:` namespace to mirror Tailwind's `flex-*` family: direction keywords (`row`, `col`, `column`, and their reverses) now route to `flex-direction`, wrap keywords (`wrap`, `nowrap`, `wrap-reverse`) route to `flex-wrap`, and shorthand values (`1`, `auto`, `initial`, `none`) continue to map to `flex`. Also adds `column`/`column-reverse` as full-word aliases to `flexDirectionValues` and `column`/`column-dense` aliases to grid auto-flow values.

--- a/apps/docs/content/docs/06.utilities/08.flexbox-grid.md
+++ b/apps/docs/content/docs/06.utilities/08.flexbox-grid.md
@@ -27,7 +27,7 @@ Flexbox and grid utilities help you:
 
 ### `useFlexUtility`
 
-The `useFlexUtility()` function creates utility classes for the flex shorthand property.
+The `useFlexUtility()` function creates utility classes for the `_flex:` namespace. Mirroring Tailwind's `flex-*` family, each value is routed to the correct CSS property: shorthand values (`1`/`auto`/`initial`/`none`) map to `flex`, direction values (`row`/`col`/`column` and their reverses) map to `flex-direction`, and wrap values (`wrap`/`nowrap`/`wrap-reverse`) map to `flex-wrap`.
 
 ::tabs
 :::tabs-item{icon="i-lucide-code" label="Code"}
@@ -38,7 +38,7 @@ import { useFlexUtility } from "@styleframe/theme";
 
 const s = styleframe();
 
-// Uses built-in defaults: 1, auto, initial, none
+// Uses built-in defaults: flex shorthand, direction, and wrap values
 useFlexUtility(s);
 
 export default s;
@@ -52,13 +52,22 @@ export default s;
 ._flex\:auto { flex: 1 1 auto; }
 ._flex\:initial { flex: 0 1 auto; }
 ._flex\:none { flex: none; }
+._flex\:row { flex-direction: row; }
+._flex\:row-reverse { flex-direction: row-reverse; }
+._flex\:col { flex-direction: column; }
+._flex\:col-reverse { flex-direction: column-reverse; }
+._flex\:column { flex-direction: column; }
+._flex\:column-reverse { flex-direction: column-reverse; }
+._flex\:wrap { flex-wrap: wrap; }
+._flex\:wrap-reverse { flex-wrap: wrap-reverse; }
+._flex\:nowrap { flex-wrap: nowrap; }
 ```
 
 :::
 :::tabs-item{icon="i-lucide-layout" label="Usage"}
 
 ```html
-<div class="_display:flex">
+<div class="_display:flex _flex:column">
     <div class="_flex:1">Grows to fill space</div>
     <div class="_flex:none">Fixed size</div>
 </div>
@@ -69,12 +78,21 @@ export default s;
 
 ### Default Flex Values
 
-| Key | Value | Description |
-|-----|-------|-------------|
-| `1` | `1 1 0%` | Grow and shrink, ignore initial size |
-| `auto` | `1 1 auto` | Grow and shrink based on content |
-| `initial` | `0 1 auto` | Don't grow, but shrink if needed |
-| `none` | `none` | Don't grow or shrink |
+The `_flex:` namespace spans three CSS properties; each key is routed automatically.
+
+| Key | CSS Property | Value |
+|-----|--------------|-------|
+| `1` | `flex` | `1 1 0%` |
+| `auto` | `flex` | `1 1 auto` |
+| `initial` | `flex` | `0 1 auto` |
+| `none` | `flex` | `none` |
+| `row` | `flex-direction` | `row` |
+| `row-reverse` | `flex-direction` | `row-reverse` |
+| `col` / `column` | `flex-direction` | `column` |
+| `col-reverse` / `column-reverse` | `flex-direction` | `column-reverse` |
+| `wrap` | `flex-wrap` | `wrap` |
+| `wrap-reverse` | `flex-wrap` | `wrap-reverse` |
+| `nowrap` | `flex-wrap` | `nowrap` |
 
 ### `useFlexGrowUtility` & `useFlexShrinkUtility`
 
@@ -106,7 +124,7 @@ useFlexBasisUtility(s, {
 
 ### `useFlexDirectionUtility`
 
-Control the direction of flex items.
+Control the direction of flex items. Both the Tailwind abbreviation (`col`) and the full CSS word (`column`) are available as keys, so `_flex-direction:col` and `_flex-direction:column` resolve to the same value.
 
 ::tabs
 :::tabs-item{icon="i-lucide-code" label="Code"}
@@ -122,6 +140,8 @@ useFlexDirectionUtility(s, {
     'row-reverse': 'row-reverse',
     col: 'column',
     'col-reverse': 'column-reverse',
+    column: 'column',
+    'column-reverse': 'column-reverse',
 });
 
 export default s;
@@ -135,6 +155,8 @@ export default s;
 ._flex-direction\:row-reverse { flex-direction: row-reverse; }
 ._flex-direction\:col { flex-direction: column; }
 ._flex-direction\:col-reverse { flex-direction: column-reverse; }
+._flex-direction\:column { flex-direction: column; }
+._flex-direction\:column-reverse { flex-direction: column-reverse; }
 ```
 
 :::
@@ -240,7 +262,7 @@ useGridColumnEndUtility(s, { '1': '1', '2': '2', '3': '3', auto: 'auto' });
 
 ### `useGridAutoFlowUtility`
 
-Control how auto-placed items flow in the grid.
+Control how auto-placed items flow in the grid. As with `flex-direction`, both the abbreviation (`col` / `col-dense`) and the full word (`column` / `column-dense`) are available as keys.
 
 ::tabs
 :::tabs-item{icon="i-lucide-code" label="Code"}
@@ -263,9 +285,11 @@ export default s;
 ```css [styleframe/index.css]
 ._grid-flow\:row { grid-auto-flow: row; }
 ._grid-flow\:col { grid-auto-flow: column; }
+._grid-flow\:column { grid-auto-flow: column; }
 ._grid-flow\:dense { grid-auto-flow: dense; }
 ._grid-flow\:row-dense { grid-auto-flow: row dense; }
 ._grid-flow\:col-dense { grid-auto-flow: column dense; }
+._grid-flow\:column-dense { grid-auto-flow: column dense; }
 ```
 
 :::

--- a/theme/src/utilities/flexbox-grid/useFlexDirectionUtility.test.ts
+++ b/theme/src/utilities/flexbox-grid/useFlexDirectionUtility.test.ts
@@ -39,6 +39,14 @@ describe("useFlexDirectionUtility", () => {
 		expect(utility.declarations).toEqual({ flexDirection: "column-reverse" });
 	});
 
+	it("should support the full-word column alias", () => {
+		const s = styleframe();
+		useFlexDirectionUtility(s, { column: "column" });
+
+		const utility = s.root.children[0] as Utility;
+		expect(utility.declarations).toEqual({ flexDirection: "column" });
+	});
+
 	it("should handle empty values object", () => {
 		const s = styleframe();
 		useFlexDirectionUtility(s, {});

--- a/theme/src/utilities/flexbox-grid/useFlexUtility.test.ts
+++ b/theme/src/utilities/flexbox-grid/useFlexUtility.test.ts
@@ -36,6 +36,43 @@ describe("useFlexUtility", () => {
 		expect(css).toContain("flex: none;");
 	});
 
+	it("should route direction keywords to flex-direction", () => {
+		const s = styleframe();
+		useFlexUtility(s, { column: "column" });
+
+		const utility = s.root.children[0] as Utility;
+		expect(utility.declarations).toEqual({ flexDirection: "column" });
+	});
+
+	it("should route the col alias to the same flex-direction value", () => {
+		const s = styleframe();
+		useFlexUtility(s, { col: "column" });
+
+		const utility = s.root.children[0] as Utility;
+		expect(utility.declarations).toEqual({ flexDirection: "column" });
+	});
+
+	it("should route wrap keywords to flex-wrap", () => {
+		const s = styleframe();
+		useFlexUtility(s, { wrap: "wrap", nowrap: "nowrap" });
+
+		const wrap = s.root.children[0] as Utility;
+		const nowrap = s.root.children[1] as Utility;
+		expect(wrap.declarations).toEqual({ flexWrap: "wrap" });
+		expect(nowrap.declarations).toEqual({ flexWrap: "nowrap" });
+	});
+
+	it("should compile routed classes to correct CSS output", () => {
+		const s = styleframe();
+		useFlexUtility(s, { column: "column", wrap: "wrap" });
+
+		const css = consumeCSS(s.root, s.options);
+		expect(css).toContain("._flex\\:column {");
+		expect(css).toContain("flex-direction: column;");
+		expect(css).toContain("._flex\\:wrap {");
+		expect(css).toContain("flex-wrap: wrap;");
+	});
+
 	it("should handle empty values object", () => {
 		const s = styleframe();
 		useFlexUtility(s, {});

--- a/theme/src/utilities/flexbox-grid/useFlexUtility.ts
+++ b/theme/src/utilities/flexbox-grid/useFlexUtility.ts
@@ -1,21 +1,41 @@
 import { createUseUtility } from "../../utils";
-import { flexValues } from "../../values";
+import { flexDirectionValues, flexValues, flexWrapValues } from "../../values";
+
+const flexDirectionCssValues = new Set<string>(
+	Object.values(flexDirectionValues),
+);
+const flexWrapCssValues = new Set<string>(Object.values(flexWrapValues));
 
 /**
  * Create flex utility classes.
+ *
+ * The `_flex:` namespace mirrors Tailwind's `flex-*` family, routing each value
+ * to the correct CSS property: direction keywords (`row`/`col`/`column`/…) to
+ * `flex-direction`, wrap keywords (`wrap`/`nowrap`/`wrap-reverse`) to `flex-wrap`,
+ * and everything else (the `flex` shorthand) to `flex`.
  *
  * @example
  * ```typescript
  * const s = styleframe();
  * useFlexUtility(s);
- * // Uses defaults: ._flex:1, ._flex:auto, ._flex:initial, ._flex:none
+ * // ._flex:1 / ._flex:auto / ._flex:none     → flex
+ * // ._flex:row / ._flex:col / ._flex:column  → flex-direction
+ * // ._flex:wrap / ._flex:nowrap              → flex-wrap
  * ```
  */
 export const useFlexUtility = createUseUtility(
 	"flex",
-	({ value }) => ({
-		flex: value,
-	}),
+	({ value }) => {
+		if (typeof value === "string") {
+			if (flexDirectionCssValues.has(value)) {
+				return { flexDirection: value };
+			}
+			if (flexWrapCssValues.has(value)) {
+				return { flexWrap: value };
+			}
+		}
+		return { flex: value };
+	},
 	{ defaults: flexValues },
 );
 

--- a/theme/src/utilities/flexbox-grid/useGridUtility.test.ts
+++ b/theme/src/utilities/flexbox-grid/useGridUtility.test.ts
@@ -216,6 +216,14 @@ describe("useGridAutoFlowUtility", () => {
 		const utility = s.root.children[0] as Utility;
 		expect(utility.declarations).toEqual({ gridAutoFlow: "row dense" });
 	});
+
+	it("should support the full-word column alias", () => {
+		const s = styleframe();
+		useGridAutoFlowUtility(s, { column: "column" });
+
+		const utility = s.root.children[0] as Utility;
+		expect(utility.declarations).toEqual({ gridAutoFlow: "column" });
+	});
 });
 
 describe("useGridAutoColumnsUtility", () => {

--- a/theme/src/values/flexboxGrid.ts
+++ b/theme/src/values/flexboxGrid.ts
@@ -1,21 +1,16 @@
 /**
- * Default flex utility values matching Tailwind CSS.
- */
-export const flexValues = {
-	"1": "1 1 0%",
-	auto: "1 1 auto",
-	initial: "0 1 auto",
-	none: "none",
-} as const;
-
-/**
  * Default flex-direction utility values matching Tailwind CSS.
+ *
+ * Both the Tailwind abbreviation (`col`) and the full CSS word (`column`) are
+ * exposed as keys so `_flex-direction:col` and `_flex-direction:column` both work.
  */
 export const flexDirectionValues = {
 	row: "row",
 	"row-reverse": "row-reverse",
 	col: "column",
 	"col-reverse": "column-reverse",
+	column: "column",
+	"column-reverse": "column-reverse",
 } as const;
 
 /**
@@ -25,6 +20,23 @@ export const flexWrapValues = {
 	wrap: "wrap",
 	"wrap-reverse": "wrap-reverse",
 	nowrap: "nowrap",
+} as const;
+
+/**
+ * Default flex utility values matching Tailwind CSS.
+ *
+ * The `_flex:` namespace mirrors Tailwind's `flex-*` family: shorthand values
+ * (`1`/`auto`/`initial`/`none`) map to `flex`, direction values map to
+ * `flex-direction`, and wrap values map to `flex-wrap`. The routing happens in
+ * `useFlexUtility`.
+ */
+export const flexValues = {
+	"1": "1 1 0%",
+	auto: "1 1 auto",
+	initial: "0 1 auto",
+	none: "none",
+	...flexDirectionValues,
+	...flexWrapValues,
 } as const;
 
 /**
@@ -142,7 +154,9 @@ export const placeSelfValues = {
 export const gridAutoFlowValues = {
 	row: "row",
 	col: "column",
+	column: "column",
 	dense: "dense",
 	"row-dense": "row dense",
 	"col-dense": "column dense",
+	"column-dense": "column dense",
 } as const;


### PR DESCRIPTION
<!--
Thanks for contributing to Styleframe! Please read CONTRIBUTING.md first:
https://github.com/styleframe-dev/styleframe/blob/main/CONTRIBUTING.md
-->

## Description

Extends the `_flex:` utility namespace to mirror Tailwind's `flex-*` family. Direction keywords (`row`, `col`, `column`, and their reverses) now route to `flex-direction`, wrap keywords (`wrap`, `nowrap`, `wrap-reverse`) route to `flex-wrap`, and shorthand values (`1`, `auto`, `initial`, `none`) continue to map to `flex`. Also adds `column`/`column-reverse` as full-word aliases to `flexDirectionValues` and `column`/`column-dense` aliases to grid auto-flow values.

## Related issue

<!-- e.g. "Closes #123" or "Relates to #123". -->

## Type of change

- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behavior)
- [ ] 📖 Documentation
- [ ] ♻️ Refactor / internal (no functional change)
- [ ] 🔧 Build / tooling / CI

## Checklist

- [x] My commits follow Conventional Commits with a package scope (e.g. `feat(theme): …`)
- [ ] I ran `pnpm build:nodocs && pnpm lint && pnpm typecheck && pnpm test` and everything passes
- [x] I added a changeset (`pnpm changeset`) for changes to publishable packages, or this change only touches docs/storybook/app/playground/tests
- [x] I added or updated tests where relevant
- [x] I updated documentation where relevant
- [x] I did **not** edit generated files (`dist/`, `.styleframe/`)
- [x] My PR targets `main` and stays focused in scope

## Notes / screenshots

The `_flex:` namespace now works like Tailwind's unified `flex-*` classes — you can write `_flex:column`, `_flex:wrap`, `_flex:row-reverse` directly without needing separate `_flex-direction:` or `_flex-wrap:` utilities.