### PR TITLE
feat(theme): anchor + view-transition escape-hatch utilities (SF-9)

### DIFF
--- a/.changeset/theme-anchor-view-transition-utilities.md
+++ b/.changeset/theme-anchor-view-transition-utilities.md
@@ -1,0 +1,5 @@
+---
+"@styleframe/theme": minor
+---
+
+Add escape-hatch tier utilities for the stable anchor-positioning and view-transition properties (RFC SF-6, surfaces 3 & 4): `useAnchorNameUtility`/`usePositionAnchorUtility`/`usePositionAreaUtility` (`anchor-name`/`position-anchor`/`position-area`) and `useViewTransitionNameUtility` (`view-transition-name`). Each emits its single declaration and, like `container-name`, ships without defaults. All four are registered in `useUtilitiesPreset`. These are thin property utilities, not first-class sugar — the still-moving parts (`anchor()` expressions, `@position-try`, `position-visibility`, the `::view-transition-*` pseudo-elements, and cross-document `@view-transition`) stay on the raw `atRule` hatch. Purely additive.

--- a/theme/src/presets/useUtilitiesPreset.ts
+++ b/theme/src/presets/useUtilitiesPreset.ts
@@ -299,6 +299,7 @@ import {
 
 // Layout
 import {
+	useAnchorNameUtility,
 	useAspectRatioUtility,
 	useBottomUtility,
 	useBoxDecorationBreakUtility,
@@ -327,6 +328,8 @@ import {
 	useOverscrollUtility,
 	useOverscrollXUtility,
 	useOverscrollYUtility,
+	usePositionAnchorUtility,
+	usePositionAreaUtility,
 	usePositionUtility,
 	useRightUtility,
 	useTopUtility,
@@ -427,6 +430,7 @@ import {
 	useTransitionPropertyUtility,
 	useTransitionTimingFunctionUtility,
 	useTransitionUtility,
+	useViewTransitionNameUtility,
 } from "../utilities/transitions-animation";
 
 // Typography
@@ -564,6 +568,7 @@ export interface UtilitiesPresetConfig {
 	willChange?: Record<string, string> | false;
 
 	// Layout
+	anchorName?: Record<string, string> | false;
 	aspectRatio?: Record<string, string> | false;
 	boxDecorationBreak?: Record<string, string> | false;
 	boxSizing?: Record<string, string> | false;
@@ -581,6 +586,8 @@ export interface UtilitiesPresetConfig {
 	overflow?: Record<string, string> | false;
 	overscroll?: Record<string, string> | false;
 	position?: Record<string, string> | false;
+	positionAnchor?: Record<string, string> | false;
+	positionArea?: Record<string, string> | false;
 	visibility?: Record<string, string> | false;
 	zIndex?: Record<string, string> | false;
 
@@ -616,6 +623,7 @@ export interface UtilitiesPresetConfig {
 	animationIterationCount?: Record<string, string> | false;
 	transitionBehavior?: Record<string, string> | false;
 	transitionProperty?: Record<string, string> | false;
+	viewTransitionName?: Record<string, string> | false;
 
 	// Typography utility
 	fontSmoothing?: Record<string, string> | false;
@@ -800,6 +808,7 @@ export function useUtilitiesPreset(
 	const touchAction = resolveValues(config.touchAction, touchActionValues);
 	const userSelect = resolveValues(config.userSelect, userSelectValues);
 	const willChange = resolveValues(config.willChange, willChangeValues);
+	const anchorName = resolveValues(config.anchorName, {});
 	const aspectRatio = resolveValues(config.aspectRatio, aspectRatioValues);
 	const boxDecorationBreak = resolveValues(
 		config.boxDecorationBreak,
@@ -826,6 +835,8 @@ export function useUtilitiesPreset(
 	const overflow = resolveValues(config.overflow, overflowValues);
 	const overscroll = resolveValues(config.overscroll, overscrollValues);
 	const position = resolveValues(config.position, positionValues);
+	const positionAnchor = resolveValues(config.positionAnchor, {});
+	const positionArea = resolveValues(config.positionArea, {});
 	const visibility = resolveValues(config.visibility, visibilityValues);
 	const zIndex = resolveValues(config.zIndex, zIndexValues);
 	const width = resolveValues(config.width, widthValues);
@@ -878,6 +889,7 @@ export function useUtilitiesPreset(
 		config.transitionProperty,
 		transitionPropertyValues,
 	);
+	const viewTransitionName = resolveValues(config.viewTransitionName, {});
 	const fontSmoothing = resolveValues(
 		config.fontSmoothing,
 		fontSmoothingValues,
@@ -1233,6 +1245,14 @@ export function useUtilitiesPreset(
 	);
 	if (willChange) createWillChangeUtility(willChange);
 
+	const createAnchorNameUtility = useAnchorNameUtility(
+		s,
+		undefined,
+		undefined,
+		resolveUtilityOptions("anchor-name"),
+	);
+	if (anchorName) createAnchorNameUtility(anchorName);
+
 	const createAspectRatioUtility = useAspectRatioUtility(
 		s,
 		undefined,
@@ -1368,6 +1388,22 @@ export function useUtilitiesPreset(
 		resolveUtilityOptions("position"),
 	);
 	if (position) createPositionUtility(position);
+
+	const createPositionAnchorUtility = usePositionAnchorUtility(
+		s,
+		undefined,
+		undefined,
+		resolveUtilityOptions("position-anchor"),
+	);
+	if (positionAnchor) createPositionAnchorUtility(positionAnchor);
+
+	const createPositionAreaUtility = usePositionAreaUtility(
+		s,
+		undefined,
+		undefined,
+		resolveUtilityOptions("position-area"),
+	);
+	if (positionArea) createPositionAreaUtility(positionArea);
 
 	const createVisibilityUtility = useVisibilityUtility(
 		s,
@@ -1642,6 +1678,14 @@ export function useUtilitiesPreset(
 		resolveUtilityOptions("transition-property"),
 	);
 	if (transitionProperty) createTransitionPropertyUtility(transitionProperty);
+
+	const createViewTransitionNameUtility = useViewTransitionNameUtility(
+		s,
+		undefined,
+		undefined,
+		resolveUtilityOptions("view-transition-name"),
+	);
+	if (viewTransitionName) createViewTransitionNameUtility(viewTransitionName);
 
 	const createFontSmoothingUtility = useFontSmoothingUtility(
 		s,
@@ -2537,6 +2581,7 @@ export function useUtilitiesPreset(
 		),
 		createBoxDecorationBreakUtility,
 		createBoxSizingUtility,
+		createAnchorNameUtility,
 		createBreakAfterUtility,
 		createBreakBeforeUtility,
 		createBreakInsideUtility,
@@ -2617,6 +2662,8 @@ export function useUtilitiesPreset(
 			resolveUtilityOptions("overscroll-y"),
 		),
 		createPositionUtility,
+		createPositionAnchorUtility,
+		createPositionAreaUtility,
 		createRightUtility: useRightUtility(
 			s,
 			undefined,
@@ -2964,6 +3011,7 @@ export function useUtilitiesPreset(
 			undefined,
 			resolveUtilityOptions("transition-timing-function"),
 		),
+		createViewTransitionNameUtility,
 
 		// Typography
 		createColorUtility: useColorUtility(

--- a/theme/src/utilities/layout/index.ts
+++ b/theme/src/utilities/layout/index.ts
@@ -1,3 +1,4 @@
+export * from "./useAnchorUtility";
 export * from "./useAspectRatioUtility";
 export * from "./useBoxUtility";
 export * from "./useBreakUtility";

--- a/theme/src/utilities/layout/useAnchorUtility.test.ts
+++ b/theme/src/utilities/layout/useAnchorUtility.test.ts
@@ -1,0 +1,96 @@
+import type { Utility } from "@styleframe/core";
+import { isUtility, styleframe } from "@styleframe/core";
+import { consumeCSS } from "@styleframe/transpiler";
+import {
+	useAnchorNameUtility,
+	usePositionAnchorUtility,
+	usePositionAreaUtility,
+} from "./useAnchorUtility";
+
+describe("useAnchorNameUtility", () => {
+	it("should create utility instances with provided values", () => {
+		const s = styleframe();
+		useAnchorNameUtility(s, { toggle: "--toggle", menu: "--menu" });
+
+		const utilities = s.root.children.filter(
+			(u): u is Utility => isUtility(u) && u.name === "anchor-name",
+		);
+		expect(utilities).toHaveLength(2);
+	});
+
+	it("should set correct declarations", () => {
+		const s = styleframe();
+		useAnchorNameUtility(s, { toggle: "--toggle" });
+
+		const utility = s.root.children[0] as Utility;
+		expect(utility.declarations).toEqual({ anchorName: "--toggle" });
+	});
+
+	it("should compile to correct CSS output", () => {
+		const s = styleframe();
+		useAnchorNameUtility(s, { toggle: "--toggle" });
+
+		const css = consumeCSS(s.root, s.options);
+		expect(css).toContain("._anchor-name\\:toggle {");
+		expect(css).toContain("anchor-name: --toggle;");
+	});
+
+	it("should ship without defaults", () => {
+		const s = styleframe();
+		useAnchorNameUtility(s);
+
+		expect(s.root.children).toHaveLength(0);
+	});
+});
+
+describe("usePositionAnchorUtility", () => {
+	it("should set correct declarations", () => {
+		const s = styleframe();
+		usePositionAnchorUtility(s, { toggle: "--toggle" });
+
+		const utility = s.root.children[0] as Utility;
+		expect(utility.declarations).toEqual({ positionAnchor: "--toggle" });
+	});
+
+	it("should compile to correct CSS output", () => {
+		const s = styleframe();
+		usePositionAnchorUtility(s, { toggle: "--toggle" });
+
+		const css = consumeCSS(s.root, s.options);
+		expect(css).toContain("._position-anchor\\:toggle {");
+		expect(css).toContain("position-anchor: --toggle;");
+	});
+
+	it("should ship without defaults", () => {
+		const s = styleframe();
+		usePositionAnchorUtility(s);
+
+		expect(s.root.children).toHaveLength(0);
+	});
+});
+
+describe("usePositionAreaUtility", () => {
+	it("should set correct declarations", () => {
+		const s = styleframe();
+		usePositionAreaUtility(s, { "top-center": "top center" });
+
+		const utility = s.root.children[0] as Utility;
+		expect(utility.declarations).toEqual({ positionArea: "top center" });
+	});
+
+	it("should compile to correct CSS output", () => {
+		const s = styleframe();
+		usePositionAreaUtility(s, { "bottom-right": "bottom right" });
+
+		const css = consumeCSS(s.root, s.options);
+		expect(css).toContain("._position-area\\:bottom-right {");
+		expect(css).toContain("position-area: bottom right;");
+	});
+
+	it("should ship without defaults", () => {
+		const s = styleframe();
+		usePositionAreaUtility(s);
+
+		expect(s.root.children).toHaveLength(0);
+	});
+});

--- a/theme/src/utilities/layout/useAnchorUtility.ts
+++ b/theme/src/utilities/layout/useAnchorUtility.ts
@@ -1,0 +1,48 @@
+import { createUseUtility } from "../../utils";
+
+/**
+ * Create anchor-name utility classes.
+ *
+ * Escape-hatch tier: a thin property utility for the stable `anchor-name`
+ * declaration, exposing an element as a named anchor so anchor-positioned
+ * elements can reference it. Names are project-defined, so this utility ships
+ * without defaults. The still-moving parts of anchor positioning —
+ * `anchor()` expressions, `@position-try`, `position-visibility` — stay on the
+ * raw `atRule` hatch.
+ */
+export const useAnchorNameUtility = createUseUtility(
+	"anchor-name",
+	({ value }) => ({
+		anchorName: value,
+	}),
+);
+
+/**
+ * Create position-anchor utility classes.
+ *
+ * Escape-hatch tier: a thin property utility for the stable `position-anchor`
+ * declaration, binding an anchor-positioned element to its default anchor by
+ * name. Anchor names are project-defined, so this utility ships without
+ * defaults.
+ */
+export const usePositionAnchorUtility = createUseUtility(
+	"position-anchor",
+	({ value }) => ({
+		positionAnchor: value,
+	}),
+);
+
+/**
+ * Create position-area utility classes.
+ *
+ * Escape-hatch tier: a thin property utility for the stable `position-area`
+ * declaration, placing an anchor-positioned element on the implicit anchor
+ * grid. Area values are project-defined, so this utility ships without
+ * defaults.
+ */
+export const usePositionAreaUtility = createUseUtility(
+	"position-area",
+	({ value }) => ({
+		positionArea: value,
+	}),
+);

--- a/theme/src/utilities/transitions-animation/index.ts
+++ b/theme/src/utilities/transitions-animation/index.ts
@@ -1,2 +1,3 @@
 export * from "./useAnimationUtility";
 export * from "./useTransitionUtility";
+export * from "./useViewTransitionUtility";

--- a/theme/src/utilities/transitions-animation/useViewTransitionUtility.test.ts
+++ b/theme/src/utilities/transitions-animation/useViewTransitionUtility.test.ts
@@ -1,0 +1,40 @@
+import type { Utility } from "@styleframe/core";
+import { isUtility, styleframe } from "@styleframe/core";
+import { consumeCSS } from "@styleframe/transpiler";
+import { useViewTransitionNameUtility } from "./useViewTransitionUtility";
+
+describe("useViewTransitionNameUtility", () => {
+	it("should create utility instances with provided values", () => {
+		const s = styleframe();
+		useViewTransitionNameUtility(s, { hero: "hero", card: "card" });
+
+		const utilities = s.root.children.filter(
+			(u): u is Utility => isUtility(u) && u.name === "view-transition-name",
+		);
+		expect(utilities).toHaveLength(2);
+	});
+
+	it("should set correct declarations", () => {
+		const s = styleframe();
+		useViewTransitionNameUtility(s, { hero: "hero" });
+
+		const utility = s.root.children[0] as Utility;
+		expect(utility.declarations).toEqual({ viewTransitionName: "hero" });
+	});
+
+	it("should compile to correct CSS output", () => {
+		const s = styleframe();
+		useViewTransitionNameUtility(s, { hero: "hero" });
+
+		const css = consumeCSS(s.root, s.options);
+		expect(css).toContain("._view-transition-name\\:hero {");
+		expect(css).toContain("view-transition-name: hero;");
+	});
+
+	it("should ship without defaults", () => {
+		const s = styleframe();
+		useViewTransitionNameUtility(s);
+
+		expect(s.root.children).toHaveLength(0);
+	});
+});

--- a/theme/src/utilities/transitions-animation/useViewTransitionUtility.ts
+++ b/theme/src/utilities/transitions-animation/useViewTransitionUtility.ts
@@ -1,0 +1,19 @@
+import { createUseUtility } from "../../utils";
+
+/**
+ * Create view-transition-name utility classes.
+ *
+ * Escape-hatch tier: a thin property utility for the stable
+ * `view-transition-name` declaration, tagging an element so the View
+ * Transitions API can animate it independently across a transition. Names are
+ * project-defined, so this utility ships without defaults. The still-moving
+ * parts — the `::view-transition-*` pseudo-elements and the cross-document
+ * `@view-transition` rule — stay on the raw `atRule` hatch until they reach
+ * Baseline.
+ */
+export const useViewTransitionNameUtility = createUseUtility(
+	"view-transition-name",
+	({ value }) => ({
+		viewTransitionName: value,
+	}),
+);


### PR DESCRIPTION
## Summary

Ships the stable plain-property utilities from **RFC SF-6, surfaces 3 & 4** (escape-hatch tier). Non-breaking, purely additive.

- **Anchor positioning** — `useAnchorNameUtility` (`anchor-name`), `usePositionAnchorUtility` (`position-anchor`), `usePositionAreaUtility` (`position-area`)
- **View transitions** — `useViewTransitionNameUtility` (`view-transition-name`)

Each utility emits its single declaration and, like `container-name`/`animation-name`, ships **without defaults** (values are project-defined idents/areas). All four are registered in `useUtilitiesPreset` (config option, resolveValues, body creation, and return).

These are thin property utilities, **not first-class sugar**. Everything still moving stays on the raw `atRule` hatch and is explicitly out of scope: `anchor()` expressions, `@position-try`, `position-visibility`, the `::view-transition-*` pseudo-elements, and cross-document `@view-transition`.

## Acceptance criteria

- [x] Each utility emits its single declaration — colocated Vitest assertions in `theme/src/utilities/layout/useAnchorUtility.test.ts` and `theme/src/utilities/transitions-animation/useViewTransitionUtility.test.ts` (declarations + compiled CSS + ships-without-defaults).
- [x] Documented as escape-hatch tier — JSDoc on each utility + changeset framing. (Public doc page is Larousse's surface — flagged in the close-out.)
- [ ] Reviewed by Étoile.

## Verification

- `pnpm build:nodocs` — ✅
- `pnpm --filter @styleframe/theme test` — ✅ 294 files, 3264 tests
- `pnpm typecheck` (full repo) — ✅ 15 tasks (incl. storybook + playground)
- `oxlint` on theme/src — ✅ clean on changed files (repo-wide `pnpm lint` OOM'd in the sandbox — environment memory, not code)

## Exit criteria (from RFC, unchanged)

- Anchor: revisit first-class `@position-try` sugar once Safari flip support (18.4+) reaches Baseline widely-available — checkpoint Q2 2027.
- View transitions: promote `::view-transition-*` to a modifier family once Firefox ships `@view-transition`.