### PR TITLE
feat(docs): port Docus FTS5 full-text search backend

### DIFF
--- a/apps/docs/app/app.vue
+++ b/apps/docs/app/app.vue
@@ -142,22 +142,6 @@ const { data: navigation } = await useAsyncData(
 	},
 );
 
-const { data: files } = useLazyAsyncData(
-	`search_${locale.value}`,
-	async () => {
-		const perSection = await Promise.all(
-			DOCS_SECTIONS.map((section) =>
-				queryCollectionSearchSections(getCollectionName(section.key)),
-			),
-		);
-		return perSection.flat();
-	},
-	{
-		server: false,
-		watch: [locale],
-	},
-);
-
 const flatNavigation = computed(() =>
 	navigation.value ? Object.values(navigation.value).flat() : [],
 );
@@ -174,7 +158,7 @@ provide("navigation", navigation);
 		</NuxtLayout>
 
 		<ClientOnly>
-			<LazyUContentSearch :files="files" :navigation="flatNavigation" />
+			<AppSearch :navigation="flatNavigation" />
 		</ClientOnly>
 	</UApp>
 </template>

--- a/apps/docs/app/components/app/AppSearch.vue
+++ b/apps/docs/app/components/app/AppSearch.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+import type { ContentNavigationItem, PageCollections } from "@nuxt/content";
+
+const props = defineProps<{
+	navigation?: ContentNavigationItem[];
+}>();
+
+const { locale, isEnabled } = useDocusI18n();
+
+// FTS5 indexes one collection at a time; our docs are split across a
+// collection per top-level section (and per locale), so we hand
+// `useSearchCollection` the whole set and let it index and query them together.
+const collections = computed(() =>
+	DOCS_SECTIONS.map(
+		(section) =>
+			(isEnabled.value
+				? `docs_${section.key}_${locale.value}`
+				: `docs_${section.key}`) as keyof PageCollections,
+	),
+);
+
+const {
+	search,
+	status: searchStatus,
+	init,
+} = useSearchCollection(collections, {
+	immediate: false,
+	ignoredTags: ["style"],
+});
+
+// Build the SQLite FTS5 index lazily: only when the palette first opens, so
+// the search payload never loads on pages the reader never searches from.
+const { open } = useContentSearch();
+watch(open, (value) => {
+	if (value && searchStatus.value === "idle") {
+		init();
+	}
+});
+
+// Empty-state shortcuts shown before the reader types anything.
+const links = computed(() =>
+	props.navigation
+		?.filter((item) => item.children?.length)
+		.map((item) => ({
+			label: item.title,
+			icon: item.icon as string | undefined,
+			to: item.children![0]!.path,
+		})),
+);
+</script>
+
+<template>
+	<LazyUContentSearch
+		:search="search"
+		:search-status="searchStatus"
+		:links="links"
+		:navigation="navigation"
+	/>
+</template>

--- a/apps/docs/app/error.vue
+++ b/apps/docs/app/error.vue
@@ -144,22 +144,6 @@ const { data: navigation } = await useAsyncData(
 	{ watch: [locale] },
 );
 
-const { data: files } = useLazyAsyncData(
-	`search_${locale.value}`,
-	async () => {
-		const perSection = await Promise.all(
-			DOCS_SECTIONS.map((section) =>
-				queryCollectionSearchSections(getCollectionName(section.key)),
-			),
-		);
-		return perSection.flat();
-	},
-	{
-		server: false,
-		watch: [locale],
-	},
-);
-
 const flatNavigation = computed(() =>
 	navigation.value ? Object.values(navigation.value).flat() : [],
 );
@@ -176,7 +160,7 @@ provide("navigation", navigation);
 		<AppFooter />
 
 		<ClientOnly>
-			<LazyUContentSearch :files="files" :navigation="flatNavigation" />
+			<AppSearch :navigation="flatNavigation" />
 		</ClientOnly>
 	</UApp>
 </template>


### PR DESCRIPTION
## What

Port the Docus 5.12.0 FTS5 full-text search backend into `apps/docs`. Search is now served by SQLite FTS5 (via `useSearchCollection`) instead of the client-side `queryCollectionSearchSections` scan. A new `AppSearch` component wraps the shared `UContentSearch` UI and drives the FTS path.

## Why

FTS5 gives indexed, ranked relevance with built-in snippet highlighting, and scales better than an in-memory JS scan as the component-docs corpus grows. The index is also built lazily — only when the command palette first opens — so pages the reader never searches from no longer pay the upfront section-loading cost. Implements SF-42.

## How

Our fork splits docs across one content collection per top-level section (Getting Started / API / Theme), optionally locale-suffixed — unlike upstream Docus, which uses a single `docs` collection. `useSearchCollection` accepts an array of collection names, so `AppSearch` hands it the whole set (locale-aware) and it indexes and queries them together. This preserves `[[lang]]` behavior: collection names and the navigation passed to the palette are both locale-scoped, so result routes resolve to the correct locale. `app.vue` and `error.vue` now render `<AppSearch :navigation="flatNavigation" />` in place of the duplicated inline search block.

## How verified

    pnpm --filter @styleframe/docs build
    # ✔ Build complete! (exit 0)

    pnpm --filter @styleframe/docs typecheck
    # ✔ nuxt typecheck — exit 0 (pre-existing vue-router volar plugin-path
    #   warning only, not a type error)

Manual smoke test against `node .output/server/index.mjs`: opened the command palette (⌘K), which triggered the deferred FTS index build, then searched "installation" — returned ranked results with `<mark>`-highlighted snippets spanning three collections (Getting Started, Tooling, Integrations), confirming cross-collection FTS search.

## Notes

- No changeset: `@styleframe/docs` is in the changesets ignore list.
- No new dependencies: `@nuxt/content` 3.14.0 and `@nuxt/ui` 4.8.2 (which provide `useSearchCollection` and the `search`/`search-status` props) are already pinned in the catalog.
- No new inline styles introduced.
- Upstream added a `search.fts` app-config toggle to keep Fuse.js as a fallback default in their reusable layer; this fork is the end app, so FTS is the single path and the toggle is omitted to avoid dead config surface.
