### PR TITLE
skill(docs-craft): fix phantom pnpm typecheck verification command

### DIFF
--- a/.claude/skills/docs-craft/SKILL.md
+++ b/.claude/skills/docs-craft/SKILL.md
@@ -51,5 +51,5 @@ Internal doc routes are rewritten at build time: theme-related docs keep the `/d
 ## Process notes
 
 - Docs-only changes ship no changeset — `@styleframe/docs` is in the changesets ignore list; its version is bumped manually.
-- Verify with `pnpm --filter @styleframe/docs typecheck` plus a dev-server or build check of the touched pages; paste outcomes in the final comment.
+- Verify with `pnpm --filter @styleframe/docs build` (Nuxt build type-checks the app) plus a dev-server check of the touched pages; paste outcomes in the final comment.
 - An API that resists clear explanation is a product finding — file it for the owning seat (@mere, @roux, @tournant) rather than writing around it. Prose cannot fix a confusing API, only hide it until support finds it.


### PR DESCRIPTION
## Summary
- The docs-craft skill's verification step named `pnpm --filter @styleframe/docs typecheck`, a script that does not exist. `apps/docs` is a Nuxt app whose only scripts are `build`, `dev`, `generate`, `preview`, `postinstall` — `nuxt build` already type-checks the app.
- Repointed the verification step at `pnpm --filter @styleframe/docs build` and dropped every reference to the phantom `typecheck`.

Closes SF-21.

## Test plan
- [x] `grep -rn typecheck .claude/skills/docs-craft/` returns nothing
- [x] Confirmed `apps/docs/package.json` has no `typecheck` script