### PR TITLE
fix(theme): map spacing multiplier scale on inset utilities

### DIFF
--- a/.changeset/theme-inset-spacing-scale.md
+++ b/.changeset/theme-inset-spacing-scale.md
@@ -1,0 +1,6 @@
+---
+"@styleframe/theme": patch
+"styleframe": patch
+---
+
+Fix inset utilities dropping the spacing multiplier scale. The nine inset composables (`inset`, `inset-x`, `inset-y`, `inset-inline-start`, `inset-inline-end`, `top`, `right`, `bottom`, `left`) were plain `createUseUtility`, so a numeric ref like `@0.5` fell through to a bare lookup for a non-existent `0.5` variable and silently emitted an undefined `var(--0--5)`. They now use `createUseSpacingUtility(..., { namespace: "spacing" })` like `margin`/`padding`/`height`, so `@0.5` resolves to `calc(var(--spacing) * 0.5)`. Object-syntax literals and preset `undefined` calls are unchanged — purely a fix for numeric-multiplier insets. Note: existing `@spacing.xs` inset usages shorten the utility class key `spacing.xs` → `xs` (resolved var identical), matching margin.

--- a/theme/src/utilities/layout/useInsetUtility.test.ts
+++ b/theme/src/utilities/layout/useInsetUtility.test.ts
@@ -216,3 +216,41 @@ describe("useLeftUtility", () => {
 		expect(css).toContain("left: auto;");
 	});
 });
+
+describe("inset multiplier support", () => {
+	it("should resolve numeric multiplier refs to calc(), not undefined vars", () => {
+		const s = styleframe();
+		s.variable("spacing", "1rem");
+
+		const createInset = useInsetUtility(s);
+		createInset(["@0.5"]);
+
+		const css = consumeCSS(s.root, s.options);
+		expect(css).toContain("top: calc(var(--spacing, 1rem) * 0.5);");
+		expect(css).toContain("bottom: calc(var(--spacing, 1rem) * 0.5);");
+		expect(css).not.toContain("var(--0--5)");
+	});
+
+	it("should resolve numeric multiplier refs on single-side insets", () => {
+		const s = styleframe();
+		s.variable("spacing", "1rem");
+
+		const createBottom = useBottomUtility(s);
+		createBottom(["@0.25"]);
+
+		const css = consumeCSS(s.root, s.options);
+		expect(css).toContain("bottom: calc(var(--spacing, 1rem) * 0.25);");
+		expect(css).not.toContain("var(--0--25)");
+	});
+
+	it("should support negative multiplier refs on insets", () => {
+		const s = styleframe();
+		s.variable("spacing", "1rem");
+
+		const createTop = useTopUtility(s);
+		createTop(["@-1"]);
+
+		const css = consumeCSS(s.root, s.options);
+		expect(css).toContain("top: calc(var(--spacing, 1rem) * -1);");
+	});
+});

--- a/theme/src/utilities/layout/useInsetUtility.ts
+++ b/theme/src/utilities/layout/useInsetUtility.ts
@@ -1,7 +1,7 @@
-import { createUseUtility } from "../../utils";
+import { createUseSpacingUtility } from "../../utils";
 
 /**
- * Create inset utility classes (top, right, bottom, left).
+ * Create inset utility classes (top, right, bottom, left) with multiplier support.
  *
  * @example
  * ```typescript
@@ -9,73 +9,103 @@ import { createUseUtility } from "../../utils";
  * useInsetUtility(s, { '0': '0', '1': '0.25rem', auto: 'auto' });
  * ```
  */
-export const useInsetUtility = createUseUtility("inset", ({ value }) => ({
-	top: value,
-	right: value,
-	bottom: value,
-	left: value,
-}));
+export const useInsetUtility = createUseSpacingUtility(
+	"inset",
+	({ value }) => ({
+		top: value,
+		right: value,
+		bottom: value,
+		left: value,
+	}),
+	{ namespace: "spacing" },
+);
 
 /**
  * Create inset-x utility classes (left and right).
  */
-export const useInsetXUtility = createUseUtility("inset-x", ({ value }) => ({
-	left: value,
-	right: value,
-}));
+export const useInsetXUtility = createUseSpacingUtility(
+	"inset-x",
+	({ value }) => ({
+		left: value,
+		right: value,
+	}),
+	{ namespace: "spacing" },
+);
 
 /**
  * Create inset-y utility classes (top and bottom).
  */
-export const useInsetYUtility = createUseUtility("inset-y", ({ value }) => ({
-	top: value,
-	bottom: value,
-}));
+export const useInsetYUtility = createUseSpacingUtility(
+	"inset-y",
+	({ value }) => ({
+		top: value,
+		bottom: value,
+	}),
+	{ namespace: "spacing" },
+);
 
 /**
  * Create inset-inline-start utility classes.
  */
-export const useInsetStartUtility = createUseUtility(
+export const useInsetStartUtility = createUseSpacingUtility(
 	"inset-inline-start",
 	({ value }) => ({
 		insetInlineStart: value,
 	}),
+	{ namespace: "spacing" },
 );
 
 /**
  * Create inset-inline-end utility classes.
  */
-export const useInsetEndUtility = createUseUtility(
+export const useInsetEndUtility = createUseSpacingUtility(
 	"inset-inline-end",
 	({ value }) => ({
 		insetInlineEnd: value,
 	}),
+	{ namespace: "spacing" },
 );
 
 /**
  * Create top utility classes.
  */
-export const useTopUtility = createUseUtility("top", ({ value }) => ({
-	top: value,
-}));
+export const useTopUtility = createUseSpacingUtility(
+	"top",
+	({ value }) => ({
+		top: value,
+	}),
+	{ namespace: "spacing" },
+);
 
 /**
  * Create right utility classes.
  */
-export const useRightUtility = createUseUtility("right", ({ value }) => ({
-	right: value,
-}));
+export const useRightUtility = createUseSpacingUtility(
+	"right",
+	({ value }) => ({
+		right: value,
+	}),
+	{ namespace: "spacing" },
+);
 
 /**
  * Create bottom utility classes.
  */
-export const useBottomUtility = createUseUtility("bottom", ({ value }) => ({
-	bottom: value,
-}));
+export const useBottomUtility = createUseSpacingUtility(
+	"bottom",
+	({ value }) => ({
+		bottom: value,
+	}),
+	{ namespace: "spacing" },
+);
 
 /**
  * Create left utility classes.
  */
-export const useLeftUtility = createUseUtility("left", ({ value }) => ({
-	left: value,
-}));
+export const useLeftUtility = createUseSpacingUtility(
+	"left",
+	({ value }) => ({
+		left: value,
+	}),
+	{ namespace: "spacing" },
+);


### PR DESCRIPTION
## Summary

Insets were plain `createUseUtility`, so a numeric ref like `@0.5` fell through to a bare token lookup for a non-existent `0.5` variable and silently emitted an undefined `var(--0--5)`. This swaps all 9 inset composables (`inset`, `inset-x`, `inset-y`, `inset-inline-start`, `inset-inline-end`, `top`, `right`, `bottom`, `left`) to `createUseSpacingUtility(..., { namespace: "spacing" })` — written exactly like `useMarginUtility` — so insets map the spacing multiplier scale like margin/padding/height.

- `@0.5` on an inset → `calc(var(--spacing, 1rem) * 0.5)`, consistent with margin/padding/height.
- Object-syntax literals (`{ "0": "0", auto: "auto" }`) and the preset's `undefined` calls are unchanged — the composable signature is identical.

**Output-shape note for review:** existing `@spacing.xs` inset usages now shorten the utility class key `spacing.xs` → `xs` (same as margin); the resolved var is identical.

## Test plan

- [x] `pnpm --filter @styleframe/theme test` — 3267 passed (incl. 3 new inset multiplier tests asserting `calc(...)` and no `var(--0--5)`)
- [x] `pnpm typecheck` — green
- [x] `pnpm lint` — green (exit 0, no new warnings)

Refs SF-12.
