### PR TITLE
docs(migration): document built-in responsive prefixes (SF-19)

### DIFF
--- a/apps/docs/content/docs/10.migration/01.tailwind.md
+++ b/apps/docs/content/docs/10.migration/01.tailwind.md
@@ -184,30 +184,27 @@ Tailwind prefixes a variant onto the class (`hover:bg-blue-600`). Styleframe use
 | `active:bg-blue-700` | `_active:background:primary-700` |
 | `disabled:opacity-50` | `_disabled:opacity:[0.5]` |
 | `dark:bg-gray-900` | `_dark:background:gray-900` |
+| `md:flex` | `_md:display:flex` |
+| `lg:px-8` | `_lg:padding-inline:xl` |
 
-`useModifiersPreset` registers pseudo-classes (`_hover:`, `_focus:`, `_focus-visible:`, `_active:`), form states (`_disabled:`, `_checked:`, `_invalid:`), structural selectors (`_first:`, `_odd:`), pseudo-elements (`_before:`, `_after:`, `_placeholder:`), and media preferences (`_dark:`, `_motion-safe:`, `_print:`).
+`useModifiersPreset` registers pseudo-classes (`_hover:`, `_focus:`, `_focus-visible:`, `_active:`), form states (`_disabled:`, `_checked:`, `_invalid:`), structural selectors (`_first:`, `_odd:`), pseudo-elements (`_before:`, `_after:`, `_placeholder:`), media preferences (`_dark:`, `_motion-safe:`, `_print:`), and responsive breakpoints (`_sm:`, `_md:`, `_lg:`, `_xl:`, `_2xl:`).
 
-::warning
-**Responsive prefixes are not built in.** Styleframe does not ship Tailwind's `sm:`/`md:`/`lg:` breakpoint modifiers by default. You define them yourself — one modifier per breakpoint, each closing over its own query, which also means you control the exact media condition. For example:
+The responsive prefixes line up with Tailwind's directly. `useModifiersPreset` ships mobile-first breakpoint modifiers out of the box, so `_md:padding:xl` resolves to a real `@media (min-width: 768px)` block with no extra setup — the same `_property:value` shape, just gated behind a `min-width` query:
 
-```ts [styleframe.config.ts]
-import { styleframe } from 'styleframe';
+| Prefix | Media query |
+|---|---|
+| `_sm:` | `@media (min-width: 576px)` |
+| `_md:` | `@media (min-width: 768px)` |
+| `_lg:` | `@media (min-width: 992px)` |
+| `_xl:` | `@media (min-width: 1200px)` |
+| `_2xl:` | `@media (min-width: 1440px)` |
 
-const s = styleframe();
-const { modifier } = s;
-
-const breakpoints = { sm: '576px', md: '768px', lg: '992px' };
-
-for (const [name, width] of Object.entries(breakpoints)) {
-    modifier(name, ({ declarations }) => ({
-        [`@media (min-width: ${width})`]: declarations,
-    }));
-}
-
-export default s;
+```html
+<div class="_display:block _md:display:flex _lg:gap:xl">…</div>
 ```
 
-Applied to a utility, `_md:padding:xl` then resolves to a real `@media (min-width: 768px)` block. See [Utility Modifiers](/docs/api/utility-modifiers) for the full API.
+::note
+Need a different scale or your own breakpoint names? The modifiers are just functions. Turn off the defaults with `useModifiersPreset(s, { responsive: false })` and register your own with `modifier()`, closing each one over the query you want. See [Utility Modifiers](/docs/api/utility-modifiers) for the full API.
 ::
 
 ## Step 4: Translate the config
@@ -387,7 +384,7 @@ The shape is the same; the class names now point at your tokens instead of a fix
 | If you relied on… | In Styleframe… |
 |---|---|
 | Arbitrary values everywhere (`p-[13px]`) | Supported (`_padding:[13px]`), but prefer tokens for consistency |
-| Responsive prefixes (`md:flex`) | Define a breakpoint modifier yourself (Step 3) |
+| Responsive prefixes (`md:flex`) | Built-in `_sm:`&ndash;`_2xl:` prefixes — same idea, same breakpoints (Step 3) |
 | A fixed color palette (`blue-500`) | Semantic tokens with generated `-50…-950` levels |
 | `@apply` to build components | Author a **recipe** — a typed variant function |
 | CVA / Tailwind Variants | Built-in `recipe()` and the `use*Recipe` composables |


### PR DESCRIPTION
## Summary

Updates the Tailwind → Styleframe migration guide now that **SF-18 (#305)** shipped built-in `sm`/`md`/`lg`/`xl`/`2xl` breakpoint modifiers in `useModifiersPreset`.

- Step 3 drops the hand-rolled `modifier()` breakpoint-loop workaround and documents the built-in `_sm:`–`_2xl:` prefixes, with a table of the real `min-width` queries (576 / 768 / 992 / 1200 / 1440 px — verified against `theme/src/values/breakpoint.ts`).
- Removes the "responsive prefixes are not built in" caveat — the vocabularies now line up. The "What to watch for" table and the modifier list are reconciled to match.
- The 15-minute guide's claim that `_sm:`–`_2xl:` ship from `useModifiersPreset` is now true — verified, no change needed.

Docs-only, no changeset (`@styleframe/docs` is in the changesets ignore list).

## Stacking note

The migration guide only exists on the **still-open PR #293** (`larousse/tailwind-migration-guide`), not on `main` — so this is stacked on that branch and its diff shows only the SF-19 change. It should land after (or fold into) #293. GitHub will retarget this to `main` once #293 merges.

## Test plan

- [x] `pnpm dev` (Nuxt Content) processed 182 files, 0 parse errors
- [x] `/docs/getting-started/migration/tailwind` → **200**, rendered content confirmed (breakpoint table with 768px/1440px, `_2xl:`, old workaround gone)
- [x] Only link in the change (`/docs/api/utility-modifiers`) resolves — target file present, unchanged