### PR TITLE
chore: add multica.json with run script configuration

### DIFF
--- a/multica.json
+++ b/multica.json
@@ -1,0 +1,10 @@
+{
+  "scripts": {
+    "setup": "pnpm install && pnpm build",
+    "run": {
+      "dev": "pnpm dev",
+      "start": "pnpm start"
+    },
+    "cleanup": "rm -rf node_modules"
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `multica.json` to configure run scripts for the Multica platform
- Scripts are nested under a `scripts` field with `setup`, `run` (dev/start), and `cleanup` entries

## Test plan

- [ ] Verify `multica.json` is present at the repo root
- [ ] Confirm the JSON structure matches the expected schema