### PR TITLE
docs: modernize homepage code examples below the hero

### DIFF
--- a/apps/docs/content/index.md
+++ b/apps/docs/content/index.md
@@ -186,19 +186,19 @@ title: styleframe.config.ts
 ```ts
 import { styleframe } from 'styleframe';
 import { useColorDesignTokens } from '@styleframe/theme';
-import { useSpacingDesignTokens, useTypography } from '@orgname/theme-minimal';
+import { useTypographyDesignTokens, useSpacingDesignTokens } from '@orgname/theme-minimal';
 import { useComponents } from './my-components';
 
 const s = styleframe();
 
 // Colors from the default theme
-const { colorPrimary, colorSecondary } = useColorDesignTokens(s, {
+useColorDesignTokens(s, {
     primary: '#318fa0',
     secondary: '#ff6b6b'
 });
 
 // Typography and spacing from another theme
-useTypography(s);
+useTypographyDesignTokens(s);
 useSpacingDesignTokens(s);
 
 // Plus your custom components
@@ -255,62 +255,34 @@ links:
 ---
 
 
-::tabs
-    :::tabs-item{.my-5 icon="i-lucide-settings" label="Configuration"}
-        ::::browser-frame
-        ---
-        title: styleframe.config.ts
-        ---
+::browser-frame
+---
+title: styleframe.config.ts
+---
 
-             ```ts
-            import { merge } from 'styleframe';
+```ts
+import { styleframe } from 'styleframe';
 
-            import lightTheme from './light.theme';
-            import darkTheme from './dark.theme';
+const s = styleframe();
+const { variable, ref, selector, theme } = s;
 
-            export default merge(lightTheme, darkTheme);
+const surface = variable('color.surface', '#ffffff');
+const text = variable('color.text', '#18181b');
 
-        ::::
-    :::
-    :::tabs-item{.my-5 icon="i-lucide-sun" label="Light Theme"}
-        ::::browser-frame
-        ---
-        title: light.theme.ts
-        ---
+selector('.card', {
+    background: ref(surface),
+    color: ref(text),
+});
 
-            ```ts
-            import { styleframe } from 'styleframe';
+// Every theme reuses the same tokens — just override their values
+theme('dark', (ctx) => {
+    ctx.variable(surface, '#18181b');
+    ctx.variable(text, '#ffffff');
+});
 
-            const s = styleframe();
-            const { variable } = s;
+export default s;
+```
 
-            export const colorPrimary = variable('color-primary', '#007bff');
-
-            export default s;
-
-        ::::
-    :::
-    :::tabs-item{.my-5 icon="i-lucide-moon" label="Dark Theme"}
-        ::::browser-frame
-        ---
-        title: dark.theme.ts
-        ---
-
-            ```ts
-            import { styleframe } from 'styleframe';
-            import { colorPrimary } from './light.theme';
-
-            const s = styleframe();
-            const { theme } = s;
-
-            theme('dark', ({ variable }) => {
-                variable(colorPrimary, '#0056b3');
-            });
-
-            export default s;
-
-        ::::
-    :::
 ::
 
 
@@ -365,21 +337,24 @@ title: Output
 ```css
 /* Static CSS generated at build time */
 .button {
-    background-color: var(--color-primary);
+    background-color: var(--color--primary);
     padding: var(--spacing);
 }
 ```
 
 ```ts
-/* Optional runtime generated for Recipes */
-export const button = recipe('button', {
-    background: "primary",
-}, {
-    size: {
-        sm: { padding: 'sm' },
-        md: { padding: 'md' },
-        lg: { padding: 'lg' }
-    }
+/* Optional runtime for prop-based Recipes */
+recipe({
+    name: 'button',
+    base: { background: '@color.primary' },
+    variants: {
+        size: {
+            sm: { padding: '@spacing.sm' },
+            md: { padding: '@spacing.md' },
+            lg: { padding: '@spacing.lg' },
+        },
+    },
+    defaultVariants: { size: 'md' },
 });
 ```
 


### PR DESCRIPTION
## Summary

The docs homepage promised "current styleframe" but three of the four example blocks below the hero taught stale idioms. This audits every block and refreshes the ones that had drifted, grounding each against the live API and the canonical API docs. The hero example was already correct and is untouched.

## What changed, block by block

**1. "Compose your system from existing parts"**
The block declared `const { colorPrimary, colorSecondary } = useColorDesignTokens(...)` and then never used those names — an unused-variable smell that makes a reader distrust the example. `useColorDesignTokens` registers its tokens as a side effect, so the call is now made directly, and the sibling composables are aligned on the real `use*DesignTokens` naming convention.

**2. "One source, every theme"**
Replaced the stale pattern of `merge()`-ing two separate `styleframe()` instances (one "light", one "dark") plus hyphenated `variable('color-primary', ...)` tokens. Merging two instances to build a theme is not how theming works today and teaches the wrong mental model. The block now shows the canonical single-source pattern from `/docs/api/themes` — base tokens on one instance with `theme('dark', (ctx) => ctx.variable(...))` — and dot-notation token names (`color.surface`), which are what actually compile to `--color--surface`.

**3. "Zero-Runtime by Default"**
The recipe used the old **positional** signature `recipe('button', {...}, {...})`. The current API is a single named-object argument: `recipe({ name, base, variants, defaultVariants })` (verified in `engine/core/src/tokens/recipe.ts` and mirrored in `/docs/api/recipes`). Also corrected the CSS var in the sibling output block from `--color-primary` to the real `--color--primary` that dot-notation tokens generate.

**4. Utility Scanner markup**
Already current (`_padding:lg`, `_hover:background:secondary`, `_gap:[1rem]` all match today's utility/modifier syntax) — left unchanged.

## Verification

- `pnpm install --frozen-lockfile` (fresh workspace) — ok
- `pnpm --filter @styleframe/docs build` — build complete, homepage content parses and renders (only a benign `sharp` darwin-arm64 image warning, unrelated)
- Fence/container balance checked: 6 code blocks, no orphaned `::tabs`, all `::browser-frame` blocks balanced

## Notes / findings

- `docs-craft` recommends `pnpm --filter @styleframe/docs typecheck`, but `@styleframe/docs` has no `typecheck` script — the build is the real gate here. Flagging the skill inaccuracy for follow-up.
- No changeset: `@styleframe/docs` is in the changesets ignore list.

Closes SF-30.
