### PR TITLE
feat(docs): support tsx syntax highlighting in code fences

### DIFF
--- a/apps/docs/nuxt.config.ts
+++ b/apps/docs/nuxt.config.ts
@@ -23,6 +23,7 @@ export default defineNuxtConfig({
 						"json",
 						"js",
 						"ts",
+						"tsx",
 						"html",
 						"css",
 						"vue",


### PR DESCRIPTION
## What

Add `"tsx"` to the Nuxt Content markdown highlighter `langs` in `apps/docs/nuxt.config.ts`, so ` ```tsx ` code fences render with correct JSX-aware highlighting. Closes SF-23.

## Why

Users were faking `.tsx` snippets with ` ```ts `, which misparses JSX (tags read as comparison operators). Shiki only loads the languages listed in `langs`; `tsx` was missing.

## How verified

`tsx` and `ts` are independent Shiki grammars, so existing `ts` blocks are byte-for-byte unaffected. Rendering the same JSX line through Shiki (the highlighter Nuxt Content uses) shows the difference:

**`ts` (before, faked):** `<button>` colored as a plain identifier and `</button>` tokenized with red comparison-operator color — JSX misread as `<`/`>` comparisons.

**`tsx` (after):** `button` tokenized as a JSX element (green `#22863A`), `className` as an attribute (purple `#6F42C1`), `=` as an operator — correct.

- Confirmed `tsx` and `ts` are both in Shiki's bundled languages.
- No changeset: `@styleframe/docs` is in the changesets ignore list.

Diff:
```diff
 						"js",
 						"ts",
+						"tsx",
 						"html",
```
