### PR TITLE
SF-27: clear 6 apps/shared type errors (blocks docs typecheck)

### DIFF
--- a/apps/shared/app/plugins/i18n.ts
+++ b/apps/shared/app/plugins/i18n.ts
@@ -1,7 +1,9 @@
 export default defineNuxtPlugin(() => {
 	const nuxtApp = useNuxtApp();
 
-	const i18nConfig = nuxtApp.$config.public.i18n;
+	const i18nConfig = nuxtApp.$config.public.i18n as
+		| { defaultLocale?: string }
+		| undefined;
 	if (!i18nConfig) {
 		return;
 	}

--- a/apps/shared/modules/config.ts
+++ b/apps/shared/modules/config.ts
@@ -14,8 +14,12 @@ export default defineNuxtModule({
 		const url = inferSiteURL();
 		const meta = await getPackageJsonMetadata(dir);
 		const gitInfo = (await getLocalGitInfo(dir)) || getGitEnv();
+		const site = nuxt.options.site;
 		const siteName =
-			nuxt.options?.site?.name || meta.name || gitInfo?.name || "";
+			(typeof site === "object" ? site.name : undefined) ||
+			meta.name ||
+			gitInfo?.name ||
+			"";
 
 		nuxt.options.llms = defu(nuxt.options.llms, {
 			domain: url,
@@ -31,7 +35,7 @@ export default defineNuxtModule({
 			url,
 			name: siteName,
 			debug: false,
-		});
+		}) as typeof nuxt.options.site;
 
 		nuxt.options.appConfig.header = defu(nuxt.options.appConfig.header, {
 			title: siteName,

--- a/apps/shared/package.json
+++ b/apps/shared/package.json
@@ -13,12 +13,15 @@
 		"@nuxtjs/i18n": "catalog:nuxt",
 		"@nuxtjs/mdc": "catalog:nuxt",
 		"@nuxtjs/robots": "catalog:nuxt",
+		"git-url-parse": "catalog:nuxt",
 		"nuxt": "catalog:nuxt",
 		"nuxt-llms": "catalog:nuxt",
 		"nuxt-og-image": "catalog:nuxt",
 		"defu": "catalog:",
+		"pkg-types": "catalog:nuxt",
 		"posthog-js": "catalog:nuxt",
 		"tailwindcss": "catalog:nuxt",
+		"vue": "catalog:nuxt",
 		"zod": "catalog:"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -630,6 +630,9 @@ importers:
       defu:
         specifier: 'catalog:'
         version: 6.1.7
+      git-url-parse:
+        specifier: catalog:nuxt
+        version: 16.1.0
       nuxt:
         specifier: catalog:nuxt
         version: 4.4.8(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@biomejs/biome@2.5.0)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.4)(@vue/compiler-sfc@3.5.38)(better-sqlite3@12.10.1)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.1))(eslint@9.37.0(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.69.0)(rolldown@1.1.1)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.1)(rollup@4.62.0))(rollup@4.62.0)(terser@5.44.0)(tsx@4.22.4)(typescript@6.0.3)(vite@8.0.16(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.9.0))(vue-tsc@3.3.5(typescript@6.0.3))(yaml@2.9.0)
@@ -639,12 +642,18 @@ importers:
       nuxt-og-image:
         specifier: catalog:nuxt
         version: 6.6.0(62e7d22600edcdd52d54fbb4abcf763e)
+      pkg-types:
+        specifier: catalog:nuxt
+        version: 2.3.1
       posthog-js:
         specifier: catalog:nuxt
         version: 1.386.6
       tailwindcss:
         specifier: catalog:nuxt
         version: 4.3.1
+      vue:
+        specifier: catalog:nuxt
+        version: 3.5.38(typescript@6.0.3)
       zod:
         specifier: 'catalog:'
         version: 4.4.3


### PR DESCRIPTION
## Summary

Stage 1 of SF-26. Clears the **6 pre-existing `apps/shared` type errors** that `nuxt typecheck` surfaces when it traverses `apps/docs` → `apps/shared`. These paths are unchecked today, so the fixes are strictly additive and this PR is green on its own. Once merged, Stage 2 (Larousse, SF-28) clears the 24 docs errors + folds in the typecheck wiring to flip docs green.

## Changes (all in `apps/shared/**`)

**Undeclared deps** — `nuxt typecheck` reported module-not-found for imports that were never declared:
- `git-url-parse`, `pkg-types` (used by `utils/git.ts`) and `vue` (used by `components/MorphingGradientBackground.vue`) added to `apps/shared/package.json` as `catalog:nuxt` (matching the versions `apps/docs` already pins).
- **No `@types/*` added.** `git-url-parse@16` ships its own `lib/index.d.ts`; `@types/git-url-parse` is a deprecated no-op stub. `pkg-types` ships its own types too.

**Typing:**
- `app/plugins/i18n.ts` — the public i18n runtime config was typed `{}`; annotated it so `defaultLocale` resolves.
- `modules/config.ts` — `nuxt.options.site` is `false | ModuleOptions`; guard for the object case before reading `.name`, and assert the `defu` result back to the site type (runtime value is a valid site config; the incompatibility is `MaybeComputedRef`/null variance only).

`apps/docs/**` is **untouched** — that's Stage 2.

## Test plan

- [x] `pnpm --filter @styleframe/docs typecheck` — reproduced via a temporary docs wiring (script + `vue-tsc`, reverted before commit): **0 `apps/shared` errors** remain; only the 24 pre-existing docs errors are left for Stage 2. No new errors introduced in shared.
- [x] `pnpm format:check` (oxfmt) — clean on changed files.
- [x] `oxlint apps/shared/` — clean.
- [x] Confirmed `git-url-parse@16.1.0` resolves types without the deprecated `@types` stub.

No changeset — `apps/shared` is an internal Nuxt layer (consumed via workspace, not published); consistent with prior `apps/shared` history.
