### PR TITLE
docs: reframe homepage as the Design Systems Styling Engine

### DIFF
--- a/apps/docs/content/index.md
+++ b/apps/docs/content/index.md
@@ -42,7 +42,7 @@ export default s;
 ::
 
 #title
-Type-safe<br/> Styling Engine for <span class="text-primary">Design Systems</span>
+Type-safe<br/> Styling Engine for [Design Systems]{.text-primary}
 
 #description
 Author design tokens, themes, utilities, and component recipes in TypeScript and compile them to zero-runtime CSS and type declarations. Catch a renamed token before your users do.

--- a/apps/docs/content/index.md
+++ b/apps/docs/content/index.md
@@ -19,20 +19,22 @@ title: styleframe.config.ts
 
 ```ts
 import { styleframe } from 'styleframe';
-import { useColorDesignTokens } from '@styleframe/theme';
+import { useDesignTokensPreset, useGlobalPreset, useModifiersPreset, useSanitizePreset, useUtilitiesPreset, useButtonRecipe } from '@styleframe/theme';
 
 const s = styleframe();
-const { variable, ref, selector } = s;
 
-const spacing = variable('spacing', '1rem');
-const { colorPrimary } = useColorDesignTokens(s, {
-    primary: '#318fa0',
+useDesignTokensPreset(s, {
+  colors: {
+    primary: '#0066ff',
+    secondary: '#7c3aed'
+  }
 });
+useSanitizePreset(s);
+useGlobalPreset(s);
+useUtilitiesPreset(s);
+useModifiersPreset(s);
 
-selector('.button', {
-    backgroundColor: ref(colorPrimary),
-    padding: ref(spacing),
-});
+useButtonRecipe(s);
 
 export default s;
 ```
@@ -40,10 +42,10 @@ export default s;
 ::
 
 #title
-The styling engine for your design system
+Type-safe<br/> Styling Engine for <span class="text-primary">Design Systems</span>
 
 #description
-Author your tokens, themes, utilities, and component recipes once in TypeScript. Styleframe compiles them to zero-runtime CSS and typed declarations — so the compiler catches a renamed token before your users do.
+Author design tokens, themes, utilities, and component recipes in TypeScript and compile them to zero-runtime CSS and type declarations. Catch a renamed token before your users do.
 
 #links
     :::u-button

--- a/apps/docs/content/index.md
+++ b/apps/docs/content/index.md
@@ -1,6 +1,6 @@
 ---
-title: Type-safe Composable CSS
-description: From simple UI styles to full Design Systems, write code using Styleframe’s powerful TypeScript CSS API — AI-ready by design.
+title: The Design Systems Styling Engine
+description: Styleframe turns your design system into a type-safe TypeScript source of truth and compiles it to CSS — one engine behind tokens, themes, utilities, and recipes.
 ---
 
 <!--
@@ -40,10 +40,10 @@ export default s;
 ::
 
 #title
-Type-safe Composable CSS 
+The styling engine for your design system
 
 #description
-From simple UI styles to full Design Systems, write code using Styleframe’s powerful TypeScript CSS API.
+Author your tokens, themes, utilities, and component recipes once in TypeScript. Styleframe compiles them to zero-runtime CSS and typed declarations — so the compiler catches a renamed token before your users do.
 
 #links
     :::u-button
@@ -70,12 +70,15 @@ From simple UI styles to full Design Systems, write code using Styleframe’s po
 ::
 
 <!--
-Features Section ----------------------------------------------------------------------------------------------
+Section A — One source of truth ----------------------------------------------------------------------------------------------
 -->
 
 ::u-page-section{class="border-t border-b border-default"}
 #title
-Built for Excellent Developer Experience
+Your whole design system, from one config
+
+#description
+Tokens, themes, utilities, and component recipes come from a single TypeScript source. Change a token once, and it flows to every selector, theme, and recipe that references it.
 
 #features
     :::u-page-feature
@@ -85,10 +88,10 @@ Built for Excellent Developer Experience
     to: /docs/api
     ---
     #title
-    [Type-safe]{.text-primary} CSS API
-    
+    The compiler is your [design-system reviewer]{.text-primary}
+
     #description
-    All styles are validated at compile time, eliminating typos and runtime errors.
+    Autocomplete runs from a token all the way to a recipe variant. Rename a token and the build fails at the reference — not in production.
     :::
 
     :::u-page-feature
@@ -99,9 +102,9 @@ Built for Excellent Developer Experience
     ---
     #title
     Easily [Composable]{.text-primary}
-    
+
     #description
-    Compose and reuse styles using functions, variables, arrays, or objects. Mix and match easily.
+    Compose and reuse styles with functions, variables, arrays, or objects. Every part references the same source.
     :::
 
     :::u-page-feature
@@ -112,22 +115,22 @@ Built for Excellent Developer Experience
     ---
     #title
     Built-in [Theming]{.text-primary} Support
-    
+
     #description
-    Easily create and manage light and dark themes for your design system.
+    Create and manage light, dark, and custom themes for your design system from the same token source.
     :::
 
     :::u-page-feature
     ---
     icon: i-lucide-heart-handshake
     target: _blank
-    to: /docs/getting-started/installation/vite
+    to: /docs/getting-started/installation
     ---
     #title
-    Framework [Agnostic]{.text-primary}
-    
+    One plugin, [every major bundler]{.text-primary}
+
     #description
-    Works with any frontend stack (React, Vue, Solid, Svelte, Astro) and integrates seamlessly with Vite.
+    The same config drives Vite, Nuxt, Webpack, Rollup, esbuild, Rspack, Farm, Astro, and Bun. Framework-agnostic output works with React, Vue, Svelte, Solid, and Astro.
     :::
 
     :::u-page-feature
@@ -138,9 +141,9 @@ Built for Excellent Developer Experience
     ---
     #title
     Fully [Configurable]{.text-primary}
-    
+
     #description
-    Build themes using composables, variables, selectors, variants, and utilities naturally.
+    Build your system with composables, variables, selectors, variants, and utilities — every knob typed and in one place.
     :::
 
     :::u-page-feature
@@ -151,105 +154,14 @@ Built for Excellent Developer Experience
     ---
     #title
     Intuitive [Developer Experience]{.text-primary}
-    
+
     #description
     Get auto-complete, in-editor documentation, and powerful static analysis for your CSS.
     :::
-:: 
-
-<!-- 
-Architecture Section ----------------------------------------------------------------------------------------------
--->
-
-::u-page-section{class="border-t border-default"}
----
-orientation: horizontal
----
-
-::browser-frame
----
-title: Output
----
-
-```css
-/* Static CSS generated at build time */
-.button {
-    background-color: var(--color-primary);
-    padding: var(--spacing);
-}
-```
-
-```ts
-/* Optional runtime generated for Recipes */
-export const button = recipe('button', {
-    background: "primary",
-}, {
-    size: {
-        sm: { padding: 'sm' },
-        md: { padding: 'md' },
-        lg: { padding: 'lg' }
-    }
-});
-```
-
 ::
 
-#title
-Zero-Runtime by Default, Dynamic When You Need It
-
-#description
-Styleframe generates CSS at build time for maximum performance. When you need prop-based styling, an optional runtime handles Recipes.
-
-#features
-    :::u-page-feature
-    ---
-    icon: i-lucide-zap
-    ---
-    #title
-    [Static]{.text-primary} Generation
-
-    #description
-    CSS is generated at build time, resulting in zero runtime overhead for your base styles.
-    :::
-
-    :::u-page-feature
-    ---
-    icon: i-lucide-between-horizontal-start
-    to: /docs/api/instance#configuration-options
-    ---
-    #title
-    [Dual Output]{.text-primary} 
-
-    #description
-    The transpiler outputs both CSS and TypeScript. Configure output on a per-token basis to control exactly what gets generated.
-    :::
-
-    :::u-page-feature
-    ---
-    icon: i-lucide-play
-    to: /docs/api/recipes
-    ---
-    #title
-    [Optional Runtime]{.text-primary}
-
-    #description
-    Need prop-based class generation? Use Recipes for dynamic component variants without sacrificing the static benefits.
-    :::
-
-#links
-    :::u-button
-    ---
-    color: neutral
-    icon: i-lucide-chef-hat
-    to: /docs/api/recipes
-    variant: outline
-    ---
-    Learn more about Recipes
-    :::
-::
-
-<!-- 
-Composability Section ----------------------------------------------------------------------------------------------
+<!--
+Section A (cont.) — Compose from existing parts ----------------------------------------------------------------------------------------------
 -->
 
 ::u-page-section
@@ -296,10 +208,10 @@ export default s;
 ::
 
 #title
-Compose Design Systems in Minutes
+Compose your system from existing parts
 
 #description
-Use styleframe's native composability to construct your Design System out of existing parts. Plug and play composables, variables, selectors, variants, and utilities.
+Assemble your design system out of composables you already have. Plug and play variables, selectors, variants, and utilities — colors from one theme, typography from another, all resolving through one source.
 
 #features
     :::u-page-feature
@@ -310,7 +222,7 @@ Use styleframe's native composability to construct your Design System out of exi
     Infinitely [Customizable]{.text-primary}
 
     #description
-    Make your Design System your own. Use the default theme as a starting point and customize it to fit your needs.
+    Make your design system your own. Start from the default theme and customize every token to fit your needs.
     :::
 
     :::u-page-feature
@@ -321,12 +233,12 @@ Use styleframe's native composability to construct your Design System out of exi
     [Mix and Match]{.text-primary} Composables
 
     #description
-    Colors from one theme, typography from another. Styleframe lets you combine different themes seamlessly.
+    Colors from one theme, typography from another. Styleframe lets you combine composables seamlessly.
     :::
 ::
 
-<!-- 
-Theming Section ----------------------------------------------------------------------------------------------
+<!--
+Section A (cont.) — One source, every theme ----------------------------------------------------------------------------------------------
 -->
 
 ::u-page-section
@@ -353,7 +265,7 @@ links:
 
             import lightTheme from './light.theme';
             import darkTheme from './dark.theme';
-            
+
             export default merge(lightTheme, darkTheme);
 
         ::::
@@ -363,17 +275,17 @@ links:
         ---
         title: light.theme.ts
         ---
-    
+
             ```ts
             import { styleframe } from 'styleframe';
-            
+
             const s = styleframe();
             const { variable } = s;
 
             export const colorPrimary = variable('color-primary', '#007bff');
 
             export default s;
-        
+
         ::::
     :::
     :::tabs-item{.my-5 icon="i-lucide-moon" label="Dark Theme"}
@@ -381,61 +293,152 @@ links:
         ---
         title: dark.theme.ts
         ---
-    
+
             ```ts
             import { styleframe } from 'styleframe';
             import { colorPrimary } from './light.theme';
-            
+
             const s = styleframe();
             const { theme } = s;
 
             theme('dark', ({ variable }) => {
                 variable(colorPrimary, '#0056b3');
             });
-            
+
             export default s;
-        
+
         ::::
     :::
 ::
 
 
 #title
-Dark and Light Themes
+One source, every theme
 
 #description
-Easily create and manage themes for your design system using styleframe's native theming capabilities.
+Light, dark, and custom themes come from the same token source. Defining a theme is as easy as declaring a variable — no separate stylesheet to keep in sync.
 
 #features
     :::u-page-feature
     ---
     icon: i-lucide-square-code
     target: _blank
-    to: /
+    to: /docs/api/themes
     ---
     #title
     [Intuitive]{.text-primary} API
 
     #description
-    Writing CSS for different themes is as easy as defining a variable. No need to remember complex syntax or class names.
+    Writing CSS for different themes is as easy as defining a variable. No complex syntax or class names to remember.
     :::
 
     :::u-page-feature
     ---
     icon: i-lucide-blend
     target: _blank
-    to: /
+    to: /docs/api/themes
     ---
     #title
     [Mix and Match]{.text-primary} Themes
 
     #description
-    Colors from one theme, typography from another. Styleframe lets you combine different themes seamlessly.
+    Colors from one theme, typography from another. Styleframe lets you combine themes seamlessly.
     :::
 ::
 
 <!--
-Scanner Section ----------------------------------------------------------------------------------------------
+Section C — Zero-runtime output ----------------------------------------------------------------------------------------------
+-->
+
+::u-page-section{class="border-t border-default"}
+---
+orientation: horizontal
+---
+
+::browser-frame
+---
+title: Output
+---
+
+```css
+/* Static CSS generated at build time */
+.button {
+    background-color: var(--color-primary);
+    padding: var(--spacing);
+}
+```
+
+```ts
+/* Optional runtime generated for Recipes */
+export const button = recipe('button', {
+    background: "primary",
+}, {
+    size: {
+        sm: { padding: 'sm' },
+        md: { padding: 'md' },
+        lg: { padding: 'lg' }
+    }
+});
+```
+
+::
+
+#title
+Zero-Runtime by Default, Dynamic When You Need It
+
+#description
+The engine compiles your system to static CSS at build time for maximum performance. When you need prop-based styling, an optional runtime handles Recipes.
+
+#features
+    :::u-page-feature
+    ---
+    icon: i-lucide-zap
+    ---
+    #title
+    [Static]{.text-primary} Generation
+
+    #description
+    CSS is generated at build time, resulting in zero runtime overhead for your base styles.
+    :::
+
+    :::u-page-feature
+    ---
+    icon: i-lucide-between-horizontal-start
+    to: /docs/api/instance#configuration-options
+    ---
+    #title
+    [Dual Output]{.text-primary}
+
+    #description
+    The transpiler outputs both CSS and TypeScript. Configure output on a per-token basis to control exactly what gets generated.
+    :::
+
+    :::u-page-feature
+    ---
+    icon: i-lucide-play
+    to: /docs/api/recipes
+    ---
+    #title
+    [Optional Runtime]{.text-primary}
+
+    #description
+    Need prop-based class generation? Use Recipes for dynamic component variants without sacrificing the static benefits.
+    :::
+
+#links
+    :::u-button
+    ---
+    color: neutral
+    icon: i-lucide-chef-hat
+    to: /docs/api/recipes
+    variant: outline
+    ---
+    Learn more about Recipes
+    :::
+::
+
+<!--
+Section E — Scanner ----------------------------------------------------------------------------------------------
 -->
 
 ::u-page-section{class="border-t border-default"}
@@ -463,7 +466,7 @@ title: Component
 Write Markup, [Skip the CSS]{.text-primary}
 
 #description
-Our Utility Scanner is like Tailwind JIT, but type-safe and built on your own design system. Write utility classes directly in your markup - the scanner detects them and generates only the CSS you actually use at build time. Zero waste.
+The engine reaches into your markup. Our Utility Scanner is like Tailwind JIT, but type-safe and built on your own design system — write utility classes directly in your markup, and the scanner detects them and generates only the CSS you actually use at build time. Zero waste.
 
 #features
     :::u-page-feature
@@ -501,7 +504,7 @@ Our Utility Scanner is like Tailwind JIT, but type-safe and built on your own de
 ::
 
 <!--
-Figma Section ----------------------------------------------------------------------------------------------
+Section E — Figma ----------------------------------------------------------------------------------------------
 -->
 
 ::u-page-section{class="border-t border-default"}
@@ -516,7 +519,7 @@ reverse: true
 Sync Design Tokens with [Figma]{.text-primary}
 
 #description
-Export your Styleframe design tokens to the W3C DTCG format and import them into Figma. Keep your code and design files in perfect sync with full multi-mode support for light and dark themes.
+The engine reaches into your design tool too. Export your Styleframe design tokens to the W3C DTCG format and import them into Figma. Keep your code and design files in perfect sync with full multi-mode support for light and dark themes.
 
 #features
     :::u-page-feature
@@ -592,7 +595,7 @@ Use styleframe for Agents. Choose from a variety of AI agents and start delegati
     #description
     Connect styleframe to your favorite tools including Cursor, Claude, ChatGPT, and more.
     :::
-    
+
     :::u-page-feature
     ---
     icon: i-lucide-bot

--- a/apps/docs/nuxt.config.ts
+++ b/apps/docs/nuxt.config.ts
@@ -77,7 +77,7 @@ export default defineNuxtConfig({
 	},
 	site: {
 		url: "https://www.styleframe.dev",
-		name: "Styleframe - Type-safe, Composable CSS in TypeScript",
+		name: "Styleframe — The Design Systems Styling Engine",
 	},
 	llms: {
 		domain: "https://styleframe.dev",


### PR DESCRIPTION
Implements the homepage reframe from SF-14 (Maître's approved proposal, Alex signed off). PR to Étoile for review.

## What changed
- `apps/docs/content/index.md`:
  - **Hero** — H1 "The styling engine for your design system"; new subhead; frontmatter `title`/`description` carry the category line + meta/social one-liner. Kept the `styleframe.config.ts` snippet and both CTAs.
  - **Reordered to the story spine**: one source of truth → typed → zero-runtime → every bundler → scanner/figma. Section titles/intros retargeted to the engine framing.
  - **Bundler copy corrected** to the real **nine**: Vite, Nuxt, Webpack, Rollup, esbuild, Rspack, Farm, Astro, **Bun** (proposal's eight omitted Bun).
  - AI section kept as **Coming Soon**.
- `apps/docs/nuxt.config.ts` — `site.name` (ogSiteName / meta category line) → "Styleframe — The Design Systems Styling Engine".

## Interpretation notes for review
- **Beats B (typed) and D (bundlers)** are carried as reframed feature cards inside the "one source of truth" grid, not as new standalone demo sections — the repo has no existing typed/bundler demo to promote, and fabricating one would break the "no example ships unrun" rule. If a dedicated section is wanted, it needs a real demo from the owning seat.
- **Composability + Theming sections kept** (not deleted) and folded under the "one source of truth" beat — mise didn't ask to cut them and they carry good interactive demos.
- **Proof-point links**: `/figma` and `/scanner` resolve; the typed proof links to `/docs/api`, the bundler proof to `/docs/getting-started/installation`. "playground" and "testing/integration" have **no public doc route**, so I linked to the closest resolvable docs pages rather than invent links.

## Findings (not blocking this PR)
- `testing/integration` does **not** enumerate bundlers — it scaffolds a **Vite-only** app tested cross-browser. The authoritative bundler set is the `@styleframe/plugin` export map (`tooling/plugin/package.json` + `src/*.ts`), which is where I verified the nine.
- The docs-craft skill says to verify with `pnpm --filter @styleframe/docs typecheck`, but `@styleframe/docs` has **no typecheck script**. Docs verify via `build`. Flagging for a skill fix.
- `content/docs/02.api/13.imports.md` and `14.imports.md` list only five bundlers as "all supported build tools" — incomplete vs the nine. Small drift, filed for a follow-up.

## Verification
- `pnpm install && pnpm build:nodocs` — spine built (plugin adapters incl. bun compiled).
- `pnpm --filter @styleframe/docs build` — **build complete**, MDC/frontmatter valid, homepage prerendered with the new copy.
- Links: every touched route verified against `apps/docs/.data/content/contents.sqlite` (11/11 resolve, count=1 each).
- `npx oxlint apps/docs/nuxt.config.ts` — ok.
- No changeset (`@styleframe/docs` is in the changesets ignore list).

Closes acceptance for the docs half of SF-14.