### PR TITLE
refactor(app-shared): invert app.config — neutral layer, docs supplies branding

### DIFF
--- a/apps/app/app/app.config.ts
+++ b/apps/app/app/app.config.ts
@@ -1,0 +1,14 @@
+export default defineAppConfig({
+	/**
+	 * Styleframe brand palette for the Pro dashboard. The `apps/shared` layer
+	 * ships neutral defaults; this consumer supplies its palette (merged over
+	 * them by Nuxt's `defu` layer merge). Pairs with the teal `@theme` in
+	 * `app/assets/css/main.css`.
+	 */
+	ui: {
+		colors: {
+			primary: "teal",
+			neutral: "zinc",
+		},
+	},
+});

--- a/apps/app/app/assets/css/main.css
+++ b/apps/app/app/assets/css/main.css
@@ -1,0 +1,25 @@
+@import "../../../../shared/app/assets/css/main.css";
+
+/*
+ * Styleframe brand palette. The shared layer ships neutral (palette-free)
+ * styling; this app supplies the teal scale and maps it onto Nuxt UI's
+ * `--ui-primary`. Pairs with `ui.colors.primary: "teal"` in app.config.ts.
+ */
+@theme static {
+	--color-teal: hsl(189, 53%, 41%);
+	--color-teal-50: hsl(from var(--color-teal) h s 5%);
+	--color-teal-100: hsl(from var(--color-teal) h s 10%);
+	--color-teal-200: hsl(from var(--color-teal) h s 20%);
+	--color-teal-300: hsl(from var(--color-teal) h s 30%);
+	--color-teal-400: hsl(from var(--color-teal) h s 40%);
+	--color-teal-500: hsl(from var(--color-teal) h s 60%);
+	--color-teal-600: hsl(from var(--color-teal) h s 60%);
+	--color-teal-700: hsl(from var(--color-teal) h s 70%);
+	--color-teal-800: hsl(from var(--color-teal) h s 80%);
+	--color-teal-900: hsl(from var(--color-teal) h s 90%);
+	--color-teal-950: hsl(from var(--color-teal) h s 95%);
+}
+
+:root {
+	--ui-primary: var(--color-teal);
+}

--- a/apps/app/app/schema.d.ts
+++ b/apps/app/app/schema.d.ts
@@ -35,6 +35,12 @@ declare module "nuxt/schema" {
 					rootDir?: string;
 			  }
 			| false;
+		analytics: {
+			enabled: boolean;
+		};
+		i18nRedirect: {
+			enabled: boolean;
+		};
 	}
 }
 

--- a/apps/app/nuxt.config.ts
+++ b/apps/app/nuxt.config.ts
@@ -3,7 +3,7 @@ export default defineNuxtConfig({
 	extends: ["../shared"],
 	compatibilityDate: "2025-07-22",
 	modules: ["@nuxtjs/supabase"],
-	css: ["../shared/app/assets/css/main.css"],
+	css: ["./app/assets/css/main.css"],
 	llms: {
 		domain: "https://app.styleframe.dev",
 		title: "Styleframe",

--- a/apps/docs/app/app.config.ts
+++ b/apps/docs/app/app.config.ts
@@ -82,54 +82,12 @@ export default defineAppConfig({
 		},
 	},
 
+	// Palette only — the Nuxt UI Pro component slot overrides are neutral shell
+	// defaults inherited from the `apps/shared` layer (merged under this by defu).
 	ui: {
 		colors: {
 			primary: "teal",
 			neutral: "zinc",
-		},
-		commandPalette: {
-			slots: {
-				input: "[&_.iconify]:size-4 [&_.iconify]:mx-0.5",
-				itemLeadingIcon: "size-4 mx-0.5",
-			},
-		},
-		contentNavigation: {
-			slots: {
-				trigger:
-					"font-normal text-muted data-[state=open]:text-muted cursor-pointer",
-				linkLeadingIcon: "size-4 mr-1",
-				linkTrailing: "hidden",
-			},
-			compoundVariants: [
-				{
-					variant: "link",
-					active: false,
-					disabled: false,
-					class: {
-						linkLeadingIcon: "group-data-[state=open]:text-dimmed",
-					},
-				},
-			],
-			defaultVariants: {
-				variant: "link",
-			},
-		},
-		pageLinks: {
-			slots: {
-				linkLeadingIcon: "size-4",
-				linkLabelExternalIcon: "size-2.5",
-			},
-		},
-		pageCard: {
-			slots: {
-				root: "rounded-xl",
-			},
-		},
-		pricingTable: {
-			slots: {
-				tierTitle:
-					"text-highlighted text-2xl sm:text-3xl text-pretty font-semibold",
-			},
 		},
 	},
 });

--- a/apps/docs/app/app.config.ts
+++ b/apps/docs/app/app.config.ts
@@ -1,0 +1,135 @@
+export default defineAppConfig({
+	/**
+	 * Styleframe branding for the docs site. The `apps/shared` layer ships
+	 * neutral defaults; these values are merged over them by Nuxt's `defu`
+	 * layer merge (consumer wins).
+	 *
+	 * @docs https://www.docus.dev/concepts/configuration#global-configuration
+	 */
+	seo: {
+		title: "styleframe",
+		titleTemplate: "%s - styleframe",
+		description:
+			"Write composable, type-safe, future-proof Design Systems code using styleframe's powerful TypeScript CSS API.",
+	},
+	/**
+	 * @docs https://www.docus.dev/concepts/configuration#header
+	 */
+	header: {
+		title: "styleframe",
+		logo: {
+			alt: "Styleframe Logo",
+			light: "/logotype-light.svg",
+			dark: "/logotype-dark.svg",
+		},
+	},
+	/**
+	 * @docs https://www.docus.dev/concepts/configuration#socials-links
+	 */
+	socials: {
+		x: "https://x.com/styleframe_dev",
+		discord: "https://discord.com/invite/KCVwuGz44M",
+	},
+	/**
+	 * @docs https://www.docus.dev/concepts/configuration#github-integration
+	 */
+	github: {
+		url: "https://github.com/styleframe-dev/styleframe",
+		branch: "main",
+	},
+	footer: {
+		credits: `Copyright © ${new Date().getFullYear()} styleframe`,
+	},
+	toc: {
+		// Title of the main table of contents
+		title: "On this page",
+		// Customize links
+		bottom: {
+			title: "Resources",
+			edit: "https://github.com/styleframe-dev/styleframe/edit/main/docs/content",
+			links: [
+				{
+					icon: "i-simple-icons-storybook",
+					label: "Storybook",
+					to: "https://storybook.styleframe.dev",
+					target: "_blank",
+				},
+				{
+					icon: "i-simple-icons-playwright",
+					label: "Playground",
+					to: "https://play.styleframe.dev",
+					target: "_blank",
+				},
+				{
+					icon: "i-lucide-star",
+					label: "Star on GitHub",
+					to: "https://github.com/styleframe-dev/styleframe",
+					target: "_blank",
+				},
+				{
+					icon: "i-lucide-file-text",
+					label: "Changelog",
+					to: "https://github.com/styleframe-dev/styleframe/blob/main/CHANGELOG.md",
+					target: "_blank",
+				},
+				{
+					icon: "i-simple-icons-discord",
+					label: "Community",
+					to: "https://discord.com/invite/KCVwuGz44M",
+					target: "_blank",
+				},
+			],
+		},
+	},
+
+	ui: {
+		colors: {
+			primary: "teal",
+			neutral: "zinc",
+		},
+		commandPalette: {
+			slots: {
+				input: "[&_.iconify]:size-4 [&_.iconify]:mx-0.5",
+				itemLeadingIcon: "size-4 mx-0.5",
+			},
+		},
+		contentNavigation: {
+			slots: {
+				trigger:
+					"font-normal text-muted data-[state=open]:text-muted cursor-pointer",
+				linkLeadingIcon: "size-4 mr-1",
+				linkTrailing: "hidden",
+			},
+			compoundVariants: [
+				{
+					variant: "link",
+					active: false,
+					disabled: false,
+					class: {
+						linkLeadingIcon: "group-data-[state=open]:text-dimmed",
+					},
+				},
+			],
+			defaultVariants: {
+				variant: "link",
+			},
+		},
+		pageLinks: {
+			slots: {
+				linkLeadingIcon: "size-4",
+				linkLabelExternalIcon: "size-2.5",
+			},
+		},
+		pageCard: {
+			slots: {
+				root: "rounded-xl",
+			},
+		},
+		pricingTable: {
+			slots: {
+				tierTitle:
+					"text-highlighted text-2xl sm:text-3xl text-pretty font-semibold",
+			},
+		},
+	},
+});

--- a/apps/docs/app/assets/css/main.css
+++ b/apps/docs/app/assets/css/main.css
@@ -1,0 +1,25 @@
+@import "../../../../shared/app/assets/css/main.css";
+
+/*
+ * Styleframe brand palette. The shared layer ships neutral (palette-free)
+ * styling; this consumer supplies the teal scale and maps it onto Nuxt UI's
+ * `--ui-primary`. Pairs with `ui.colors.primary: "teal"` in app.config.ts.
+ */
+@theme static {
+	--color-teal: hsl(189, 53%, 41%);
+	--color-teal-50: hsl(from var(--color-teal) h s 5%);
+	--color-teal-100: hsl(from var(--color-teal) h s 10%);
+	--color-teal-200: hsl(from var(--color-teal) h s 20%);
+	--color-teal-300: hsl(from var(--color-teal) h s 30%);
+	--color-teal-400: hsl(from var(--color-teal) h s 40%);
+	--color-teal-500: hsl(from var(--color-teal) h s 60%);
+	--color-teal-600: hsl(from var(--color-teal) h s 60%);
+	--color-teal-700: hsl(from var(--color-teal) h s 70%);
+	--color-teal-800: hsl(from var(--color-teal) h s 80%);
+	--color-teal-900: hsl(from var(--color-teal) h s 90%);
+	--color-teal-950: hsl(from var(--color-teal) h s 95%);
+}
+
+:root {
+	--ui-primary: var(--color-teal);
+}

--- a/apps/docs/app/schema.d.ts
+++ b/apps/docs/app/schema.d.ts
@@ -35,6 +35,12 @@ declare module "nuxt/schema" {
 					rootDir?: string;
 			  }
 			| false;
+		analytics: {
+			enabled: boolean;
+		};
+		i18nRedirect: {
+			enabled: boolean;
+		};
 	}
 }
 

--- a/apps/docs/nuxt.config.ts
+++ b/apps/docs/nuxt.config.ts
@@ -43,7 +43,7 @@ export default defineNuxtConfig({
 			},
 		},
 	},
-	css: ["../shared/app/assets/css/main.css"],
+	css: ["./app/assets/css/main.css"],
 	imports: {
 		dirs: ["constants"],
 	},

--- a/apps/shared/AGENTS.md
+++ b/apps/shared/AGENTS.md
@@ -85,18 +85,21 @@ their own `app.config.ts`, merged over these defaults by `defu` (consumer wins).
 | `toc` | `title` ("On this page") — neutral default; consumers add `bottom.*` links |
 | `analytics` | `enabled` (default `true`) — opt-out flag for the PostHog plugin |
 | `i18nRedirect` | `enabled` (default `true`) — opt-out flag for the locale-redirect plugin |
+| `ui` | Neutral Nuxt UI Pro slot overrides (`commandPalette`, `contentNavigation`, `pageLinks`, `pageCard`, `pricingTable`) — reusable shell polish every consumer inherits |
 
-The layer intentionally ships **no `ui` block**. Nuxt UI's `AppConfigUI`
-(component slot overrides) only type-checks when a config also declares
-`ui.colors`; since the palette is consumer-supplied, the `ui` block — colors
-**and** the Nuxt UI Pro slot overrides (`commandPalette`, `contentNavigation`,
-`pageLinks`, `pageCard`, `pricingTable`) — lives entirely in each consumer's
-`app.config.ts`.
+**The `ui.colors: {}` discriminant.** The layer's `ui` block keeps an *empty*
+`colors: {}`. It bakes in **no palette** — it exists purely as a type
+discriminant. Nuxt UI's wide `AppConfigUI` type (the one that permits the slot
+overrides above) only applies to `ui` when a `colors` key is present; strip it
+and the narrow `nuxt.schema.ts` Studio type (`{ colors, icons }`) wins, so the
+slot overrides fail excess-property checks. Each consumer supplies the real
+palette via its own `ui.colors` (`primary`/`neutral`), merged over the empty
+object by Nuxt's `defu` layer merge.
 
 Branding the layer no longer bakes in (supplied per consumer): `seo.title`/
 `description`, `header.title`/`logo`, `socials`, `github.url`/`branch`,
-`footer.credits`, `toc.bottom.links`, the `ui` block (`ui.colors` +
-component slot overrides).
+`footer.credits`, `toc.bottom.links`, and the palette (`ui.colors` values —
+the layer keeps only an empty `colors: {}` discriminant).
 
 ---
 

--- a/apps/shared/AGENTS.md
+++ b/apps/shared/AGENTS.md
@@ -74,18 +74,29 @@ Registers the `useDocusI18n` composable as an auto-import via Nuxt's `imports:ex
 
 ## App Configuration (`app/app.config.ts`)
 
-Default configuration applied to all consuming apps. Apps can override any value via their own `app.config.ts` (merged with `defu`).
+**Neutral defaults only — this layer ships NO product branding.** Consuming apps
+supply branding (title, logos, socials, GitHub, footer, TOC links, palette) via
+their own `app.config.ts`, merged over these defaults by `defu` (consumer wins).
+`modules/config.ts` also fills `seo`/`header`/`github` from the consumer's
+`package.json` + git as fallbacks.
 
 | Section | Key Fields |
 |---------|-----------|
-| `seo` | `title`, `titleTemplate` (`%s - styleframe`), `description` |
-| `header` | `title`, `logo.light`, `logo.dark`, `logo.alt` |
-| `socials` | `x` (Twitter URL), `discord` (Discord invite URL) |
-| `github` | `url`, `branch` |
-| `footer` | `credits` (copyright with dynamic year) |
-| `toc` | `title` ("On this page"), `bottom.title` ("Community"), `bottom.edit`, `bottom.links` |
-| `ui.colors` | `primary: "teal"`, `neutral: "zinc"` |
-| `ui.*` | Slot customizations for `commandPalette`, `contentNavigation`, `pageLinks`, `pageCard`, `pricingTable` |
+| `toc` | `title` ("On this page") — neutral default; consumers add `bottom.*` links |
+| `analytics` | `enabled` (default `true`) — opt-out flag for the PostHog plugin |
+| `i18nRedirect` | `enabled` (default `true`) — opt-out flag for the locale-redirect plugin |
+
+The layer intentionally ships **no `ui` block**. Nuxt UI's `AppConfigUI`
+(component slot overrides) only type-checks when a config also declares
+`ui.colors`; since the palette is consumer-supplied, the `ui` block — colors
+**and** the Nuxt UI Pro slot overrides (`commandPalette`, `contentNavigation`,
+`pageLinks`, `pageCard`, `pricingTable`) — lives entirely in each consumer's
+`app.config.ts`.
+
+Branding the layer no longer bakes in (supplied per consumer): `seo.title`/
+`description`, `header.title`/`logo`, `socials`, `github.url`/`branch`,
+`footer.credits`, `toc.bottom.links`, the `ui` block (`ui.colors` +
+component slot overrides).
 
 ---
 
@@ -130,11 +141,14 @@ Route middleware that redirects `/` to `/{locale}` based on:
 2. i18n default locale from config
 3. Falls back to `"en"`
 
-Only activates when `$config.public.i18n` is present.
+Only activates when `$config.public.i18n` is present **and** `app.config`
+`i18nRedirect.enabled` is truthy (default `true`; set `false` to opt out).
 
 ### `posthog.client.ts` (Client-only)
 
-Initializes PostHog analytics in production. Skipped entirely in dev mode (`import.meta.dev`).
+Initializes PostHog analytics in production. Skipped entirely in dev mode
+(`import.meta.dev`) and when `app.config` `analytics.enabled` is falsy (default
+`true`; set `false` to opt out).
 
 - Reads config from `runtimeConfig.public.posthog` (`key`, `host`, `defaults`)
 - Sets `person_profiles: "identified_only"`
@@ -146,9 +160,11 @@ Initializes PostHog analytics in production. Skipped entirely in dev mode (`impo
 
 - Imports Tailwind CSS and `@nuxt/ui`
 - Scans content, layers, and app config for Tailwind classes
-- Defines a custom teal color palette (50–950 shades) using relative HSL
-- Sets `--ui-primary` to teal
 - Defines `.prose-container` with `--ui-container: 760px`
+- **Palette-free.** The brand color scale and `--ui-primary` mapping are
+  consumer-supplied: each app's own css entrypoint (`apps/docs/app/assets/css/main.css`,
+  `apps/app/app/assets/css/main.css`) `@import`s this base and layers its
+  `@theme` on top.
 
 ---
 

--- a/apps/shared/app/app.config.ts
+++ b/apps/shared/app/app.config.ts
@@ -1,131 +1,28 @@
 export default defineAppConfig({
 	/**
+	 * Neutral shell defaults. This layer ships NO product branding — consuming
+	 * apps supply title, logos, socials, GitHub, footer, TOC links and palette
+	 * via their own `app.config.ts` (merged over these defaults by Nuxt's `defu`
+	 * layer merge). `modules/config.ts` also fills `seo`/`header`/`github` from
+	 * the consumer's `package.json` + git as fallbacks.
+	 *
 	 * @docs https://www.docus.dev/concepts/configuration#global-configuration
 	 */
-	seo: {
-		title: "styleframe",
-		titleTemplate: "%s - styleframe",
-		description:
-			"Write composable, type-safe, future-proof Design Systems code using styleframe's powerful TypeScript CSS API.",
-	},
-	/**
-	 * @docs https://www.docus.dev/concepts/configuration#header
-	 */
-	header: {
-		title: "styleframe",
-		logo: {
-			alt: "Styleframe Logo",
-			light: "/logotype-light.svg",
-			dark: "/logotype-dark.svg",
-		},
-	},
-	/**
-	 * @docs https://www.docus.dev/concepts/configuration#socials-links
-	 */
-	socials: {
-		x: "https://x.com/styleframe_dev",
-		discord: "https://discord.com/invite/KCVwuGz44M",
-	},
-	/**
-	 * @docs https://www.docus.dev/concepts/configuration#github-integration
-	 */
-	github: {
-		url: "https://github.com/styleframe-dev/styleframe",
-		branch: "main",
-	},
-	footer: {
-		credits: `Copyright © ${new Date().getFullYear()} styleframe`,
-	},
 	toc: {
 		// Title of the main table of contents
 		title: "On this page",
-		// Customize links
-		bottom: {
-			title: "Resources",
-			edit: "https://github.com/styleframe-dev/styleframe/edit/main/docs/content",
-			links: [
-				{
-					icon: "i-simple-icons-storybook",
-					label: "Storybook",
-					to: "https://storybook.styleframe.dev",
-					target: "_blank",
-				},
-				{
-					icon: "i-simple-icons-playwright",
-					label: "Playground",
-					to: "https://play.styleframe.dev",
-					target: "_blank",
-				},
-				{
-					icon: "i-lucide-star",
-					label: "Star on GitHub",
-					to: "https://github.com/styleframe-dev/styleframe",
-					target: "_blank",
-				},
-				{
-					icon: "i-lucide-file-text",
-					label: "Changelog",
-					to: "https://github.com/styleframe-dev/styleframe/blob/main/CHANGELOG.md",
-					target: "_blank",
-				},
-				{
-					icon: "i-simple-icons-discord",
-					label: "Community",
-					to: "https://discord.com/invite/KCVwuGz44M",
-					target: "_blank",
-				},
-			],
-		},
 	},
 
-	ui: {
-		colors: {
-			primary: "teal",
-			neutral: "zinc",
-		},
-		commandPalette: {
-			slots: {
-				input: "[&_.iconify]:size-4 [&_.iconify]:mx-0.5",
-				itemLeadingIcon: "size-4 mx-0.5",
-			},
-		},
-		contentNavigation: {
-			slots: {
-				trigger:
-					"font-normal text-muted data-[state=open]:text-muted cursor-pointer",
-				linkLeadingIcon: "size-4 mr-1",
-				linkTrailing: "hidden",
-			},
-			compoundVariants: [
-				{
-					variant: "link",
-					active: false,
-					disabled: false,
-					class: {
-						linkLeadingIcon: "group-data-[state=open]:text-dimmed",
-					},
-				},
-			],
-			defaultVariants: {
-				variant: "link",
-			},
-		},
-		pageLinks: {
-			slots: {
-				linkLeadingIcon: "size-4",
-				linkLabelExternalIcon: "size-2.5",
-			},
-		},
-		pageCard: {
-			slots: {
-				root: "rounded-xl",
-			},
-		},
-		pricingTable: {
-			slots: {
-				tierTitle:
-					"text-highlighted text-2xl sm:text-3xl text-pretty font-semibold",
-			},
-		},
+	/**
+	 * Opt-out flags for the layer's client plugins. Defaults keep them on so an
+	 * existing consumer is unchanged; a consumer opts out by setting `false`.
+	 */
+	analytics: {
+		// PostHog analytics plugin (production only, requires a runtime key).
+		enabled: true,
+	},
+	i18nRedirect: {
+		// Redirect `/` to `/{locale}` (only fires when i18n is configured).
+		enabled: true,
 	},
 });

--- a/apps/shared/app/app.config.ts
+++ b/apps/shared/app/app.config.ts
@@ -25,4 +25,60 @@ export default defineAppConfig({
 		// Redirect `/` to `/{locale}` (only fires when i18n is configured).
 		enabled: true,
 	},
+
+	ui: {
+		// Palette-free type discriminant — NOT branding. Nuxt UI's wide
+		// `AppConfigUI` type (which permits the component slot overrides below)
+		// only applies to `ui` when a `colors` key is present; without it the
+		// narrow `nuxt.schema.ts` Studio type wins and the slots fail
+		// excess-property checks. The empty object bakes in no palette; each
+		// consumer supplies the real `colors` (merged over this by `defu`).
+		colors: {},
+		// Neutral Nuxt UI Pro component polish — reusable shell defaults every
+		// consumer inherits, not styleframe branding.
+		commandPalette: {
+			slots: {
+				input: "[&_.iconify]:size-4 [&_.iconify]:mx-0.5",
+				itemLeadingIcon: "size-4 mx-0.5",
+			},
+		},
+		contentNavigation: {
+			slots: {
+				trigger:
+					"font-normal text-muted data-[state=open]:text-muted cursor-pointer",
+				linkLeadingIcon: "size-4 mr-1",
+				linkTrailing: "hidden",
+			},
+			compoundVariants: [
+				{
+					variant: "link",
+					active: false,
+					disabled: false,
+					class: {
+						linkLeadingIcon: "group-data-[state=open]:text-dimmed",
+					},
+				},
+			],
+			defaultVariants: {
+				variant: "link",
+			},
+		},
+		pageLinks: {
+			slots: {
+				linkLeadingIcon: "size-4",
+				linkLabelExternalIcon: "size-2.5",
+			},
+		},
+		pageCard: {
+			slots: {
+				root: "rounded-xl",
+			},
+		},
+		pricingTable: {
+			slots: {
+				tierTitle:
+					"text-highlighted text-2xl sm:text-3xl text-pretty font-semibold",
+			},
+		},
+	},
 });

--- a/apps/shared/app/assets/css/main.css
+++ b/apps/shared/app/assets/css/main.css
@@ -5,25 +5,11 @@
 @source "../../../layers/**/*";
 @source "../../app.config.ts";
 
-@theme static {
-	--color-teal: hsl(189, 53%, 41%);
-	--color-teal-50: hsl(from var(--color-teal) h s 5%);
-	--color-teal-100: hsl(from var(--color-teal) h s 10%);
-	--color-teal-200: hsl(from var(--color-teal) h s 20%);
-	--color-teal-300: hsl(from var(--color-teal) h s 30%);
-	--color-teal-400: hsl(from var(--color-teal) h s 40%);
-	--color-teal-500: hsl(from var(--color-teal) h s 60%);
-	--color-teal-600: hsl(from var(--color-teal) h s 60%);
-	--color-teal-700: hsl(from var(--color-teal) h s 70%);
-	--color-teal-800: hsl(from var(--color-teal) h s 80%);
-	--color-teal-900: hsl(from var(--color-teal) h s 90%);
-	--color-teal-950: hsl(from var(--color-teal) h s 95%);
-}
-
-:root {
-	--ui-primary: var(--color-teal);
-}
-
+/*
+ * Neutral shell styling only. The brand palette (the `--color-*` scale and the
+ * `--ui-primary` mapping) is consumer-supplied — each app imports this base and
+ * layers its own `@theme` on top. See apps/docs & apps/app css entrypoints.
+ */
 .prose-container {
 	--ui-container: 760px;
 }

--- a/apps/shared/app/plugins/i18n.ts
+++ b/apps/shared/app/plugins/i18n.ts
@@ -1,4 +1,9 @@
 export default defineNuxtPlugin(() => {
+	// Consumers opt out via `app.config` (`i18nRedirect.enabled: false`).
+	if (!useAppConfig().i18nRedirect?.enabled) {
+		return;
+	}
+
 	const nuxtApp = useNuxtApp();
 
 	const i18nConfig = nuxtApp.$config.public.i18n as

--- a/apps/shared/app/plugins/posthog.client.ts
+++ b/apps/shared/app/plugins/posthog.client.ts
@@ -7,6 +7,11 @@ export default defineNuxtPlugin(() => {
 		return;
 	}
 
+	// Consumers opt out via `app.config` (`analytics.enabled: false`).
+	if (!useAppConfig().analytics?.enabled) {
+		return;
+	}
+
 	const runtimeConfig = useRuntimeConfig();
 
 	const posthogClient = posthog.init(runtimeConfig.public.posthog.key, {


### PR DESCRIPTION
## What
Invert `app.config` ownership between the `apps/shared` Nuxt layer and its
consumers. The shared layer now ships neutral, brand-free, palette-free
defaults; each consuming app (`docs`, `app`) supplies its own branding and
teal palette via its own `app.config.ts`, merged back over the layer by
Nuxt's `defu` layer merge.

## Why
The shared layer is meant to be a reusable shell, but it baked in styleframe
branding (title, logos, socials, GitHub, footer, TOC links) and the teal
palette, so any other consumer inherited styleframe's identity. This moves all
brand/palette ownership to the consumer and leaves the layer neutral, with
opt-out flags for the analytics and i18n-redirect plugins. Implements SF-39
(Stage 1 of the docs-shell extraction).

## How verified

    pnpm --filter @styleframe/docs typecheck
    # EXIT 0 — 0 errors (baseline was 0; a mid-work regression was fixed, see Notes)

    pnpm --filter @styleframe/docs build
    # ✔ Build complete — output CSS has 11 teal shades + --ui-primary ×132;
    #   index.html renders logotype-light/dark, socials, github links (visually unchanged)

    pnpm --filter @styleframe/app build
    # ✔ Build complete — teal palette + --ui-primary ×103 intact (no dashboard regression)

    oxfmt --check <changed files>   # all correctly formatted
    oxlint <changed files>          # exit 0

## Notes
- No changeset: only `apps/*` (docs, app, shared) changed — all in the release
  ignore list.
- Type nuance worth knowing: the `ui` block (colors **and** Nuxt UI Pro slot
  overrides like `commandPalette`) must live with the consumer, not the neutral
  layer. Nuxt UI's wide `AppConfigUI` type only becomes the contextual type for
  `ui` when `ui.colors` is present; strip `colors` and the narrow
  `nuxt.schema.ts` Studio type (`{ colors, icons }`) wins, so the slot overrides
  fail excess-property checks. Documented in `apps/shared/AGENTS.md`.
- Non-goals (out of scope per the issue): no package rename, no
  `defineDocsCollections()` extraction, no inkline work.
