### PR TITLE
fix(storybook): replace undefined @0.25 @0.5 chat-message padding with spacing tokens

### DIFF
--- a/apps/storybook/stories/components/chat-message.styleframe.ts
+++ b/apps/storybook/stories/components/chat-message.styleframe.ts
@@ -54,7 +54,7 @@ selector(".chat-message-action-button", {
 	display: "inline-flex",
 	alignItems: "center",
 	gap: "@spacing.xs",
-	padding: "@0.25 @0.5",
+	padding: "@spacing.2xs @spacing.xs",
 	fontSize: "@font-size.xs",
 	color: "@color.text-weak",
 	background: "transparent",


### PR DESCRIPTION
## What

Replace the undefined `@0.25 @0.5` padding on `.chat-message-action-button` with defined named spacing tokens (`@spacing.2xs @spacing.xs`) in the chat-message story fixture.

## Why

`@0.25` / `@0.5` are undefined variables — a raw numeric compound `@`-shorthand that silently resolves to `var(--0--25) var(--0--5)`. This was the last such undefined compound ref in the storybook build. Once SF-13 (#316) lands, resolving these throws and the storybook build fails, so this fixture had to be corrected first. `2xs` = 0.25rem and `xs` = 0.5rem preserve the intended pill padding exactly, and match the file's sibling token usage (the neighboring `gap` uses `@spacing.xs`). Implements SF-35.

## How verified

    grep -rn '@[0-9]' apps/storybook/stories
    # (no output — no raw numeric compound @-refs remain)

    pnpm --filter @styleframe/storybook build
    # Storybook build completed successfully

    pnpm --filter @styleframe/storybook typecheck
    # vue-tsc --noEmit — clean

    # compiled CSS now emits real spacing vars:
    # .chat-message-action-button{...padding:var(--spacing--2xs) var(--spacing--xs);...}
    # no var(--0--25) var(--0--5) anywhere in storybook-static

## Notes

Storybook-only change (apps/storybook is in the changeset ignore list) — no changeset. Scope is this one file; the engine breaking-change that turns these refs into a hard throw is SF-13/#316.
