### PR TITLE
fix(core): validate refs in compound @-shorthand values

### DIFF
--- a/.changeset/core-compound-ref-validation.md
+++ b/.changeset/core-compound-ref-validation.md
@@ -1,0 +1,6 @@
+---
+"@styleframe/core": patch
+"styleframe": patch
+---
+
+Validate variable references inside compound `@`-shorthand values. `resolvePropertyValue` already threw `Variable "X" is not defined` for a single exact ref (`padding: "@0.5"`), but the embedded/compound path (`padding: "@0.25 @0.5"`, `border: "1px solid @undefined"`) only recorded usage and skipped `validateReference`, so a compound ref to an undefined variable silently emitted a dead `var(--…)`. The embedded branch now calls `validateReference` for each ref part, matching the single-ref path. Compound refs whose variables are all defined are unchanged (byte-for-byte identical output); only compound refs to undefined variables change — from a silent dead `var(--…)` to a thrown error.

--- a/engine/core/src/tokens/atRule.test.ts
+++ b/engine/core/src/tokens/atRule.test.ts
@@ -668,7 +668,7 @@ describe("createMediaFunction", () => {
 			const result = media(
 				"(-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi)",
 				{
-					backgroundImage: 'url("image@2x.png")',
+					backgroundImage: 'url("image-2x.png")',
 				},
 			);
 

--- a/engine/core/src/tokens/css.test.ts
+++ b/engine/core/src/tokens/css.test.ts
@@ -618,6 +618,13 @@ describe("createCSSFunction", () => {
 		});
 
 		it("should resolve embedded @reference to a CSS object", () => {
+			root.variables.push({
+				type: "variable",
+				id: "color-primary",
+				name: "color.primary",
+				value: "#006cff",
+			});
+
 			const result = resolvePropertyValue("1px solid @color.primary");
 
 			expect(result).toEqual({
@@ -630,6 +637,21 @@ describe("createCSSFunction", () => {
 		});
 
 		it("should resolve multiple embedded @references to a CSS object", () => {
+			root.variables.push(
+				{
+					type: "variable",
+					id: "spacing-sm",
+					name: "spacing.sm",
+					value: "0.5rem",
+				},
+				{
+					type: "variable",
+					id: "spacing-md",
+					name: "spacing.md",
+					value: "1rem",
+				},
+			);
+
 			const result = resolvePropertyValue("@spacing.sm @spacing.md");
 
 			expect(result).toEqual({

--- a/engine/core/src/tokens/declarations.test.ts
+++ b/engine/core/src/tokens/declarations.test.ts
@@ -378,6 +378,13 @@ describe("parseDeclarationsBlock", () => {
 		});
 
 		it("should resolve embedded @references to a CSS object", () => {
+			root.variables.push({
+				type: "variable",
+				id: "color-primary",
+				name: "color.primary",
+				value: "#006cff",
+			});
+
 			const declarations: any = {
 				border: "1px solid @color.primary",
 			};
@@ -391,6 +398,21 @@ describe("parseDeclarationsBlock", () => {
 		});
 
 		it("should resolve multiple embedded @references to a CSS object", () => {
+			root.variables.push(
+				{
+					type: "variable",
+					id: "spacing-sm",
+					name: "spacing.sm",
+					value: "0.5rem",
+				},
+				{
+					type: "variable",
+					id: "spacing-md",
+					name: "spacing.md",
+					value: "1rem",
+				},
+			);
+
 			const declarations: any = {
 				padding: "@spacing.sm @spacing.md",
 			};

--- a/engine/core/src/tokens/resolve.test.ts
+++ b/engine/core/src/tokens/resolve.test.ts
@@ -313,6 +313,13 @@ describe("createPropertyValueResolver", () => {
 
 	describe("embedded @ references", () => {
 		it("should resolve embedded @variable to a CSS object", () => {
+			root.variables.push({
+				type: "variable",
+				id: "color-primary",
+				name: "color.primary",
+				value: "#006cff",
+			});
+
 			const result = resolvePropertyValue("1px solid @color.primary");
 
 			expect(result).toEqual({
@@ -329,6 +336,21 @@ describe("createPropertyValueResolver", () => {
 		});
 
 		it("should resolve multiple embedded @variables to a CSS object", () => {
+			root.variables.push(
+				{
+					type: "variable",
+					id: "border-width",
+					name: "border.width",
+					value: "1px",
+				},
+				{
+					type: "variable",
+					id: "color-primary",
+					name: "color.primary",
+					value: "#006cff",
+				},
+			);
+
 			const result = resolvePropertyValue("@border.width solid @color.primary");
 
 			expect(result).toEqual({
@@ -343,6 +365,61 @@ describe("createPropertyValueResolver", () => {
 					{
 						type: "reference",
 						name: "color.primary",
+						fallback: undefined,
+					},
+				],
+			});
+		});
+
+		it("should throw when an embedded @variable is not defined", () => {
+			expect(() => resolvePropertyValue("@0.25 @0.5")).toThrow(
+				'Variable "0.25" is not defined',
+			);
+		});
+
+		it("should throw when only one of several embedded refs is undefined", () => {
+			root.variables.push({
+				type: "variable",
+				id: "border-width",
+				name: "border.width",
+				value: "1px",
+			});
+
+			expect(() =>
+				resolvePropertyValue("@border.width solid @color.primary"),
+			).toThrow('Variable "color.primary" is not defined');
+		});
+
+		it("should still compile embedded refs when every variable is defined", () => {
+			root.variables.push(
+				{
+					type: "variable",
+					id: "spacing-sm",
+					name: "spacing.sm",
+					value: "0.5rem",
+				},
+				{
+					type: "variable",
+					id: "spacing-md",
+					name: "spacing.md",
+					value: "1rem",
+				},
+			);
+
+			const result = resolvePropertyValue("@spacing.sm @spacing.md");
+
+			expect(result).toEqual({
+				type: "css",
+				value: [
+					{
+						type: "reference",
+						name: "spacing.sm",
+						fallback: undefined,
+					},
+					" ",
+					{
+						type: "reference",
+						name: "spacing.md",
 						fallback: undefined,
 					},
 				],

--- a/engine/core/src/tokens/resolve.ts
+++ b/engine/core/src/tokens/resolve.ts
@@ -111,6 +111,7 @@ export function createPropertyValueResolver(parent: Container, root: Root) {
 		if (hasReferences) {
 			for (const part of parts) {
 				if (isRef(part)) {
+					validateReference(part.name, parent, root);
 					root._usage.variables.add(part.name);
 				}
 			}


### PR DESCRIPTION
## What

Validate variable references inside compound `@`-shorthand values. `resolvePropertyValue` in `engine/core/src/tokens/resolve.ts` already threw for a single exact ref (`padding: "@0.5"`), but the embedded/compound branch (`padding: "@0.25 @0.5"`, `border: "1px solid @undefined"`) only recorded usage and skipped `validateReference` — so a compound ref to an undefined variable silently emitted a dead `var(--…)`. The embedded branch now calls `validateReference` for each ref part, mirroring the single-ref path.

## Why

A compound `@`-shorthand referencing an undefined variable produced invalid CSS (e.g. `padding: var(--0--25) var(--0--5)`) with no error, while the single-ref form correctly threw. This closes that gap so both paths validate identically. Implements SF-13 (split out from SF-12).

## Output diff (silent → throw)

The only behavior change is for compound refs to **undefined** variables:

```
// padding: "@0.25 @0.5"   (no 0.25 / 0.5 variables defined)
- before:  .x { padding: var(--0--25) var(--0--5); }   // silent dead vars
+ after:   throws  [styleframe] Variable "0.25" is not defined.
```

Compound refs whose variables are **all defined** are unchanged — byte-for-byte identical output:

```
// padding: "@spacing.sm @spacing.md"   (both defined)
  before === after:  .x { padding: var(--spacing-sm) var(--spacing-md); }
```

## How verified

    pnpm --filter @styleframe/core test
    # ✓ Test Files 21 passed (21) · Tests 710 passed (710)

    pnpm --filter @styleframe/theme test
    # ✓ Test Files 303 passed (303) · Tests 3320 passed (3320)

    pnpm typecheck
    # ✓ Tasks 15 successful, 15 total

    pnpm exec oxlint engine/core/src
    # ✓ no findings in changed files

Repo-wide audit for compound `@`-shorthand refs to undefined variables: theme (3320 tests, incl. `calc(@tooltip.arrow.size * -1)` etc.) is clean; `apps/storybook` compound refs (`calc(@spacing * N)`, `1px solid @color.primary`, `1px solid @border-color`, `@spacing.sm @spacing`, `*.arrow.size`) all resolve to defined variables. One known undefined compound ref remains — the chat-message story padding `@0.25 @0.5` — tracked separately under SF-12; not touched here.

## Notes

- Changeset added (`@styleframe/core` + `styleframe`, patch).
- Existing `resolve` / `css` / `declarations` embedded-ref tests referenced undefined variables as fixtures; they now define the variables first, since the compound path validates. New tests cover: compound undefined ref throws, one-of-several undefined throws, all-defined compiles.
- Separate engine finding surfaced by this change: `parseAtReferences` treats `@` inside a larger token as a reference, so `url("image@2x.png")` (a retina filename) is parsed as ref `2x.png` — silently `var(--2x--png)` on `main`, and now a throw. Neutralized the one incidental core-test fixture that hit it; recommend a follow-up to boundary-guard the parser. Not fixed here to keep this change scoped.
- Build is fully clean once the SF-12 chat-message story fix lands.
