### PR TITLE
test(loader): add unit tests for config, module, jiti, build, HMR

### DIFF
--- a/engine/loader/src/build.test.ts
+++ b/engine/loader/src/build.test.ts
@@ -1,0 +1,90 @@
+import { styleframe } from "@styleframe/core";
+import { validateInstanceLicense } from "@styleframe/license";
+import { transpile } from "@styleframe/transpiler";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { build } from "./build";
+
+vi.mock("@styleframe/transpiler", () => ({ transpile: vi.fn() }));
+vi.mock("@styleframe/license", () => ({
+	validateInstanceLicense: vi.fn(),
+	getLicenseKeyFromEnv: vi.fn(() => ""),
+}));
+
+const mockedTranspile = vi.mocked(transpile);
+const mockedValidate = vi.mocked(validateInstanceLicense);
+
+let outputDir: string;
+
+beforeEach(async () => {
+	vi.clearAllMocks();
+	mockedValidate.mockResolvedValue(undefined as never);
+	mockedTranspile.mockResolvedValue({
+		files: [
+			{ name: "index.css", content: ".a{color:red}" },
+			{ name: "nested/deep.css", content: ".b{color:blue}" },
+		],
+	} as never);
+	outputDir = await mkdtemp(path.join(tmpdir(), "sf-loader-build-"));
+});
+
+afterEach(async () => {
+	await rm(outputDir, { recursive: true, force: true });
+});
+
+describe("build", () => {
+	test("validates the license then writes transpiled files, creating nested dirs", async () => {
+		const instance = styleframe();
+
+		await build(instance, { outputDir });
+
+		expect(mockedValidate).toHaveBeenCalledOnce();
+		expect(mockedTranspile).toHaveBeenCalledWith(instance, undefined);
+
+		expect(await readFile(path.join(outputDir, "index.css"), "utf8")).toBe(
+			".a{color:red}",
+		);
+		expect(
+			await readFile(path.join(outputDir, "nested/deep.css"), "utf8"),
+		).toBe(".b{color:blue}");
+	});
+
+	test("removes existing output when clean is true (default)", async () => {
+		const stalePath = path.join(outputDir, "stale.css");
+		await writeFile(stalePath, "stale");
+
+		await build(styleframe(), { outputDir });
+
+		expect(existsSync(stalePath)).toBe(false);
+		expect(existsSync(path.join(outputDir, "index.css"))).toBe(true);
+	});
+
+	test("keeps existing output when clean is false", async () => {
+		const stalePath = path.join(outputDir, "stale.css");
+		await writeFile(stalePath, "stale");
+
+		await build(styleframe(), { outputDir, clean: false });
+
+		expect(existsSync(stalePath)).toBe(true);
+		expect(existsSync(path.join(outputDir, "index.css"))).toBe(true);
+	});
+
+	test("forwards transpiler options", async () => {
+		const transpiler = { minify: true };
+		await build(styleframe(), { outputDir, transpiler });
+
+		expect(mockedTranspile).toHaveBeenCalledWith(expect.anything(), transpiler);
+	});
+
+	test("does not transpile or write when license validation fails", async () => {
+		mockedValidate.mockRejectedValueOnce(new Error("invalid license"));
+
+		await expect(build(styleframe(), { outputDir })).rejects.toThrow(
+			/invalid license/,
+		);
+		expect(mockedTranspile).not.toHaveBeenCalled();
+	});
+});

--- a/engine/loader/src/config.test.ts
+++ b/engine/loader/src/config.test.ts
@@ -1,0 +1,180 @@
+import type { Styleframe } from "@styleframe/core";
+import { watch } from "chokidar";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { loadConfiguration, watchConfiguration } from "./config";
+
+vi.mock("chokidar", () => ({ watch: vi.fn() }));
+
+const mockedWatch = vi.mocked(watch);
+const packageDir = fileURLToPath(new URL(".", import.meta.url));
+
+type Handler = () => unknown;
+
+/**
+ * A chokidar watcher stand-in that records event handlers so tests can drive
+ * "change"/"unlink" events deterministically instead of touching the real FS.
+ */
+function createFakeWatcher() {
+	const handlers = new Map<string, Handler>();
+	const watcher = {
+		on(event: string, handler: Handler) {
+			handlers.set(event, handler);
+			return watcher;
+		},
+		close: vi.fn(async () => {}),
+		async emit(event: string) {
+			return handlers.get(event)?.();
+		},
+	};
+	return watcher;
+}
+
+const validConfig = `import { styleframe } from "@styleframe/core";
+export default styleframe();`;
+
+let fixtureDir: string;
+
+beforeEach(async () => {
+	fixtureDir = await mkdtemp(path.join(packageDir, "__fixtures-"));
+	mockedWatch.mockReset();
+});
+
+afterEach(async () => {
+	await rm(fixtureDir, { recursive: true, force: true });
+});
+
+async function writeConfig(
+	content: string,
+	name = "styleframe.config.ts",
+): Promise<string> {
+	const filePath = path.join(fixtureDir, name);
+	await writeFile(filePath, content);
+	return filePath;
+}
+
+describe("loadConfiguration", () => {
+	test("loads a config file and returns the Styleframe instance", async () => {
+		await writeConfig(validConfig);
+
+		const instance = await loadConfiguration({
+			cwd: fixtureDir,
+			entry: "styleframe.config",
+		});
+
+		expect(instance.id).toEqual(expect.any(String));
+		expect(instance.root).toBeDefined();
+	});
+
+	test("resolves an absolute entry path with a known extension", async () => {
+		const filePath = await writeConfig(validConfig, "custom.config.ts");
+
+		const instance = await loadConfiguration({ entry: filePath });
+
+		expect(instance.root).toBeDefined();
+	});
+
+	test("returns a default instance when no config file is found", async () => {
+		const instance = await loadConfiguration({
+			cwd: fixtureDir,
+			entry: "styleframe.config",
+		});
+
+		expect(instance.id).toEqual(expect.any(String));
+		expect(instance.root.recipes).toHaveLength(0);
+	});
+
+	test("propagates errors from an invalid config file", async () => {
+		await writeConfig(`export default { not: "styleframe" };`);
+
+		await expect(
+			loadConfiguration({ cwd: fixtureDir, entry: "styleframe.config" }),
+		).rejects.toThrow(/Invalid default export/);
+	});
+});
+
+describe("watchConfiguration", () => {
+	test("throws when the config file cannot be found", async () => {
+		await expect(
+			watchConfiguration({ cwd: fixtureDir, entry: "styleframe.config" }),
+		).rejects.toThrow(/Config file not found/);
+	});
+
+	test("returns the loaded config, resolved path, and an unwatch fn", async () => {
+		const filePath = await writeConfig(validConfig);
+		const watcher = createFakeWatcher();
+		mockedWatch.mockReturnValue(watcher as unknown as ReturnType<typeof watch>);
+
+		const { config, configFile, unwatch } = await watchConfiguration({
+			cwd: fixtureDir,
+			entry: "styleframe.config",
+		});
+
+		expect(config.root).toBeDefined();
+		expect(configFile).toBe(filePath);
+
+		await unwatch();
+		expect(watcher.close).toHaveBeenCalledOnce();
+	});
+
+	test("reloads and calls onUpdate when the file changes", async () => {
+		await writeConfig(validConfig);
+		const watcher = createFakeWatcher();
+		mockedWatch.mockReturnValue(watcher as unknown as ReturnType<typeof watch>);
+		const onUpdate = vi.fn<(config: Styleframe) => void>();
+
+		await watchConfiguration({
+			cwd: fixtureDir,
+			entry: "styleframe.config",
+			onUpdate,
+		});
+
+		await watcher.emit("change");
+
+		expect(onUpdate).toHaveBeenCalledOnce();
+		const [updated] = onUpdate.mock.lastCall ?? [];
+		expect(updated?.root).toBeDefined();
+	});
+
+	test("calls onError when a reload fails", async () => {
+		const filePath = await writeConfig(validConfig);
+		const watcher = createFakeWatcher();
+		mockedWatch.mockReturnValue(watcher as unknown as ReturnType<typeof watch>);
+		const onError = vi.fn<(error: Error) => void>();
+
+		await watchConfiguration({
+			cwd: fixtureDir,
+			entry: "styleframe.config",
+			onError,
+		});
+
+		// Make the next reload throw by writing an invalid config.
+		await writeFile(filePath, `export default { not: "styleframe" };`);
+		await watcher.emit("change");
+
+		expect(onError).toHaveBeenCalledOnce();
+		const [reloadError] = onError.mock.lastCall ?? [];
+		expect(reloadError).toBeInstanceOf(Error);
+	});
+
+	test("calls onError when the config file is deleted", async () => {
+		const filePath = await writeConfig(validConfig);
+		const watcher = createFakeWatcher();
+		mockedWatch.mockReturnValue(watcher as unknown as ReturnType<typeof watch>);
+		const onError = vi.fn<(error: Error) => void>();
+
+		await watchConfiguration({
+			cwd: fixtureDir,
+			entry: "styleframe.config",
+			onError,
+		});
+
+		await watcher.emit("unlink");
+
+		expect(onError).toHaveBeenCalledOnce();
+		const [deleteError] = onError.mock.lastCall ?? [];
+		expect(deleteError?.message).toBe(`Config file was deleted: ${filePath}`);
+	});
+});

--- a/engine/loader/src/jiti.test.ts
+++ b/engine/loader/src/jiti.test.ts
@@ -1,0 +1,100 @@
+import type { Jiti } from "jiti";
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+import { clearAllJitiCache, clearJitiCache, createSharedJiti } from "./jiti";
+
+/**
+ * Build a fake Jiti whose cache is a plain object or Map, so cache-clearing
+ * behaviour can be asserted without spinning up a real jiti runtime.
+ */
+function fakeJiti(cache: unknown): Jiti {
+	return { cache } as unknown as Jiti;
+}
+
+describe("createSharedJiti", () => {
+	test("returns an importable jiti instance with module caching enabled", () => {
+		const jiti = createSharedJiti();
+		expect(typeof jiti.import).toBe("function");
+		expect(jiti.cache).toBeDefined();
+	});
+
+	test("merges caller options over the defaults", () => {
+		const jiti = createSharedJiti({ interopDefault: false });
+		expect(typeof jiti.import).toBe("function");
+	});
+});
+
+describe("clearJitiCache", () => {
+	test("removes both the resolved and file:// keys from a Map cache", () => {
+		const filePath = "./theme/useTokens.ts";
+		const resolved = path.resolve(filePath);
+		const cache = new Map<string, unknown>();
+		cache.set(resolved, {});
+		cache.set(`file://${resolved}`, {});
+		cache.set("unrelated", {});
+
+		clearJitiCache(fakeJiti(cache), filePath);
+
+		expect(cache.has(resolved)).toBe(false);
+		expect(cache.has(`file://${resolved}`)).toBe(false);
+		expect(cache.has("unrelated")).toBe(true);
+	});
+
+	test("removes both key formats from an object cache", () => {
+		const filePath = "./theme/useTokens.ts";
+		const resolved = path.resolve(filePath);
+		const cache: Record<string, unknown> = {
+			[resolved]: {},
+			[`file://${resolved}`]: {},
+			unrelated: {},
+		};
+
+		clearJitiCache(fakeJiti(cache), filePath);
+
+		expect(resolved in cache).toBe(false);
+		expect(`file://${resolved}` in cache).toBe(false);
+		expect("unrelated" in cache).toBe(true);
+	});
+
+	test("clears multiple files in one call", () => {
+		const a = path.resolve("./a.ts");
+		const b = path.resolve("./b.ts");
+		const cache = new Map<string, unknown>([
+			[a, {}],
+			[b, {}],
+		]);
+
+		clearJitiCache(fakeJiti(cache), "./a.ts", "./b.ts");
+
+		expect(cache.size).toBe(0);
+	});
+
+	test("is a no-op when the jiti instance has no cache", () => {
+		expect(() => clearJitiCache(fakeJiti(undefined), "./a.ts")).not.toThrow();
+	});
+});
+
+describe("clearAllJitiCache", () => {
+	test("empties a Map cache", () => {
+		const cache = new Map<string, unknown>([
+			["a", {}],
+			["b", {}],
+		]);
+
+		clearAllJitiCache(fakeJiti(cache));
+
+		expect(cache.size).toBe(0);
+	});
+
+	test("removes every key from an object cache", () => {
+		const cache: Record<string, unknown> = { a: {}, b: {} };
+
+		clearAllJitiCache(fakeJiti(cache));
+
+		expect(Object.keys(cache)).toHaveLength(0);
+	});
+
+	test("is a no-op when the jiti instance has no cache", () => {
+		expect(() => clearAllJitiCache(fakeJiti(undefined))).not.toThrow();
+	});
+});

--- a/engine/loader/src/module.test.ts
+++ b/engine/loader/src/module.test.ts
@@ -1,0 +1,154 @@
+import { styleframe } from "@styleframe/core";
+import type { Jiti } from "jiti";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import {
+	createLoader,
+	loadExtensionModule,
+	loadModule,
+	trackExports,
+} from "./module";
+
+const packageDir = fileURLToPath(new URL(".", import.meta.url));
+
+// Fixtures must live inside the package tree so jiti resolves the
+// "@styleframe/core" workspace import from node_modules.
+let fixtureDir: string;
+
+beforeEach(async () => {
+	fixtureDir = await mkdtemp(path.join(packageDir, "__fixtures-"));
+});
+
+afterEach(async () => {
+	await rm(fixtureDir, { recursive: true, force: true });
+});
+
+async function writeFixture(name: string, content: string): Promise<string> {
+	const filePath = path.join(fixtureDir, name);
+	await writeFile(filePath, content);
+	return filePath;
+}
+
+describe("trackExports", () => {
+	test("tracks recipes and selectors and sets _exportName", () => {
+		const s = styleframe();
+		const buttonRecipe = s.recipe({ name: "button" });
+		const cardSelector = s.selector(".card", {});
+
+		const module: Record<string, unknown> = {
+			buttonRecipe,
+			cardSelector,
+			someNumber: 42,
+			default: s,
+		};
+
+		const exports = trackExports(module);
+
+		expect(exports.size).toBe(2);
+		expect(exports.get("buttonRecipe")).toEqual({
+			name: "buttonRecipe",
+			type: "recipe",
+		});
+		expect(exports.get("cardSelector")).toEqual({
+			name: "cardSelector",
+			type: "selector",
+		});
+		expect(buttonRecipe._exportName).toBe("buttonRecipe");
+		expect(cardSelector._exportName).toBe("cardSelector");
+	});
+
+	test("skips the default export even when it is a recipe", () => {
+		const s = styleframe();
+		const module: Record<string, unknown> = {
+			default: s.recipe({ name: "ignored" }),
+		};
+
+		expect(trackExports(module).size).toBe(0);
+	});
+
+	test("ignores exports that are neither recipes nor selectors", () => {
+		expect(trackExports({ foo: 1, bar: "two", baz: {} }).size).toBe(0);
+	});
+});
+
+describe("createLoader", () => {
+	test("returns an importable jiti instance", () => {
+		const jiti = createLoader(packageDir);
+		expect(typeof jiti.import).toBe("function");
+	});
+});
+
+describe("loadModule", () => {
+	test("loads a module with a valid default export and tracks exports", async () => {
+		const filePath = await writeFixture(
+			"config.ts",
+			`import { styleframe } from "@styleframe/core";
+			const s = styleframe();
+			export const cardSelector = s.selector(".card", {});
+			export const buttonRecipe = s.recipe({ name: "button" });
+			export default s;`,
+		);
+
+		const { instance, exports, module } = await loadModule(filePath);
+
+		expect(instance).toBeDefined();
+		expect(instance.id).toEqual(expect.any(String));
+		expect(module.default).toBe(instance);
+		expect(exports.get("cardSelector")?.type).toBe("selector");
+		expect(exports.get("buttonRecipe")?.type).toBe("recipe");
+	});
+
+	test("throws when the default export is missing", async () => {
+		// A module namespace with named exports but no default. Driven through a
+		// stub jiti because the loader's real jiti interops a default in.
+		const jiti = {
+			import: async () => ({ value: 1 }),
+		} as unknown as Jiti;
+
+		await expect(
+			loadModule(path.join(fixtureDir, "no-default.ts"), { jiti }),
+		).rejects.toThrow(/Missing default export/);
+	});
+
+	test("throws when the default export is not a Styleframe instance", async () => {
+		const filePath = await writeFixture(
+			"invalid-default.ts",
+			`export default { not: "styleframe" };`,
+		);
+
+		await expect(loadModule(filePath)).rejects.toThrow(
+			/Invalid default export/,
+		);
+	});
+
+	test("skips validation when validateInstance is false", async () => {
+		const filePath = await writeFixture(
+			"invalid-default.ts",
+			`export default { not: "styleframe" };`,
+		);
+
+		const { instance } = await loadModule(filePath, {
+			validateInstance: false,
+		});
+
+		expect(instance).toEqual({ not: "styleframe" });
+	});
+});
+
+describe("loadExtensionModule", () => {
+	test("loads a module without a default export and tracks exports", async () => {
+		const filePath = await writeFixture(
+			"extension.ts",
+			`import { styleframe } from "@styleframe/core";
+			const s = styleframe();
+			export const cardSelector = s.selector(".card", {});`,
+		);
+
+		const { module, exports } = await loadExtensionModule(filePath);
+
+		expect(module.cardSelector).toBeDefined();
+		expect(exports.get("cardSelector")?.type).toBe("selector");
+	});
+});

--- a/engine/loader/src/utils.test.ts
+++ b/engine/loader/src/utils.test.ts
@@ -1,0 +1,31 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { directoryExists } from "./utils";
+
+describe("directoryExists", () => {
+	let dir: string;
+
+	beforeEach(async () => {
+		dir = await mkdtemp(path.join(tmpdir(), "sf-loader-utils-"));
+	});
+
+	afterEach(async () => {
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	test("returns true for an existing directory", async () => {
+		expect(await directoryExists(dir)).toBe(true);
+	});
+
+	test("returns false for a path that does not exist", async () => {
+		expect(await directoryExists(path.join(dir, "missing"))).toBe(false);
+	});
+
+	test("returns false when the path is a file, not a directory", async () => {
+		const filePath = path.join(dir, "file.txt");
+		await writeFile(filePath, "content");
+		expect(await directoryExists(filePath)).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

`engine/loader` was the only engine package with zero unit tests (SF-4). This adds colocated happy- and failure-path tests for **every exported function**, wired into `pnpm --filter @styleframe/loader test`.

- **config.ts** — `loadConfiguration` (resolve/default/invalid) and `watchConfiguration` HMR: not-found throw, `onUpdate` on change, `onError` on reload failure, `onError` on unlink. Chokidar is mocked so change/unlink events fire deterministically.
- **module.ts** — `trackExports`, `createLoader`, `loadModule` (valid / missing-default / invalid-default / `validateInstance: false`), `loadExtensionModule`. Real jiti loads temp fixtures inside the package tree.
- **jiti.ts** — `createSharedJiti`, `clearJitiCache` (Map + object cache + no-cache no-op), `clearAllJitiCache`.
- **build.ts** — transpiler + license mocked: writes files (nested dirs), `clean` true/false, options forwarding, and the license-gate short-circuit.
- **utils.ts** — `directoryExists` (dir / missing / file).

No source changes — tests only.

Coverage (loader src): **100% stmts / 100% lines / 100% funcs / 91.5% branches** (35 tests).

## Verification

- `pnpm --filter @styleframe/loader test` → 35 passed
- `pnpm --filter @styleframe/loader typecheck` → clean
- `pnpm --filter @styleframe/loader build` → ok
- `npx oxlint src` (in engine/loader) → ok

## Test plan

- [ ] CI green (build / test / typecheck / lint)
- [ ] codecov patch target met