### PR TITLE
docs(core): fix non-compiling modifier `key` example in AGENTS.md

### DIFF
--- a/engine/core/AGENTS.md
+++ b/engine/core/AGENTS.md
@@ -137,17 +137,24 @@ createPadding({ sm: ref(spacingSm) }, [hover, focus]);
 
 Creates a reusable modifier that wraps utility declarations.
 
-- **`name`** (`string | string[]`) — Modifier name(s). Arrays create multi-key modifiers (e.g., breakpoints).
-- **`factory`** (`(ctx) => DeclarationsBlock | void`) — Receives `{ declarations, variables, children, key?, selector }`.
+- **`name`** (`string | string[]`) — Modifier name(s). An array registers the same factory under several keys; the factory receives **no** key argument, so every key produces identical output. Use it only for aliases, not for per-key output like breakpoints.
+- **`factory`** (`(ctx) => DeclarationsBlock | void`) — Receives `{ declarations, variables, children }` plus the standard declarations context (`variable`, `selector`, `atRule`, `keyframes`, `media`, `ref`, `css`).
 
 ```ts
 const hover = modifier('hover', ({ declarations }) => ({
     '&:hover': declarations,
 }));
 
-// Multi-key modifier (for breakpoints)
-const responsive = modifier(['sm', 'md', 'lg'], ({ key, declarations }) => ({
-    [`@media (min-width: ${breakpoints[key]}px)`]: declarations,
+// Breakpoints: one modifier per value, each closing over its own width.
+// (There is no `key` param — a single array-key modifier cannot tell sm/md/lg apart.)
+const smUp = modifier('sm', ({ declarations }) => ({
+    [`@media (min-width: ${breakpoints.sm})`]: declarations,
+}));
+const mdUp = modifier('md', ({ declarations }) => ({
+    [`@media (min-width: ${breakpoints.md})`]: declarations,
+}));
+const lgUp = modifier('lg', ({ declarations }) => ({
+    [`@media (min-width: ${breakpoints.lg})`]: declarations,
 }));
 ```
 


### PR DESCRIPTION
## Summary

`engine/core/AGENTS.md` documented a `key?` param on the modifier factory and a multi-key breakpoint snippet that does not compile and cannot work at runtime (SF-11).

- **Type:** `ModifierCallbackFn = DeclarationsCallbackContext & Pick<Utility, "declarations" | "variables" | "children">` (`engine/core/src/types/tokens.ts:85`). No `key` → destructuring `{ key }` is a `TS2339`.
- **Runtime:** the factory is invoked as `factory({ ...callbackContext, declarations, variables, children })` (`engine/core/src/tokens/modifier.ts:37`); `callbackContext` carries `{ variable, selector, atRule, keyframes, media, ref, css }` — no `key`. A single array-key factory cannot tell `sm`/`md`/`lg` apart (the multi-key test hardcodes one width for all three: `engine/core/src/tokens/modifier.test.ts:417`).

## Change

Docs-only. Drops the `key?` documentation and shows one modifier per breakpoint, each closing over its own width. Also corrects the array-key description: an array registers the same factory under several keys and produces identical output — aliases only, not per-key breakpoints. The `factory` context list now matches the actual type.

Root-caused by Étoile during the Tailwind migration-guide review. Closes SF-11.

## Test plan

- [x] `grep` confirms no remaining `key` param references in the modifier section
- [x] Snippet now compiles against `ModifierCallbackFn` (destructures only `declarations`)