### PR TITLE
fix(docs): clear type errors and wire up typecheck script

### DIFF
--- a/apps/docs/app/app.vue
+++ b/apps/docs/app/app.vue
@@ -40,7 +40,9 @@ useSeoMeta({
 
 if (isEnabled.value) {
 	const route = useRoute();
-	const defaultLocale = useRuntimeConfig().public.i18n.defaultLocale!;
+	const defaultLocale = (
+		useRuntimeConfig().public.i18n as { defaultLocale: string }
+	).defaultLocale;
 	onMounted(() => {
 		const currentLocale = route.path.split("/")[1];
 		if (!locales.some((locale) => locale.code === currentLocale)) {
@@ -71,7 +73,7 @@ const { data: navigation } = await useAsyncData(
 					const rootIdx =
 						"rootFolder" in section ? (section.rootFolder as number) : -1;
 					const rootWrapper =
-						localeResult.length === 1 && localeResult[0].path === sectionPath
+						localeResult.length === 1 && localeResult[0]?.path === sectionPath
 							? localeResult[0]
 							: null;
 					const allItems = rootWrapper
@@ -99,7 +101,7 @@ const { data: navigation } = await useAsyncData(
 								const found = allItems.find(
 									(item) =>
 										item.path ===
-										`${sectionPath}/${section.folder[i].replace(/^\d+\./, "")}`,
+										`${sectionPath}/${section.folder[i]?.replace(/^\d+\./, "")}`,
 								);
 								if (found) items.push(found);
 							}

--- a/apps/docs/app/components/app/AppHeader.vue
+++ b/apps/docs/app/components/app/AppHeader.vue
@@ -17,7 +17,7 @@ onMounted(() => {
 });
 
 useResizeObserver(headerEl, ([entry]) => {
-	if (!isDocs.value) return;
+	if (!isDocs.value || !entry) return;
 	const height = entry.contentRect.height;
 	if (height > 0) {
 		document.documentElement.style.setProperty(

--- a/apps/docs/app/components/content/FrameworkSwitcher.vue
+++ b/apps/docs/app/components/content/FrameworkSwitcher.vue
@@ -15,7 +15,7 @@ const fallback = computed(() => {
 <template>
 	<div class="framework-switcher">
 		<p v-if="fallback" class="text-sm text-muted mb-2">
-			Not available for {{ current.label }} — showing {{ fallback.label }}.
+			Not available for {{ current?.label }} — showing {{ fallback.label }}.
 		</p>
 		<slot v-if="!fallback" :name="framework" />
 		<slot v-else :name="fallback.value" />

--- a/apps/docs/app/components/docs/DocsFrameworkSelect.vue
+++ b/apps/docs/app/components/docs/DocsFrameworkSelect.vue
@@ -14,7 +14,7 @@ const current = computed(
 		:items="[...frameworks]"
 		variant="ghost"
 		color="neutral"
-		:icon="current.icon"
+		:icon="current?.icon"
 		class="w-full"
 	/>
 </template>

--- a/apps/docs/app/composables/useAppI18n.ts
+++ b/apps/docs/app/composables/useAppI18n.ts
@@ -1,5 +1,16 @@
 import type { LocaleObject } from "@nuxtjs/i18n";
+import type { Ref } from "vue";
 import en from "~~/i18n/locales/en.json";
+
+/**
+ * `@nuxtjs/i18n` auto-imports. This app ships with i18n disabled — the module is
+ * not registered (see apps/shared/modules/config.ts) — so the enabled branch
+ * below is inert. These declarations let the file typecheck without the module
+ * generating the globals; when i18n is enabled the real composables are used.
+ */
+declare function useI18n(): { locale: Ref<string>; t: (key: string) => string };
+declare function useLocalePath(): (route: string, locale?: string) => string;
+declare function useSwitchLocalePath(): (locale: string) => string;
 
 export const useAppI18n = () => {
 	const config = useRuntimeConfig().public;
@@ -11,7 +22,7 @@ export const useAppI18n = () => {
 			locale: ref("en"),
 			locales: [],
 			localePath: (path: string) => path,
-			switchLocalePath: () => {},
+			switchLocalePath: (_locale?: string): string => "",
 			t: (key: string): string => {
 				const path = key.split(".");
 				return path.reduce(

--- a/apps/docs/app/composables/useDocusI18n.ts
+++ b/apps/docs/app/composables/useDocusI18n.ts
@@ -1,5 +1,16 @@
 import type { LocaleObject } from "@nuxtjs/i18n";
+import type { Ref } from "vue";
 import en from "../../i18n/locales/en.json";
+
+/**
+ * `@nuxtjs/i18n` auto-imports. This app ships with i18n disabled — the module is
+ * not registered (see apps/shared/modules/config.ts) — so the enabled branch
+ * below is inert. These declarations let the file typecheck without the module
+ * generating the globals; when i18n is enabled the real composables are used.
+ */
+declare function useI18n(): { locale: Ref<string>; t: (key: string) => string };
+declare function useLocalePath(): (route: string, locale?: string) => string;
+declare function useSwitchLocalePath(): (locale: string) => string;
 
 export const useDocusI18n = () => {
 	const config = useRuntimeConfig().public;
@@ -11,7 +22,7 @@ export const useDocusI18n = () => {
 			locale: ref("en"),
 			locales: [],
 			localePath: (path: string) => path,
-			switchLocalePath: () => {},
+			switchLocalePath: (_locale?: string): string => "",
 			t: (key: string): string => {
 				const path = key.split(".");
 				return path.reduce(

--- a/apps/docs/app/error.vue
+++ b/apps/docs/app/error.vue
@@ -39,7 +39,9 @@ useSeoMeta({
 
 if (isEnabled.value) {
 	const route = useRoute();
-	const defaultLocale = useRuntimeConfig().public.i18n.defaultLocale!;
+	const defaultLocale = (
+		useRuntimeConfig().public.i18n as { defaultLocale: string }
+	).defaultLocale;
 	onMounted(() => {
 		const currentLocale = route.path.split("/")[1];
 		if (!locales.some((locale) => locale.code === currentLocale)) {
@@ -75,7 +77,7 @@ const { data: navigation } = await useAsyncData(
 					const rootIdx =
 						"rootFolder" in section ? (section.rootFolder as number) : -1;
 					const rootWrapper =
-						localeResult.length === 1 && localeResult[0].path === sectionPath
+						localeResult.length === 1 && localeResult[0]?.path === sectionPath
 							? localeResult[0]
 							: null;
 					const allItems = rootWrapper
@@ -103,7 +105,7 @@ const { data: navigation } = await useAsyncData(
 								const found = allItems.find(
 									(item) =>
 										item.path ===
-										`${sectionPath}/${section.folder[i].replace(/^\d+\./, "")}`,
+										`${sectionPath}/${section.folder[i]?.replace(/^\d+\./, "")}`,
 								);
 								if (found) items.push(found);
 							}

--- a/apps/docs/app/pages/[[lang]]/[...slug].vue
+++ b/apps/docs/app/pages/[[lang]]/[...slug].vue
@@ -43,7 +43,7 @@ if (page.value?.seo?.ogImage) {
 		twitterImage: page.value.seo.ogImage,
 	});
 } else {
-	defineOgImage("Docs", {
+	defineOgImage("DocsSatori", {
 		headline: "styleframe",
 		title,
 		description,

--- a/apps/docs/app/pages/[[lang]]/docs/[section]/[...slug].vue
+++ b/apps/docs/app/pages/[[lang]]/docs/[section]/[...slug].vue
@@ -98,7 +98,7 @@ watch(
 	},
 );
 
-defineOgImage("Docs", {
+defineOgImage("DocsSatori", {
 	headline: headline.value,
 	title,
 	description,

--- a/apps/docs/app/utils/flattenNavigation.ts
+++ b/apps/docs/app/utils/flattenNavigation.ts
@@ -10,7 +10,7 @@ export function flattenNavigation(
 	items: ContentNavigationItem[],
 ): ContentNavigationItem[] {
 	return items.map((item) => {
-		if (item.children?.length === 1 && item.children[0].path === item.path) {
+		if (item.children?.length === 1 && item.children[0]?.path === item.path) {
 			const { children: _, ...parent } = item;
 			return { ...parent, ...item.children[0], children: undefined };
 		}

--- a/apps/docs/modules/nonRouteCategories.ts
+++ b/apps/docs/modules/nonRouteCategories.ts
@@ -27,7 +27,7 @@ function folderToStemPrefix(folder: string): string | undefined {
 		const folders = Array.isArray(section.folder)
 			? section.folder
 			: [section.folder];
-		const idx = folders.indexOf(folder);
+		const idx = (folders as readonly string[]).indexOf(folder);
 		if (idx === -1) continue;
 		const rootIdx = (section as { rootFolder?: number }).rootFolder ?? -1;
 		const base = `docs/${section.slug}`;

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -7,6 +7,7 @@
 		"dev": "nuxt dev",
 		"generate": "nuxt generate",
 		"preview": "nuxt preview",
+		"typecheck": "nuxt typecheck",
 		"postinstall": "nuxt prepare"
 	},
 	"dependencies": {
@@ -51,7 +52,8 @@
 		"pkg-types": "catalog:nuxt",
 		"tailwindcss": "catalog:nuxt",
 		"typescript": "catalog:nuxt",
-		"unist-util-visit": "catalog:nuxt"
+		"unist-util-visit": "catalog:nuxt",
+		"vue-tsc": "catalog:nuxt"
 	},
 	"files": [
 		"LICENSE",

--- a/apps/docs/server/routes/raw/[...slug].md.get.ts
+++ b/apps/docs/server/routes/raw/[...slug].md.get.ts
@@ -21,17 +21,20 @@ export default eventHandler(async (event) => {
 	let localeSegment: string | undefined;
 	let sectionIndex = 1; // expect /docs/<section>/...
 
-	if (config.i18n?.locales) {
-		const availableLocales = config.i18n.locales.map(
-			(locale: string | { code: string }) =>
-				typeof locale === "string" ? locale : locale.code,
+	const i18n = config.i18n as
+		| { locales?: (string | { code: string })[]; defaultLocale?: string }
+		| undefined;
+
+	if (i18n?.locales) {
+		const availableLocales = i18n.locales.map((locale) =>
+			typeof locale === "string" ? locale : locale.code,
 		);
 		const firstSegment = pathSegments[0];
 		if (firstSegment && availableLocales.includes(firstSegment)) {
 			localeSegment = firstSegment;
 			sectionIndex = 2;
-		} else if (config.i18n.defaultLocale) {
-			localeSegment = config.i18n.defaultLocale;
+		} else if (i18n.defaultLocale) {
+			localeSegment = i18n.defaultLocale;
 		}
 	}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -512,6 +512,9 @@ importers:
       unist-util-visit:
         specifier: catalog:nuxt
         version: 5.1.0
+      vue-tsc:
+        specifier: catalog:nuxt
+        version: 3.3.5(typescript@6.0.3)
 
   apps/playground:
     dependencies:
@@ -19042,7 +19045,7 @@ snapshots:
       alien-signals: 3.2.1
       muggle-string: 0.4.1
       path-browserify: 1.0.1
-      picomatch: 4.0.4
+      picomatch: 4.0.5
 
   '@vue/reactivity@3.5.38':
     dependencies:
@@ -27177,7 +27180,7 @@ snapshots:
       expect-type: 1.3.0
       magic-string: 0.30.21
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 0.3.2


### PR DESCRIPTION
## What
Clears the 24 pre-existing TypeScript errors in `apps/docs` and wires the docs
package into `turbo run typecheck` by adding a `typecheck` script and the
`vue-tsc` devDependency.

## Why
The docs package had no real `typecheck` script, so its 24 latent type errors
were invisible to CI. Adding the wiring without first fixing the errors would
turn CI red, so both land together. Implements SF-28 (Stage 2 of SF-26); the
shared/app-level errors were cleared separately in Stage 1 (#311).

The errors fell into four groups, each fixed at the source:

- **i18n auto-imports (6):** `@nuxtjs/i18n` is declared as a dependency but never
  registered as a Nuxt module in this app, so its auto-imported composables
  (`useI18n`, `useLocalePath`, `useSwitchLocalePath`) never exist as globals. The
  app already gates all i18n behavior behind a runtime flag and ships with it
  disabled. Added co-located ambient `declare function` shims so the inert
  enabled-branch typechecks, preserving the existing runtime behavior.
- **Strict-null / unknown (13):** guarded optional array/index access
  (`localeResult[0]?.path`, `section.folder[i]?.replace`, `current?.label`, …)
  and typed the `useRuntimeConfig` i18n reads that TypeScript widened to `{}`.
- **OG image (2):** `defineOgImage("Docs", …)` — bare `"Docs"` is not a valid
  `OgImageComponents` key (ambiguous between the satori/takumi variants). Changed
  to the resolved `"DocsSatori"` key for the local `OgImageDocs.satori.vue`.
- **Category tuple (1):** narrowed a tuple `.indexOf` call in
  `modules/nonRouteCategories.ts` via `as readonly string[]`.

## How verified

    pnpm --filter @styleframe/docs typecheck
    # exit 0 — no TS errors (only the pre-existing vue-router/volar
    #          ERR_PACKAGE_PATH_NOT_EXPORTED warning, unrelated to source)

    pnpm turbo run typecheck
    # Tasks: 16 successful, 16 total

    pnpm lint
    # exit 0 — 0 errors (pre-existing warnings only)

## Notes
No changeset — `@styleframe/docs` is in the changesets ignore list. Changes are
confined to `apps/docs/**` plus the `vue-tsc` dependency wiring; the lockfile
also carries an incidental `picomatch` patch refresh from `pnpm install`.
