### PR TITLE
build(deploy): add Dockerfiles for docs and storybook (Dokploy)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+# VCS & local tooling
+.git
+.github
+.husky
+.claude
+.context
+.zed
+.changeset
+
+# Dependencies
+node_modules
+**/node_modules
+
+# Build outputs & caches
+**/.output
+**/.nuxt
+**/.nitro
+**/.cache
+**/.turbo
+**/.data
+**/.styleframe
+**/dist
+**/storybook-static
+**/coverage
+
+# Docker
+**/Dockerfile
+.dockerignore
+
+# Local env & OS files
+**/.env
+**/.env.*
+**/*.log
+**/.DS_Store

--- a/apps/docs/Dockerfile
+++ b/apps/docs/Dockerfile
@@ -1,0 +1,50 @@
+# syntax=docker/dockerfile:1
+
+# Build from the monorepo root:
+#   docker build -f apps/docs/Dockerfile -t styleframe-docs .
+# Dokploy: Build Type "Dockerfile", Docker File "apps/docs/Dockerfile",
+# Docker Context Path ".", container port 3000.
+
+FROM node:22-slim AS build
+
+ENV PNPM_HOME=/pnpm \
+    PATH=/pnpm:$PATH \
+    COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
+    CI=true \
+    HUSKY=0 \
+    NUXT_TELEMETRY_DISABLED=1
+RUN corepack enable
+
+WORKDIR /app
+COPY . .
+
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm install --frozen-lockfile --filter @styleframe/docs --filter @styleframe/app-shared
+
+# Public runtime config is baked into prerendered pages at build time,
+# so these must be provided as build args, not runtime env.
+ARG NUXT_PUBLIC_BASE_URL=https://www.styleframe.dev
+ARG NUXT_PUBLIC_POSTHOG_KEY=phc_Vu3wqbMj8M5iWzvEulIXlK5U0A3hqkb5rlVM1DLtZsb
+ARG NUXT_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com
+ARG NUXT_PUBLIC_POSTHOG_DEFAULTS=2025-05-24
+ENV NUXT_PUBLIC_BASE_URL=$NUXT_PUBLIC_BASE_URL \
+    NUXT_PUBLIC_POSTHOG_KEY=$NUXT_PUBLIC_POSTHOG_KEY \
+    NUXT_PUBLIC_POSTHOG_HOST=$NUXT_PUBLIC_POSTHOG_HOST \
+    NUXT_PUBLIC_POSTHOG_DEFAULTS=$NUXT_PUBLIC_POSTHOG_DEFAULTS
+
+# The prerenderer needs more heap than node's default in memory-limited containers.
+RUN NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter @styleframe/docs run build
+
+FROM node:22-slim AS runtime
+
+ENV NODE_ENV=production \
+    HOST=0.0.0.0 \
+    PORT=3000
+
+WORKDIR /app/apps/docs
+# chown: Nuxt Content creates its SQLite database inside .output/server at runtime.
+COPY --from=build --chown=node:node /app/apps/docs/.output ./.output
+USER node
+
+EXPOSE 3000
+CMD ["node", ".output/server/index.mjs"]

--- a/apps/storybook/Dockerfile
+++ b/apps/storybook/Dockerfile
@@ -1,0 +1,34 @@
+# syntax=docker/dockerfile:1
+
+# Build from the monorepo root:
+#   docker build -f apps/storybook/Dockerfile -t styleframe-storybook .
+# Dokploy: Build Type "Dockerfile", Docker File "apps/storybook/Dockerfile",
+# Docker Context Path ".", container port 80.
+
+FROM node:22-slim AS build
+
+ENV PNPM_HOME=/pnpm \
+    PATH=/pnpm:$PATH \
+    COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
+    CI=true \
+    HUSKY=0 \
+    PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+RUN corepack enable
+
+WORKDIR /app
+COPY . .
+
+# Storybook imports the built @styleframe/* workspace packages (core, plugin,
+# runtime, theme), so a full install + turbo build resolves the dependency
+# graph and builds those packages before Storybook itself.
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm install --frozen-lockfile
+
+RUN pnpm turbo run build --filter=@styleframe/storybook
+
+FROM nginx:alpine AS runtime
+
+# Storybook builds to a fully static site; nginx serves it directly.
+COPY --from=build /app/apps/storybook/storybook-static /usr/share/nginx/html
+
+EXPOSE 80


### PR DESCRIPTION
## Description

Adds production Dockerfiles for `apps/docs` (Nuxt node-server) and `apps/storybook` (static/nginx), plus a root `.dockerignore`. Both images build from the monorepo root and are configured for Dokploy deployment.

- `apps/docs/Dockerfile`: filtered pnpm install, 4 GB prerender heap, SQLite-friendly runtime user, exposes port 3000
- `apps/storybook/Dockerfile`: full install + turbo build of workspace deps, nginx static serve, exposes port 80
- `.dockerignore`: excludes `.git`, `node_modules`, build outputs, and local tooling

## Related issue

<!-- e.g. "Closes #123" or "Relates to #123". -->

## Type of change

- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behavior)
- [ ] 📖 Documentation
- [ ] ♻️ Refactor / internal (no functional change)
- [x] 🔧 Build / tooling / CI

## Checklist

- [x] My commits follow Conventional Commits with a package scope (e.g. `feat(theme): …`)
- [x] I ran `pnpm build:nodocs && pnpm lint && pnpm typecheck && pnpm test` and everything passes
- [x] I added a changeset (`pnpm changeset`) for changes to publishable packages, or this change only touches docs/storybook/app/playground/tests
- [ ] I added or updated tests where relevant
- [x] I updated documentation where relevant
- [x] I did **not** edit generated files (`dist/`, `.styleframe/`)
- [x] My PR targets `main` and stays focused in scope

## Notes / screenshots

Dokploy configuration per app:
- **docs**: Build Type `Dockerfile`, Docker File `apps/docs/Dockerfile`, Docker Context Path `.`, container port `3000`
- **storybook**: Build Type `Dockerfile`, Docker File `apps/storybook/Dockerfile`, Docker Context Path `.`, container port `80`