### PR TITLE
feat(theme): add built-in responsive breakpoint modifiers (SF-18)

### DIFF
--- a/.changeset/theme-responsive-modifiers.md
+++ b/.changeset/theme-responsive-modifiers.md
@@ -1,0 +1,5 @@
+---
+"@styleframe/theme": minor
+---
+
+Add built-in responsive breakpoint modifiers: `useResponsiveModifiers` (`sm`/`md`/`lg`/`xl`/`2xl`), the viewport-scoped twin of the container-query modifiers. A `_md:padding:xl` prefix now resolves to a real `@media (min-width: …)` block out of the box, so the Tailwind-style responsive vocabulary lines up. One modifier per breakpoint, each closing over its own width from the shared `breakpointValues` scale (576/768/992/1200/1440) — the same source of truth the container-query modifiers use, keeping `_md:` and `_container-md:` aligned. Registered in `useModifiersPreset` (toggle via `responsive: false`). Purely additive — no existing output changes.

--- a/theme/src/modifiers/index.ts
+++ b/theme/src/modifiers/index.ts
@@ -6,4 +6,5 @@ export * from "./useMediaPreferenceModifiers";
 export * from "./useOtherStateModifiers";
 export * from "./usePseudoElementModifiers";
 export * from "./usePseudoStateModifiers";
+export * from "./useResponsiveModifiers";
 export * from "./useStructuralModifiers";

--- a/theme/src/modifiers/useResponsiveModifiers.test.ts
+++ b/theme/src/modifiers/useResponsiveModifiers.test.ts
@@ -1,0 +1,85 @@
+import type { Utility } from "@styleframe/core";
+import { isUtility, styleframe } from "@styleframe/core";
+import { consumeCSS } from "@styleframe/transpiler";
+import { useResponsiveModifiers } from "./useResponsiveModifiers";
+
+describe("useResponsiveModifiers", () => {
+	it("should register all responsive modifier factories", () => {
+		const s = styleframe();
+		const modifiers = useResponsiveModifiers(s);
+
+		expect(modifiers.sm.key).toEqual(["sm"]);
+		expect(modifiers.md.key).toEqual(["md"]);
+		expect(modifiers.lg.key).toEqual(["lg"]);
+		expect(modifiers.xl.key).toEqual(["xl"]);
+		expect(modifiers["2xl"].key).toEqual(["2xl"]);
+	});
+
+	it("should add modifiers to root.modifiers", () => {
+		const s = styleframe();
+		useResponsiveModifiers(s);
+
+		expect(s.root.modifiers).toHaveLength(5);
+	});
+
+	it("should generate correct CSS class names for the md modifier", () => {
+		const s = styleframe();
+		const { md } = useResponsiveModifiers(s);
+
+		const createDisplay = s.utility("display", ({ value }) => ({
+			display: value,
+		}));
+		createDisplay({ flex: "flex" }, [md]);
+
+		const css = consumeCSS(s.root, s.options);
+		expect(css).toContain("._display\\:flex {");
+		expect(css).toContain("._md\\:display\\:flex {");
+	});
+
+	it("should transpile to a real @media (min-width) block sized to the breakpoint", () => {
+		const s = styleframe();
+		const { md } = useResponsiveModifiers(s);
+
+		const createDisplay = s.utility("display", ({ value }) => ({
+			display: value,
+		}));
+		createDisplay({ flex: "flex" }, [md]);
+
+		const css = consumeCSS(s.root, s.options);
+		expect(css).toContain("@media (min-width: 768px) {");
+	});
+
+	it("should render every breakpoint at its shared scale value", () => {
+		const s = styleframe();
+		const { sm, lg, xl, "2xl": xxl } = useResponsiveModifiers(s);
+
+		const createDisplay = s.utility("display", ({ value }) => ({
+			display: value,
+		}));
+		createDisplay({ block: "block" }, [sm, lg, xl, xxl]);
+
+		const css = consumeCSS(s.root, s.options);
+		expect(css).toContain("@media (min-width: 576px) {");
+		expect(css).toContain("@media (min-width: 992px) {");
+		expect(css).toContain("@media (min-width: 1200px) {");
+		expect(css).toContain("@media (min-width: 1440px) {");
+	});
+
+	it("should work with utility creation", () => {
+		const s = styleframe();
+		const { lg } = useResponsiveModifiers(s);
+
+		const createColor = s.utility("color", ({ value }) => ({
+			color: value,
+		}));
+		createColor({ white: "#fff" }, [lg]);
+
+		const utilities = s.root.children.filter(
+			(u): u is Utility => isUtility(u) && u.name === "color",
+		);
+		expect(utilities).toHaveLength(2);
+
+		const responsiveUtility = utilities.find((u) => u.modifiers.includes("lg"));
+		expect(responsiveUtility).toBeDefined();
+	});
+});

--- a/theme/src/modifiers/useResponsiveModifiers.ts
+++ b/theme/src/modifiers/useResponsiveModifiers.ts
@@ -1,0 +1,88 @@
+import type { ModifierFactory, Styleframe } from "@styleframe/core";
+import { breakpointValues } from "../values";
+
+export interface ResponsiveModifiers {
+	sm: ModifierFactory;
+	md: ModifierFactory;
+	lg: ModifierFactory;
+	xl: ModifierFactory;
+	"2xl": ModifierFactory;
+}
+
+export function useResponsiveSmModifier(s: Styleframe): ModifierFactory {
+	return s.modifier("sm", ({ declarations, variables, children }) => ({
+		[`@media (min-width: ${breakpointValues.sm}px)`]: {
+			declarations,
+			variables,
+			children,
+		},
+	}));
+}
+
+export function useResponsiveMdModifier(s: Styleframe): ModifierFactory {
+	return s.modifier("md", ({ declarations, variables, children }) => ({
+		[`@media (min-width: ${breakpointValues.md}px)`]: {
+			declarations,
+			variables,
+			children,
+		},
+	}));
+}
+
+export function useResponsiveLgModifier(s: Styleframe): ModifierFactory {
+	return s.modifier("lg", ({ declarations, variables, children }) => ({
+		[`@media (min-width: ${breakpointValues.lg}px)`]: {
+			declarations,
+			variables,
+			children,
+		},
+	}));
+}
+
+export function useResponsiveXlModifier(s: Styleframe): ModifierFactory {
+	return s.modifier("xl", ({ declarations, variables, children }) => ({
+		[`@media (min-width: ${breakpointValues.xl}px)`]: {
+			declarations,
+			variables,
+			children,
+		},
+	}));
+}
+
+export function useResponsive2xlModifier(s: Styleframe): ModifierFactory {
+	return s.modifier("2xl", ({ declarations, variables, children }) => ({
+		[`@media (min-width: ${breakpointValues["2xl"]}px)`]: {
+			declarations,
+			variables,
+			children,
+		},
+	}));
+}
+
+/**
+ * Register responsive breakpoint modifiers for viewport-based responsive styling.
+ *
+ * Each modifier wraps declarations in a mobile-first `@media (min-width: …)`
+ * block sized to the shared breakpoint scale — the viewport-scoped twin of the
+ * container-query modifiers, named to mirror the familiar `sm`/`md`/`lg`/`xl`/
+ * `2xl` vocabulary so a `_md:padding:xl` prefix resolves to a real media query
+ * out of the box.
+ *
+ * @example
+ * ```typescript
+ * const s = styleframe();
+ * const { md } = useResponsiveModifiers(s);
+ *
+ * const createDisplay = s.utility("display", ({ value }) => ({ display: value }));
+ * createDisplay({ flex: "flex" }, [md]);
+ * ```
+ */
+export function useResponsiveModifiers(s: Styleframe): ResponsiveModifiers {
+	return {
+		sm: useResponsiveSmModifier(s),
+		md: useResponsiveMdModifier(s),
+		lg: useResponsiveLgModifier(s),
+		xl: useResponsiveXlModifier(s),
+		"2xl": useResponsive2xlModifier(s),
+	};
+}

--- a/theme/src/presets/useModifiersPreset.ts
+++ b/theme/src/presets/useModifiersPreset.ts
@@ -9,6 +9,7 @@ import {
 	type OtherStateModifiers,
 	type PseudoElementModifiers,
 	type PseudoStateModifiers,
+	type ResponsiveModifiers,
 	type StructuralModifiers,
 	useAriaStateModifiers,
 	useContainerQueryModifiers,
@@ -18,6 +19,7 @@ import {
 	useOtherStateModifiers,
 	usePseudoElementModifiers,
 	usePseudoStateModifiers,
+	useResponsiveModifiers,
 	useStructuralModifiers,
 } from "../modifiers";
 
@@ -40,6 +42,8 @@ export interface ModifiersConfig {
 	mediaPreferences?: boolean;
 	/** Container-query modifiers (container-sm, container-md, etc.) */
 	containerQueries?: boolean;
+	/** Responsive breakpoint modifiers (sm, md, lg, xl, 2xl) */
+	responsive?: boolean;
 	/** ARIA state modifiers (aria-expanded, aria-disabled, etc.) */
 	ariaStates?: boolean;
 	/** Directional modifiers (rtl, ltr) */
@@ -59,6 +63,7 @@ export type ModifierInstances = Partial<
 		PseudoElementModifiers &
 		MediaPreferenceModifiers &
 		ContainerQueryModifiers &
+		ResponsiveModifiers &
 		AriaStateModifiers &
 		DirectionalModifiers &
 		OtherStateModifiers
@@ -91,6 +96,7 @@ export function useModifiersPreset(
 		...(config.containerQueries !== false
 			? useContainerQueryModifiers(s)
 			: undefined),
+		...(config.responsive !== false ? useResponsiveModifiers(s) : undefined),
 		...(config.ariaStates !== false ? useAriaStateModifiers(s) : undefined),
 		...(config.directional !== false ? useDirectionalModifiers(s) : undefined),
 		...(config.otherStates !== false ? useOtherStateModifiers(s) : undefined),


### PR DESCRIPTION
## Summary

Ships built-in responsive breakpoint modifiers so `_md:padding:xl` (and siblings) resolve to a real `@media (min-width: …)` block out of the box — closing the one gap the Tailwind → Styleframe migration guide (SF-5) had to work around.

- `useResponsiveModifiers` (`sm`/`md`/`lg`/`xl`/`2xl`) — the viewport-scoped twin of the SF-8 container-query modifiers, same shape and structure.
- **One modifier per breakpoint**, each closing over its own width (not the array-key form Étoile proved cannot emit per-breakpoint queries — SF-5/SF-11).
- Registered in `useModifiersPreset` behind a `responsive?: boolean` toggle (enabled by default), mirroring `containerQueries`.
- Purely additive & non-breaking — modifiers only emit CSS when a utility uses them; default theme output is unchanged.
- Changeset added (`@styleframe/theme` minor).

## Decision: px values (theme-taste call)

Anchored to the existing Styleframe `breakpointValues` scale (**576 / 768 / 992 / 1200 / 1440**), **not** Tailwind's exact px (640/768/1024/1280/1536).

Rationale: the container-query modifiers (SF-8) — the structural twin — already anchor to `breakpointValues`. Forking a second breakpoint scale for the media siblings would make `_md:` (viewport) and `_container-md:` (container) emit *different* widths, splitting the breakpoint vocabulary inside the theme. One source of truth wins. The "vocabularies line up" promise is delivered by the **names** (`_sm:` … `_2xl:`) resolving out of the box — exactly what a migrating Tailwind user types. Flagging for Alex's ruling if you'd prefer the exact Tailwind px instead; it's a one-line change to a dedicated value map.

## The pass

- `pnpm --filter @styleframe/theme test` — ✅ 296 files / 3279 tests pass (incl. new `useResponsiveModifiers.test.ts` asserting the emitted `@media (min-width: 768px)` block)
- `pnpm --filter @styleframe/theme typecheck` — ✅ clean
- `oxlint` + `oxfmt --check` on changed files — ✅ ok

## Handoffs

Reviewer: Étoile (compile + emitted-CSS verification). On merge, this unblocks the docs follow-up — Larousse updates the migration guide to document the now-built-in prefixes.