### PR TITLE
feat(theme): first-class container-query modifiers + utility

### DIFF
--- a/.changeset/theme-container-queries.md
+++ b/.changeset/theme-container-queries.md
@@ -1,0 +1,5 @@
+---
+"@styleframe/theme": minor
+---
+
+Add first-class container-query support: `useContainerQueryModifiers` (container-sm/md/lg/xl/2xl, mirroring the media-preference modifiers) and `useContainerTypeUtility`/`useContainerNameUtility` for `container-type`/`container-name` setup. Both are registered in `useModifiersPreset`/`useUtilitiesPreset`. Container units (`cqi`/`cqb`/`cqw`/`cqh`) work as raw token values with no extra API. Purely additive — the raw `atRule('container', …)` path is unchanged.

--- a/theme/src/modifiers/index.ts
+++ b/theme/src/modifiers/index.ts
@@ -1,4 +1,5 @@
 export * from "./useAriaStateModifiers";
+export * from "./useContainerQueryModifiers";
 export * from "./useDirectionalModifiers";
 export * from "./useFormStateModifiers";
 export * from "./useMediaPreferenceModifiers";

--- a/theme/src/modifiers/useContainerQueryModifiers.test.ts
+++ b/theme/src/modifiers/useContainerQueryModifiers.test.ts
@@ -1,0 +1,93 @@
+import type { Utility } from "@styleframe/core";
+import { isUtility, styleframe } from "@styleframe/core";
+import { consumeCSS } from "@styleframe/transpiler";
+import { useContainerQueryModifiers } from "./useContainerQueryModifiers";
+
+describe("useContainerQueryModifiers", () => {
+	it("should register all container-query modifier factories", () => {
+		const s = styleframe();
+		const modifiers = useContainerQueryModifiers(s);
+
+		expect(modifiers.containerSm.key).toEqual(["container-sm"]);
+		expect(modifiers.containerMd.key).toEqual(["container-md"]);
+		expect(modifiers.containerLg.key).toEqual(["container-lg"]);
+		expect(modifiers.containerXl.key).toEqual(["container-xl"]);
+		expect(modifiers.container2xl.key).toEqual(["container-2xl"]);
+	});
+
+	it("should add modifiers to root.modifiers", () => {
+		const s = styleframe();
+		useContainerQueryModifiers(s);
+
+		expect(s.root.modifiers).toHaveLength(5);
+	});
+
+	it("should generate correct CSS class names for the md modifier", () => {
+		const s = styleframe();
+		const { containerMd } = useContainerQueryModifiers(s);
+
+		const createDisplay = s.utility("display", ({ value }) => ({
+			display: value,
+		}));
+		createDisplay({ flex: "flex" }, [containerMd]);
+
+		const css = consumeCSS(s.root, s.options);
+		expect(css).toContain("._display\\:flex {");
+		expect(css).toContain("._container-md\\:display\\:flex {");
+	});
+
+	it("should transpile to a valid @container block sized to the breakpoint", () => {
+		const s = styleframe();
+		const { containerMd } = useContainerQueryModifiers(s);
+
+		const createDisplay = s.utility("display", ({ value }) => ({
+			display: value,
+		}));
+		createDisplay({ flex: "flex" }, [containerMd]);
+
+		const css = consumeCSS(s.root, s.options);
+		expect(css).toContain("@container (min-width: 768px) {");
+	});
+
+	it("should render every breakpoint at its shared scale value", () => {
+		const s = styleframe();
+		const { containerSm, containerLg, containerXl, container2xl } =
+			useContainerQueryModifiers(s);
+
+		const createDisplay = s.utility("display", ({ value }) => ({
+			display: value,
+		}));
+		createDisplay({ block: "block" }, [
+			containerSm,
+			containerLg,
+			containerXl,
+			container2xl,
+		]);
+
+		const css = consumeCSS(s.root, s.options);
+		expect(css).toContain("@container (min-width: 576px) {");
+		expect(css).toContain("@container (min-width: 992px) {");
+		expect(css).toContain("@container (min-width: 1200px) {");
+		expect(css).toContain("@container (min-width: 1440px) {");
+	});
+
+	it("should work with utility creation", () => {
+		const s = styleframe();
+		const { containerLg } = useContainerQueryModifiers(s);
+
+		const createColor = s.utility("color", ({ value }) => ({
+			color: value,
+		}));
+		createColor({ white: "#fff" }, [containerLg]);
+
+		const utilities = s.root.children.filter(
+			(u): u is Utility => isUtility(u) && u.name === "color",
+		);
+		expect(utilities).toHaveLength(2);
+
+		const containerUtility = utilities.find((u) =>
+			u.modifiers.includes("container-lg"),
+		);
+		expect(containerUtility).toBeDefined();
+	});
+});

--- a/theme/src/modifiers/useContainerQueryModifiers.ts
+++ b/theme/src/modifiers/useContainerQueryModifiers.ts
@@ -1,0 +1,103 @@
+import type { ModifierFactory, Styleframe } from "@styleframe/core";
+import { breakpointValues } from "../values";
+
+export interface ContainerQueryModifiers {
+	containerSm: ModifierFactory;
+	containerMd: ModifierFactory;
+	containerLg: ModifierFactory;
+	containerXl: ModifierFactory;
+	container2xl: ModifierFactory;
+}
+
+export function useContainerSmModifier(s: Styleframe): ModifierFactory {
+	return s.modifier(
+		"container-sm",
+		({ declarations, variables, children }) => ({
+			[`@container (min-width: ${breakpointValues.sm}px)`]: {
+				declarations,
+				variables,
+				children,
+			},
+		}),
+	);
+}
+
+export function useContainerMdModifier(s: Styleframe): ModifierFactory {
+	return s.modifier(
+		"container-md",
+		({ declarations, variables, children }) => ({
+			[`@container (min-width: ${breakpointValues.md}px)`]: {
+				declarations,
+				variables,
+				children,
+			},
+		}),
+	);
+}
+
+export function useContainerLgModifier(s: Styleframe): ModifierFactory {
+	return s.modifier(
+		"container-lg",
+		({ declarations, variables, children }) => ({
+			[`@container (min-width: ${breakpointValues.lg}px)`]: {
+				declarations,
+				variables,
+				children,
+			},
+		}),
+	);
+}
+
+export function useContainerXlModifier(s: Styleframe): ModifierFactory {
+	return s.modifier(
+		"container-xl",
+		({ declarations, variables, children }) => ({
+			[`@container (min-width: ${breakpointValues.xl}px)`]: {
+				declarations,
+				variables,
+				children,
+			},
+		}),
+	);
+}
+
+export function useContainer2xlModifier(s: Styleframe): ModifierFactory {
+	return s.modifier(
+		"container-2xl",
+		({ declarations, variables, children }) => ({
+			[`@container (min-width: ${breakpointValues["2xl"]}px)`]: {
+				declarations,
+				variables,
+				children,
+			},
+		}),
+	);
+}
+
+/**
+ * Register container-query modifiers for component-based responsive styling.
+ *
+ * Each modifier wraps declarations in an `@container (min-width: …)` block sized
+ * to the shared breakpoint scale — the structural twin of the media-preference
+ * modifiers, scoped to the nearest query container instead of the viewport.
+ *
+ * @example
+ * ```typescript
+ * const s = styleframe();
+ * const { containerMd } = useContainerQueryModifiers(s);
+ *
+ * const createDisplay = s.utility("display", ({ value }) => ({ display: value }));
+ * createDisplay({ flex: "flex" }, [containerMd]);
+ * ```
+ */
+export function useContainerQueryModifiers(
+	s: Styleframe,
+): ContainerQueryModifiers {
+	return {
+		containerSm: useContainerSmModifier(s),
+		containerMd: useContainerMdModifier(s),
+		containerLg: useContainerLgModifier(s),
+		containerXl: useContainerXlModifier(s),
+		container2xl: useContainer2xlModifier(s),
+	};
+}

--- a/theme/src/presets/useModifiersPreset.ts
+++ b/theme/src/presets/useModifiersPreset.ts
@@ -2,6 +2,7 @@ import type { Styleframe } from "@styleframe/core";
 
 import {
 	type AriaStateModifiers,
+	type ContainerQueryModifiers,
 	type DirectionalModifiers,
 	type FormStateModifiers,
 	type MediaPreferenceModifiers,
@@ -10,6 +11,7 @@ import {
 	type PseudoStateModifiers,
 	type StructuralModifiers,
 	useAriaStateModifiers,
+	useContainerQueryModifiers,
 	useDirectionalModifiers,
 	useFormStateModifiers,
 	useMediaPreferenceModifiers,
@@ -36,6 +38,8 @@ export interface ModifiersConfig {
 	pseudoElements?: boolean;
 	/** Media/preference query modifiers (dark, motion-safe, print, etc.) */
 	mediaPreferences?: boolean;
+	/** Container-query modifiers (container-sm, container-md, etc.) */
+	containerQueries?: boolean;
 	/** ARIA state modifiers (aria-expanded, aria-disabled, etc.) */
 	ariaStates?: boolean;
 	/** Directional modifiers (rtl, ltr) */
@@ -54,6 +58,7 @@ export type ModifierInstances = Partial<
 		StructuralModifiers &
 		PseudoElementModifiers &
 		MediaPreferenceModifiers &
+		ContainerQueryModifiers &
 		AriaStateModifiers &
 		DirectionalModifiers &
 		OtherStateModifiers
@@ -82,6 +87,9 @@ export function useModifiersPreset(
 			: undefined),
 		...(config.mediaPreferences !== false
 			? useMediaPreferenceModifiers(s)
+			: undefined),
+		...(config.containerQueries !== false
+			? useContainerQueryModifiers(s)
 			: undefined),
 		...(config.ariaStates !== false ? useAriaStateModifiers(s) : undefined),
 		...(config.directional !== false ? useDirectionalModifiers(s) : undefined),

--- a/theme/src/presets/useUtilitiesPreset.ts
+++ b/theme/src/presets/useUtilitiesPreset.ts
@@ -58,6 +58,7 @@ import {
 	breakBeforeValues,
 	breakInsideValues,
 	clearValues,
+	containerTypeValues,
 	displayValues,
 	floatValues,
 	isolationValues,
@@ -307,6 +308,8 @@ import {
 	useBreakInsideUtility,
 	useClearUtility,
 	useColumnsUtility,
+	useContainerNameUtility,
+	useContainerTypeUtility,
 	useDisplayUtility,
 	useFloatUtility,
 	useInsetEndUtility,
@@ -568,6 +571,8 @@ export interface UtilitiesPresetConfig {
 	breakBefore?: Record<string, string> | false;
 	breakInside?: Record<string, string> | false;
 	clear?: Record<string, string> | false;
+	containerType?: Record<string, string> | false;
+	containerName?: Record<string, string> | false;
 	display?: Record<string, string> | false;
 	float?: Record<string, string> | false;
 	isolation?: Record<string, string> | false;
@@ -805,6 +810,11 @@ export function useUtilitiesPreset(
 	const breakBefore = resolveValues(config.breakBefore, breakBeforeValues);
 	const breakInside = resolveValues(config.breakInside, breakInsideValues);
 	const clear = resolveValues(config.clear, clearValues);
+	const containerType = resolveValues(
+		config.containerType,
+		containerTypeValues,
+	);
+	const containerName = resolveValues(config.containerName, {});
 	const display = resolveValues(config.display, displayValues);
 	const float = resolveValues(config.float, floatValues);
 	const isolation = resolveValues(config.isolation, isolationValues);
@@ -1278,6 +1288,22 @@ export function useUtilitiesPreset(
 		resolveUtilityOptions("clear"),
 	);
 	if (clear) createClearUtility(clear);
+
+	const createContainerTypeUtility = useContainerTypeUtility(
+		s,
+		undefined,
+		undefined,
+		resolveUtilityOptions("container-type"),
+	);
+	if (containerType) createContainerTypeUtility(containerType);
+
+	const createContainerNameUtility = useContainerNameUtility(
+		s,
+		undefined,
+		undefined,
+		resolveUtilityOptions("container-name"),
+	);
+	if (containerName) createContainerNameUtility(containerName);
 
 	const createDisplayUtility = useDisplayUtility(
 		s,
@@ -2521,6 +2547,8 @@ export function useUtilitiesPreset(
 			undefined,
 			resolveUtilityOptions("columns"),
 		),
+		createContainerTypeUtility,
+		createContainerNameUtility,
 		createDisplayUtility,
 		createFloatUtility,
 		createInsetEndUtility: useInsetEndUtility(

--- a/theme/src/utilities/layout/index.ts
+++ b/theme/src/utilities/layout/index.ts
@@ -3,6 +3,7 @@ export * from "./useBoxUtility";
 export * from "./useBreakUtility";
 export * from "./useClearUtility";
 export * from "./useColumnsUtility";
+export * from "./useContainerUtility";
 export * from "./useDisplayUtility";
 export * from "./useFloatUtility";
 export * from "./useInsetUtility";

--- a/theme/src/utilities/layout/useContainerUtility.test.ts
+++ b/theme/src/utilities/layout/useContainerUtility.test.ts
@@ -1,0 +1,91 @@
+import type { Utility } from "@styleframe/core";
+import { isUtility, styleframe } from "@styleframe/core";
+import { consumeCSS } from "@styleframe/transpiler";
+import {
+	useContainerNameUtility,
+	useContainerTypeUtility,
+} from "./useContainerUtility";
+
+describe("useContainerTypeUtility", () => {
+	it("should create utility instances with provided values", () => {
+		const s = styleframe();
+		useContainerTypeUtility(s, { size: "size", "inline-size": "inline-size" });
+
+		const utilities = s.root.children.filter(
+			(u): u is Utility => isUtility(u) && u.name === "container-type",
+		);
+		expect(utilities).toHaveLength(2);
+	});
+
+	it("should set correct declarations", () => {
+		const s = styleframe();
+		useContainerTypeUtility(s, { "inline-size": "inline-size" });
+
+		const utility = s.root.children[0] as Utility;
+		expect(utility.declarations).toEqual({ containerType: "inline-size" });
+	});
+
+	it("should compile to correct CSS output", () => {
+		const s = styleframe();
+		useContainerTypeUtility(s, { "inline-size": "inline-size" });
+
+		const css = consumeCSS(s.root, s.options);
+		expect(css).toContain("._container-type\\:inline-size {");
+		expect(css).toContain("container-type: inline-size;");
+	});
+
+	it("should register the default container-type values", () => {
+		const s = styleframe();
+		useContainerTypeUtility(s);
+
+		const utilities = s.root.children.filter(
+			(u): u is Utility => isUtility(u) && u.name === "container-type",
+		);
+		expect(utilities).toHaveLength(3);
+	});
+});
+
+describe("useContainerNameUtility", () => {
+	it("should set correct declarations", () => {
+		const s = styleframe();
+		useContainerNameUtility(s, { sidebar: "sidebar" });
+
+		const utility = s.root.children[0] as Utility;
+		expect(utility.declarations).toEqual({ containerName: "sidebar" });
+	});
+
+	it("should compile to correct CSS output", () => {
+		const s = styleframe();
+		useContainerNameUtility(s, { sidebar: "sidebar" });
+
+		const css = consumeCSS(s.root, s.options);
+		expect(css).toContain("._container-name\\:sidebar {");
+		expect(css).toContain("container-name: sidebar;");
+	});
+
+	it("should ship without defaults", () => {
+		const s = styleframe();
+		useContainerNameUtility(s);
+
+		expect(s.root.children).toHaveLength(0);
+	});
+});
+
+describe("container query units", () => {
+	it("should accept cqi/cqb/cqw/cqh as raw token values", () => {
+		const s = styleframe();
+		const createWidth = s.utility("width", ({ value }) => ({ width: value }));
+		createWidth({
+			"50cqi": "50cqi",
+			"50cqb": "50cqb",
+			"50cqw": "50cqw",
+			"50cqh": "50cqh",
+		});
+
+		const css = consumeCSS(s.root, s.options);
+		expect(css).toContain("width: 50cqi;");
+		expect(css).toContain("width: 50cqb;");
+		expect(css).toContain("width: 50cqw;");
+		expect(css).toContain("width: 50cqh;");
+	});
+});

--- a/theme/src/utilities/layout/useContainerUtility.ts
+++ b/theme/src/utilities/layout/useContainerUtility.ts
@@ -1,0 +1,29 @@
+import { createUseUtility } from "../../utils";
+import { containerTypeValues } from "../../values";
+
+/**
+ * Create container-type utility classes.
+ *
+ * Establishes a query container so descendants can respond to its size via
+ * the container-query modifiers.
+ */
+export const useContainerTypeUtility = createUseUtility(
+	"container-type",
+	({ value }) => ({
+		containerType: value,
+	}),
+	{ defaults: containerTypeValues },
+);
+
+/**
+ * Create container-name utility classes.
+ *
+ * Names a query container so `@container <name> (…)` queries can target it.
+ * Names are project-defined, so this utility ships without defaults.
+ */
+export const useContainerNameUtility = createUseUtility(
+	"container-name",
+	({ value }) => ({
+		containerName: value,
+	}),
+);

--- a/theme/src/values/layout.ts
+++ b/theme/src/values/layout.ts
@@ -132,6 +132,15 @@ export const aspectRatioValues = {
 } as const;
 
 /**
+ * Default container-type utility values matching the CSS container-query spec.
+ */
+export const containerTypeValues = {
+	normal: "normal",
+	size: "size",
+	"inline-size": "inline-size",
+} as const;
+
+/**
  * Default box-sizing utility values matching Tailwind CSS.
  */
 export const boxSizingValues = {


### PR DESCRIPTION
## What

First-class container-query support in the theme (SF-8, from RFC SF-6 surface 1). Theme-only, zero engine change, non-breaking.

- **Modifiers** — `useContainerQueryModifiers` adds `container-sm/md/lg/xl/2xl`, the structural twin of `useMediaPreferenceModifiers`: each wraps `{declarations, variables, children}` under an `@container (min-width: …)` key, sized to the shared `breakpointValues` scale. Registered in `useModifiersPreset` (`containerQueries` config flag).
- **Utility** — `useContainerTypeUtility` (`container-type`: normal/size/inline-size) and `useContainerNameUtility` (`container-name`, no defaults — names are project-defined), next to `useAspectRatioUtility`. Registered in `useUtilitiesPreset` + utilities barrel.
- **Units** — `cqi`/`cqb`/`cqw`/`cqh` work as raw token values with no extra API (per the RFC), covered by a test.

## Why

RFC SF-6 accepted container queries as first-class: stable since 2023, exact media-modifier shape, perfect abstraction fit, zero engine risk.

## How verified

- `pnpm --filter @styleframe/theme test` → 292 files, 3250 tests pass (14 new)
- `pnpm typecheck --filter @styleframe/theme` → clean
- `oxlint` + `oxfmt --check` on changed files → clean
- The raw `atRule('container', …)` path is untouched (no engine changes) → renders verbatim as before.

Changeset: `@styleframe/theme` minor.

Closes SF-8.