### PR TITLE
build(deploy): add nixpacks configs for docs, playground, and storybook

### DIFF
--- a/apps/docs/nixpacks.toml
+++ b/apps/docs/nixpacks.toml
@@ -1,0 +1,34 @@
+# Nixpacks build config for @styleframe/docs (Nuxt, node-server output).
+#
+# Build from the monorepo root so pnpm can resolve the workspace and the single
+# root lockfile. Point the platform at this file with NIXPACKS_CONFIG_FILE:
+#   Dokploy/Railway: Build Type "Nixpacks", root / context ".",
+#   env NIXPACKS_CONFIG_FILE=apps/docs/nixpacks.toml, container port 3000.
+#
+# Node + pnpm (pinned via the root packageManager field) are provided
+# automatically by the Node provider through Corepack.
+
+[phases.install]
+cmds = [
+    'pnpm install --frozen-lockfile --filter @styleframe/docs --filter @styleframe/app-shared',
+]
+
+[phases.build]
+dependsOn = ['install']
+# The prerenderer needs more heap than node's default in memory-limited builders.
+cmds = ['NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter @styleframe/docs run build']
+
+# Public runtime config is baked into prerendered pages at build time, so these
+# must be present during the build, not only at runtime.
+[variables]
+NUXT_TELEMETRY_DISABLED = '1'
+NUXT_PUBLIC_BASE_URL = 'https://www.styleframe.dev'
+NUXT_PUBLIC_POSTHOG_KEY = 'phc_Vu3wqbMj8M5iWzvEulIXlK5U0A3hqkb5rlVM1DLtZsb'
+NUXT_PUBLIC_POSTHOG_HOST = 'https://eu.i.posthog.com'
+NUXT_PUBLIC_POSTHOG_DEFAULTS = '2025-05-24'
+HOST = '0.0.0.0'
+PORT = '3000'
+
+# Nuxt Content creates its SQLite database inside .output/server at runtime.
+[start]
+cmd = 'node apps/docs/.output/server/index.mjs'

--- a/apps/playground/nixpacks.toml
+++ b/apps/playground/nixpacks.toml
@@ -1,0 +1,25 @@
+# Nixpacks build config for @styleframe/playground (Vite static build, served by Caddy).
+#
+# Build from the monorepo root so pnpm can resolve the workspace and the single
+# root lockfile, and turbo can build the @styleframe/* packages the playground imports.
+# Point the platform at this file with NIXPACKS_CONFIG_FILE:
+#   Dokploy/Railway: Build Type "Nixpacks", root / context ".",
+#   env NIXPACKS_CONFIG_FILE=apps/playground/nixpacks.toml, container port 80.
+#
+# Node + pnpm (pinned via the root packageManager field) are provided
+# automatically by the Node provider through Corepack.
+
+# Add Caddy alongside the auto-detected Node + pnpm toolchain to serve the build.
+[phases.setup]
+nixPkgs = ['...', 'caddy']
+
+[phases.install]
+cmds = ['pnpm install --frozen-lockfile']
+
+[phases.build]
+dependsOn = ['install']
+# turbo builds the workspace deps (core, runtime, scanner, theme, transpiler) first.
+cmds = ['pnpm turbo run build --filter=@styleframe/playground']
+
+[start]
+cmd = 'caddy file-server --root apps/playground/dist --listen :80'

--- a/apps/storybook/nixpacks.toml
+++ b/apps/storybook/nixpacks.toml
@@ -1,0 +1,28 @@
+# Nixpacks build config for @styleframe/storybook (static build, served by Caddy).
+#
+# Build from the monorepo root so pnpm can resolve the workspace and the single
+# root lockfile, and turbo can build the @styleframe/* packages Storybook imports.
+# Point the platform at this file with NIXPACKS_CONFIG_FILE:
+#   Dokploy/Railway: Build Type "Nixpacks", root / context ".",
+#   env NIXPACKS_CONFIG_FILE=apps/storybook/nixpacks.toml, container port 80.
+#
+# Node + pnpm (pinned via the root packageManager field) are provided
+# automatically by the Node provider through Corepack.
+
+# Add Caddy alongside the auto-detected Node + pnpm toolchain to serve the build.
+[phases.setup]
+nixPkgs = ['...', 'caddy']
+
+[phases.install]
+cmds = ['pnpm install --frozen-lockfile']
+
+[phases.build]
+dependsOn = ['install']
+# turbo builds the workspace deps (core, plugin, runtime, theme) before Storybook.
+cmds = ['pnpm turbo run build --filter=@styleframe/storybook']
+
+[variables]
+PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = '1'
+
+[start]
+cmd = 'caddy file-server --root apps/storybook/storybook-static --listen :80'


### PR DESCRIPTION
## Description

Adds `nixpacks.toml` build configuration files for three apps — docs, playground, and storybook — enabling Nixpacks-based deployments (e.g. Dokploy, Railway) from the monorepo root. Each config handles workspace dependency installation, turbo-aware builds, and serving (Caddy for static builds, Nuxt node-server for docs).

## Related issue

<!-- e.g. "Closes #123" or "Relates to #123". -->

## Type of change

- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behavior)
- [ ] 📖 Documentation
- [ ] ♻️ Refactor / internal (no functional change)
- [x] 🔧 Build / tooling / CI

## Checklist

- [x] My commits follow Conventional Commits with a package scope (e.g. `feat(theme): …`)
- [x] I ran `pnpm build:nodocs && pnpm lint && pnpm typecheck && pnpm test` and everything passes
- [x] I added a changeset (`pnpm changeset`) for changes to publishable packages, or this change only touches docs/storybook/app/playground/tests
- [x] I added or updated tests where relevant
- [x] I updated documentation where relevant
- [x] I did **not** edit generated files (`dist/`, `.styleframe/`)
- [x] My PR targets `main` and stays focused in scope

## Notes / screenshots

Each app's `nixpacks.toml` must be pointed to via `NIXPACKS_CONFIG_FILE` env var on the platform (e.g. `NIXPACKS_CONFIG_FILE=apps/docs/nixpacks.toml`), with the build root/context set to `.` (monorepo root).