### PR TITLE
fix(docs): render real title/description in section OG images

### DIFF
--- a/apps/docs/app/pages/[[lang]]/docs/[section]/[...slug].vue
+++ b/apps/docs/app/pages/[[lang]]/docs/[section]/[...slug].vue
@@ -100,6 +100,8 @@ watch(
 
 defineOgImage("Docs", {
 	headline: headline.value,
+	title,
+	description,
 });
 
 const github = computed(() => (appConfig.github ? appConfig.github : null));


### PR DESCRIPTION
## What
Docs section pages (`/docs/<section>/...`) were rendering literal `title` / `description` placeholders in their Open Graph share image instead of the page's real title and description.

## Why
`app/pages/[[lang]]/docs/[section]/[...slug].vue` called:

```ts
defineOgImage("Docs", { headline: headline.value });
```

`OgImageDocs.satori.vue` declares `withDefaults` prop defaults of `title: "title"` and `description: "description"`. Because the call omitted both, the component fell back to those literal strings and baked them into the prerendered OG image. The `og:title` / `og:description` meta tags were correct (they come from `useSeoMeta`), which is why the link-preview text in the screenshot was right while the image showed "title" / "description".

The sibling landing route `[[lang]]/[...slug].vue` already passes `{ headline, title, description }` — this brings the section route in line with it.

## How
Pass the already-computed `title` / `description` (the same values used in `useSeoMeta` above) into the `defineOgImage` call. Two-line change; no other `defineOgImage("Docs", ...)` call sites remain unfixed.

## Verified
- `pnpm install --frozen-lockfile` — clean.
- `nuxt prepare` (postinstall) — succeeds; generated types load.
- Both `defineOgImage("Docs", ...)` call sites now pass `title` + `description`.
- Note: `apps/docs` ships no `typecheck` script and `vue-tsc` is not installed, so `nuxi typecheck` can't run here — a tooling gap, not related to this change. The added identifiers are the same typed refs already consumed by `useSeoMeta` on the lines above.

No changeset (`@styleframe/docs` is in the changesets ignore list).

Closes SF-25.
