### PR TITLE
fix(core): boundary-guard @-reference parsing for mid-token literals

### DIFF
--- a/.changeset/core-at-ref-word-boundary.md
+++ b/.changeset/core-at-ref-word-boundary.md
@@ -1,0 +1,6 @@
+---
+"@styleframe/core": patch
+"styleframe": patch
+---
+
+Boundary-guard `@`-reference parsing so a `@` mid-token is a literal, not a reference. `AT_VARIABLE_REGEX` matched `@` anywhere in a string, so a retina URL like `url("image@2x.png")` parsed `@2x.png` as a variable reference — silently emitting a dead `var(--2x--png)` before SF-13, and *throwing* `Variable "2x.png" is not defined` after SF-13 tightened ref validation. The regex now requires a non-word boundary before `@` (`(?<!\w)`), so `@` only starts a reference when not preceded by a word character. Genuine leading-`@` refs (`@color.primary`, `1px solid @spacing.sm`, `@border.width solid @color.primary`) are unchanged, byte for byte; only `@`-mid-token literals change — from broken/throwing to passthrough.

--- a/engine/core/src/tokens/atRule.test.ts
+++ b/engine/core/src/tokens/atRule.test.ts
@@ -668,13 +668,16 @@ describe("createMediaFunction", () => {
 			const result = media(
 				"(-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi)",
 				{
-					backgroundImage: 'url("image-2x.png")',
+					backgroundImage: 'url("image@2x.png")',
 				},
 			);
 
 			expect(result.rule).toBe(
 				"(-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi)",
 			);
+			// A retina URL's mid-token @ must stay a literal string, not parse as
+			// a reference (no throw, no dead var(--2x--png)). See SF-33.
+			expect(result.declarations.backgroundImage).toBe('url("image@2x.png")');
 		});
 
 		it("should handle empty query string", () => {

--- a/engine/core/src/tokens/resolve.test.ts
+++ b/engine/core/src/tokens/resolve.test.ts
@@ -63,6 +63,27 @@ describe("parseAtReferences", () => {
 
 		expect(result).toEqual([]);
 	});
+
+	it("should not treat a mid-token @ as a reference (retina URL)", () => {
+		const result = parseAtReferences('url("image@2x.png")');
+
+		expect(result).toEqual(['url("image@2x.png")']);
+	});
+
+	it("should not treat a @ preceded by a word character as a reference", () => {
+		const result = parseAtReferences("foo@bar");
+
+		expect(result).toEqual(["foo@bar"]);
+	});
+
+	it("should still parse a leading @ reference after a non-word boundary", () => {
+		const result = parseAtReferences('url("image@2x.png") @color.primary');
+
+		expect(result).toEqual([
+			'url("image@2x.png") ',
+			{ type: "reference", name: "color.primary", fallback: undefined },
+		]);
+	});
 });
 
 describe("findVariableInScope", () => {
@@ -283,6 +304,16 @@ describe("createPropertyValueResolver", () => {
 
 		it("should return empty strings unchanged", () => {
 			expect(resolvePropertyValue("")).toBe("");
+		});
+
+		it("should return a retina URL literal unchanged (no throw, no ref)", () => {
+			expect(resolvePropertyValue('url("image@2x.png")')).toBe(
+				'url("image@2x.png")',
+			);
+		});
+
+		it("should return a bare mid-token @ literal unchanged", () => {
+			expect(resolvePropertyValue("foo@bar")).toBe("foo@bar");
 		});
 	});
 

--- a/engine/core/src/tokens/resolve.ts
+++ b/engine/core/src/tokens/resolve.ts
@@ -23,7 +23,10 @@ export function trackReferenceUsage(root: Root, value: TokenValue): void {
 
 export type RefFunction = (variable: string, fallback?: string) => Reference;
 
-const AT_VARIABLE_REGEX = /@([\w.-]+)/g;
+// `@` only starts a reference at a non-word boundary. Guarding with `(?<!\w)`
+// keeps mid-token literals like a retina URL `url("image@2x.png")` intact
+// instead of parsing `@2x.png` as a variable reference (SF-33).
+const AT_VARIABLE_REGEX = /(?<!\w)@([\w.-]+)/g;
 
 export function parseAtReferences(str: string): TokenValue[] {
 	const parts: TokenValue[] = [];


### PR DESCRIPTION
## What

Boundary-guard `@`-reference parsing in `@styleframe/core` so a `@` in the middle of a token is treated as a literal, not a variable reference. `AT_VARIABLE_REGEX` now requires a non-word boundary before `@` (`/(?<!\w)@([\w.-]+)/g`).

## Why

`AT_VARIABLE_REGEX` matched `@` anywhere in a string, so a legitimate retina URL like `url("image@2x.png")` parsed `@2x.png` as a variable reference:

- Before SF-13: silently emitted a dead `var(--2x--png)`.
- After SF-13 tightened ref validation: the same input now *throws* `Variable "2x.png" is not defined`, breaking the build on a valid URL.

SF-13 had to neutralize the incidental `atRule.test.ts` fixture (`url("image@2x.png")` → `url("image-2x.png")`) to stay scoped; this change fixes the root cause and restores that fixture. Genuine leading-`@` refs are unchanged, byte for byte — only `@`-mid-token literals change, from broken/throwing to passthrough.

Implements SF-33.

## How verified

    pnpm --filter @styleframe/core test
    # ✓ Test Files 21 passed (21) — Tests 715 passed (715)

    pnpm --filter @styleframe/core typecheck
    # ✓ tsc --noEmit, clean

    npx oxlint src/tokens/resolve.ts src/tokens/resolve.test.ts src/tokens/atRule.test.ts
    # ✓ ok

    pnpm build:nodocs
    # ✓ Tasks: 11 successful, 11 total

New/changed tests (each fails on `main`, passes with the guard):

- `parseAtReferences` — `url("image@2x.png")` and `foo@bar` parse as literal string parts; a leading `@` ref after a non-word boundary still parses.
- `createPropertyValueResolver` — retina URL and bare mid-token `@` literals return unchanged (no throw, no `css` object).
- `atRule.test.ts` resolution-query fixture restored to `url("image@2x.png")` and asserts `declarations.backgroundImage` stays the literal string.

## Notes

Patch changeset added (`@styleframe/core`, `styleframe`) — it only fixes already-broken/newly-throwing output for `@`-mid-token literals.
