### PR TITLE
Teach agents to author changeset files directly (SF-15)

### DIFF
--- a/.claude/skills/styleframe-team-protocol/SKILL.md
+++ b/.claude/skills/styleframe-team-protocol/SKILL.md
@@ -92,7 +92,7 @@ Agents forget everything between tasks; the skills do not. That is why Loop 2 co
 - Branches: `<agent>/<short-slug>` (e.g. `mere/toast-recipe`). Never work on `main` directly.
 - Commits: conventional commits with package scope, matching repo history — `feat(theme): add toast recipe`, `fix(plugin): resolve virtual module on windows`, `docs:`, `chore:`, `build(deploy):`.
 - PRs target `main`, stay small, and describe: what, why, how verified. Link the issue.
-- **Changesets:** any behavior change in a publishable package (`engine/*`, `theme`, `tooling/*`) ships a changeset in the same PR (`pnpm ci:changeset`). Docs and apps (`docs`, `app`, `playground`, `storybook`) are in the changesets ignore list — no changesets there (the docs version is bumped manually).
+- **Changesets:** any behavior change in a publishable package (`engine/*`, `theme`, `tooling/*`) ships a changeset in the same PR. Write the `.changeset/<area>-<topic>.md` file directly as part of the work — format, bump selection, and examples are in the styleframe-verification skill; do **not** use the interactive `pnpm ci:changeset`, which cannot be driven headlessly. Docs and apps (`docs`, `app`, `playground`, `storybook`) are in the changesets ignore list — no changesets there (the docs version is bumped manually).
 - Root workspace files (`package.json`, `pnpm-workspace.yaml`, `pnpm-lock.yaml`, `turbo.json`) belong to @tournant — with one shared exception: any PR may update `pnpm-lock.yaml` as a side effect of its own dependency change. On a lockfile conflict, rebase on latest `main`, take main's lockfile, and re-run `pnpm install` to regenerate; the PR author rebases when their PR falls behind.
 - Never edit `dist/` or `.styleframe/` directories — they are generated.
 

--- a/.claude/skills/styleframe-verification/SKILL.md
+++ b/.claude/skills/styleframe-verification/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: styleframe-verification
-description: How to build and verify work in the Styleframe monorepo — fresh-workspace build order, per-package test/typecheck/lint commands, Storybook shim regeneration, integration-test costs, and CI gates (codecov patch). Consult before running any verification and before claiming any task done.
+description: How to build and verify work in the Styleframe monorepo — fresh-workspace build order, per-package test/typecheck/lint commands, Storybook shim regeneration, integration-test costs, authoring changeset files, and CI gates (codecov patch). Consult before running any verification and before claiming any task done.
 ---
 
 # Verifying work in the Styleframe monorepo
@@ -47,3 +47,39 @@ Always paste the commands you ran and their outcomes in your final task comment.
 - **codecov patch coverage gates ALL packages** — including `apps/playground` (the lcov path globs miss some packages and CI falls back to a repo-wide clover.xml, so nothing is exempt). New code in any package must carry tests that meet the patch target, or CI blocks the PR.
 - Pre-commit hooks (husky + lint-staged) run oxfmt/oxlint on staged files and actionlint on workflow files.
 - CI runs build, test, typecheck, lint on PRs; keep them green locally first — a red CI run wastes a full review round-trip.
+
+## Authoring a changeset
+
+Any behavior change in a **publishable** package needs a changeset in the same PR — a definition-of-done gate, not a review afterthought. Write it yourself as part of the work; do not leave it for review to catch.
+
+- **Publishable (needs a changeset):** `engine/*`, `theme`, `tooling/*` — npm names `@styleframe/core`, `@styleframe/loader`, `@styleframe/runtime`, `@styleframe/transpiler`, `@styleframe/theme`, `styleframe`, `@styleframe/cli`, `@styleframe/scanner`, `@styleframe/dtcg`, `@styleframe/figma`, `@styleframe/plugin`.
+- **Ignore list (no changeset — versions bumped by hand):** `@styleframe/docs`, `@styleframe/app`, `@styleframe/plugin-playground`, `@styleframe/storybook`, `@styleframe/testing-integration`.
+
+Do **not** run `pnpm ci:changeset` — it is the interactive `changeset` prompt and cannot be driven headlessly. Write the file directly:
+
+1. Create `.changeset/<area>-<short-topic>.md` — a descriptive kebab-case name (`theme-container-queries.md`, `plugin-windows-vmodule.md`), never the random `changeset`-generated slug.
+2. Frontmatter: one quoted `"<package>": <bump>` line per publishable package you changed. `bump` is `patch` (bug fix or internal-only change), `minor` (additive, backward-compatible feature), or `major` (breaking). A `major` needs Alex's sign-off first — never author one unprompted; escalate via @mise.
+3. Body: one or two imperative present-tense sentences for the changelog — what a consumer gets, not how you built it. Match the voice of existing entries in `.changeset/`.
+
+Single package:
+
+```md
+---
+"@styleframe/theme": minor
+---
+
+Add the `toast` recipe with `variant` (info/success/warning/danger) and `placement` axes, registered in `useRecipesPreset`.
+```
+
+Multiple packages — one line per package with its own bump:
+
+```md
+---
+"@styleframe/core": patch
+"@styleframe/plugin": patch
+---
+
+Fix virtual-module resolution on Windows so recipe trees tree-shake correctly under Vite.
+```
+
+Confirm it is picked up with `pnpm changeset status` before claiming the task done. A docs-only or apps-only change ships no changeset; a missing changeset on a publishable-package change is a standing review block.


### PR DESCRIPTION
## Summary

Agents knew changesets were *required* (definition of done, review nudges) but the only authoring instruction pointed at `pnpm ci:changeset` — the interactive `changeset` prompt, which headless agents cannot drive. So the step was routinely skipped and only caught at review.

This adds a positive, actionable authoring path to the skills every implementing seat carries.

## Changes

- **`styleframe-verification` skill** — new "Authoring a changeset" section: when one is needed (publishable `engine/*`, `theme`, `tooling/*` with the exact npm names), the ignore list that needs none, and a step-by-step for writing the `.changeset/<area>-<topic>.md` file directly — filename convention, frontmatter package+bump lines, bump selection (patch/minor/major, with major gated on Alex's sign-off), body voice, single- and multi-package examples, and `pnpm changeset status` as the check. Also surfaced in the skill `description` for discovery.
- **`styleframe-team-protocol` skill** — repointed the Changesets bullet away from the interactive `pnpm ci:changeset` to "write the file directly," cross-referencing the verification skill.

No product code, tests, or docs touched — skills only.

## Note

Multica reads skills at import time, not from git — these lessons go live only after the affected skills are re-imported post-merge.

Closes SF-15.