### PR TITLE
docs: list all nine supported bundlers on imports pages

### DIFF
--- a/apps/docs/content/docs/02.api/13.imports.md
+++ b/apps/docs/content/docs/02.api/13.imports.md
@@ -347,6 +347,10 @@ Yes. Both patterns work with any build tool supported by `@styleframe/plugin`:
 - webpack
 - Rollup
 - esbuild
+- Rspack
+- Farm
+- Astro
+- Bun
 
 The plugin handles virtual module resolution and compilation for all supported bundlers.
 :::

--- a/apps/docs/content/docs/02.api/14.imports.md
+++ b/apps/docs/content/docs/02.api/14.imports.md
@@ -455,6 +455,10 @@ Yes. The plugin works with any bundler supported by `@styleframe/plugin`:
 - webpack
 - Rollup
 - esbuild
+- Rspack
+- Farm
+- Astro
+- Bun
 
 The plugin handles virtual module resolution and compilation for all supported bundlers.
 :::


### PR DESCRIPTION
## What
The two API imports pages (`13.imports.md`, `14.imports.md`) listed only five supported bundlers. They now name all nine, matching the `@styleframe/plugin` export map.

## Why
The FAQ answers on both pages claimed "any build tool supported by `@styleframe/plugin`" but enumerated only Vite, Nuxt, webpack, Rollup, and esbuild. The real supported set — confirmed by the `@styleframe/plugin` export map (`tooling/plugin/package.json` + `tooling/plugin/src/{vite,nuxt,webpack,rollup,esbuild,rspack,farm,astro,bun}.ts`) — is nine: Vite, Nuxt, webpack, Rollup, esbuild, Rspack, Farm, Astro, Bun. The homepage (`content/index.md`) already lists all nine; this brings the API pages into line. Fixes SF-20.

## How verified

    pnpm --filter @styleframe/docs build
    # ✨ Build complete! (pages prerender)

The updated lists are plain-text bullets (no links), so no link resolution is affected. The `@styleframe/docs` package has no `typecheck` script; the prerendering build is the verification gate.

## Notes
Docs-only change — no changeset (`@styleframe/docs` is in the changesets ignore list).
