### PR TITLE
docs(canon): lead positioning What with "The Design Systems Styling Engine"

### DIFF
--- a/.claude/skills/marketing-craft/SKILL.md
+++ b/.claude/skills/marketing-craft/SKILL.md
@@ -11,7 +11,7 @@ Developers are marketed at all day and punish it. The only marketing that works 
 
 Every outbound piece derives from this section. A piece that needs a claim the canon lacks means the canon changes first (PR, @mise review), then the piece. **Canon v0, drafted from the repo survey of 2026-07-11 — the cold-start issue refines it with Alex. Category line locked 2026-07-12 (SF-14, Alex sign-off): "The Design Systems Styling Engine."**
 
-- **Category line:** Styleframe — the Design Systems Styling Engine. This is the standing one-liner; every piece derives its framing from it.
+- **Category line:** Styleframe — The Design Systems Styling Engine. This is the standing one-liner; every piece derives its framing from it.
 - **What:** Styleframe is **the Design Systems Styling Engine** — the single source of truth that compiles a design system's tokens, themes, utilities, and component recipes into CSS and typed declarations. *Mechanism, the proof underneath the category:* a type-safe, composable CSS-in-TypeScript framework — you author the system in TypeScript, and the transpiler emits CSS, TypeScript, and type declarations.
 - **For whom:** teams building a design system — who want utility-class speed with a type system behind it, or CSS-in-JS ergonomics without the runtime.
 - **Lead claims, each with its proof:**

--- a/.claude/skills/marketing-craft/SKILL.md
+++ b/.claude/skills/marketing-craft/SKILL.md
@@ -9,9 +9,10 @@ Developers are marketed at all day and punish it. The only marketing that works 
 
 ## The positioning canon — the single source of truth
 
-Every outbound piece derives from this section. A piece that needs a claim the canon lacks means the canon changes first (PR, @mise review), then the piece. **Canon v0, drafted from the repo survey of 2026-07-11 — the cold-start issue refines it with Alex.**
+Every outbound piece derives from this section. A piece that needs a claim the canon lacks means the canon changes first (PR, @mise review), then the piece. **Canon v0, drafted from the repo survey of 2026-07-11 — the cold-start issue refines it with Alex. Category line locked 2026-07-12 (SF-14, Alex sign-off): "The Design Systems Styling Engine."**
 
-- **What:** Styleframe is a type-safe, composable CSS-in-TypeScript framework for building design systems — tokens, utilities, recipes, and themes compiled to CSS, TypeScript, and type declarations.
+- **Category line:** Styleframe — the Design Systems Styling Engine. This is the standing one-liner; every piece derives its framing from it.
+- **What:** Styleframe is **the Design Systems Styling Engine** — the single source of truth that compiles a design system's tokens, themes, utilities, and component recipes into CSS and typed declarations. *Mechanism, the proof underneath the category:* a type-safe, composable CSS-in-TypeScript framework — you author the system in TypeScript, and the transpiler emits CSS, TypeScript, and type declarations.
 - **For whom:** teams building a design system — who want utility-class speed with a type system behind it, or CSS-in-JS ergonomics without the runtime.
 - **Lead claims, each with its proof:**
   1. *Type-safe end to end* — autocomplete from token to recipe variant; the compiler catches a renamed token. Proof: playground demo, the generated `.d.ts` output.


### PR DESCRIPTION
## Summary
Locks the category line from SF-14 (Alex sign-off) into the positioning canon (`.claude/skills/marketing-craft/SKILL.md`), so every future outbound piece derives from one story.

- **What** entry now leads with the category — *"the Design Systems Styling Engine"* — and demotes the mechanism (type-safe, composable CSS-in-TypeScript) to the proof beneath it.
- Adds an explicit **Category line** bullet as the standing one-liner.
- Dates the lock in the canon header note.

No product code touched; canon only.

## Context
Homepage reframe proposal + framing sign-off: SF-14. This canon change is the story-of-record; the homepage implementation (Larousse, `apps/docs/content/index.md`) derives from it.

## Test plan
- [ ] @mise review — confirm the What entry reads correctly and the category line matches the signed framing.