### PR TITLE
docs: redirect homepage to /llms.txt for AI agents

### DIFF
--- a/apps/docs/server/plugins/llms-redirect.ts
+++ b/apps/docs/server/plugins/llms-redirect.ts
@@ -1,0 +1,60 @@
+import type { H3Event } from "h3";
+import { withoutTrailingSlash } from "ufo";
+
+/**
+ * Serve `/llms.txt` from the homepage for AI agents and crawlers.
+ *
+ * Human browsers still get the rendered homepage; only clients that ask for
+ * markdown (`Accept: text/markdown`) or identify as `curl` are redirected to
+ * the `nuxt-llms` entry point. This mirrors Docus's agent-friendly behaviour
+ * but works across Nitro presets (we deploy the node-server output), where the
+ * upstream Vercel-config rewrite does not apply.
+ *
+ * It runs on the `request` hook rather than as route middleware so it fires
+ * before Nitro's public-asset handler serves the prerendered homepage — route
+ * middleware would never see a request for a statically generated page.
+ */
+export default defineNitroPlugin((nitroApp) => {
+	nitroApp.hooks.hook("request", (event) => {
+		if (event.method !== "GET" && event.method !== "HEAD") {
+			return;
+		}
+
+		const path = withoutTrailingSlash(event.path.split("?")[0]) || "/";
+		if (!isRootPath(event, path)) {
+			return;
+		}
+
+		const accept = getHeader(event, "accept") ?? "";
+		const userAgent = getHeader(event, "user-agent") ?? "";
+
+		const wantsMarkdown = accept.includes("text/markdown");
+		const isCurl = /^curl\//i.test(userAgent);
+
+		if (wantsMarkdown || isCurl) {
+			return sendRedirect(event, "/llms.txt", 302);
+		}
+	});
+});
+
+/**
+ * True for `/` and, when i18n is enabled, each locale homepage (e.g. `/en`).
+ */
+function isRootPath(event: H3Event, path: string) {
+	if (path === "/") {
+		return true;
+	}
+
+	const i18n = useRuntimeConfig(event).public.i18n as
+		| { locales?: (string | { code: string })[] }
+		| undefined;
+
+	if (!i18n?.locales) {
+		return false;
+	}
+
+	return i18n.locales.some((locale) => {
+		const code = typeof locale === "string" ? locale : locale.code;
+		return path === `/${code}`;
+	});
+}


### PR DESCRIPTION
## What

Redirect the docs homepage (and any locale root) to `/llms.txt` for AI agents
and crawlers, while human browsers keep the rendered homepage. Clients that ask
for markdown (`Accept: text/markdown`) or identify as `curl` get a 302 to the
`nuxt-llms` entry point.

## Why

The `/raw/**.md` routes already expose clean per-page markdown, but there was no
agent-friendly entry point at the root. This exposes `/llms.txt` from the
homepage so AI crawlers can discover the docs directly — cheap, high-signal, and
on-brand for a DX-first project. Cherry-picked from the Docus 5.4.4 / 5.5.0
upstream review.

Docus implements this as a Vercel-config rewrite; we deploy the Nitro
node-server output, so this is implemented as a Nitro `request`-hook plugin
instead. It runs before Nitro serves the prerendered `index.html` — plain route
middleware never sees a request for a statically generated page.

Implements SF-43.

## How verified

    pnpm --filter @styleframe/docs typecheck
    # exit 0, 0 TS errors

    pnpm --filter @styleframe/docs run build
    # ✨ Build complete! (exit 0)

Manual checks against the production build (`node .output/server/index.mjs`):

    # browser homepage — served, no redirect
    curl -A "Mozilla/5.0" -H "Accept: text/html" /        -> 200

    # agents redirected to /llms.txt
    curl /                                                 -> 302 -> /llms.txt   (curl UA)
    curl -A "Mozilla/5.0" -H "Accept: text/markdown" /     -> 302 -> /llms.txt

    # nuxt-llms output + raw route intact
    curl /llms.txt                                         -> 200 text/plain
    curl /raw/docs/getting-started/introduction.md         -> 200 text/markdown

## Notes

No changeset — `@styleframe/docs` is in the changesets ignore list. Scope is
`apps/docs/**` only; `theme/**` untouched. `nuxt-llms` output is unchanged and
already emits `/raw/**.md` links.
