### PR TITLE
docs(theme): correct stale toast title size docstring

### DIFF
--- a/theme/src/recipes/toast/useToastTitleRecipe.test.ts
+++ b/theme/src/recipes/toast/useToastTitleRecipe.test.ts
@@ -41,9 +41,11 @@ describe("useToastTitleRecipe", () => {
 			const s = createInstance();
 			const recipe = useToastTitleRecipe(s);
 
-			// Title and description share the same literal size token at every
-			// step — sm → sm, md → md, lg → lg — so they render equal in size;
-			// the title stays dominant through weight alone.
+			// Title tracks the size axis on the literal token — sm → sm,
+			// md → md, lg → lg. The description carries the same axis one token
+			// below (sm → xs, md → sm, lg → md), so it sits a step under the
+			// title at every size; the title stays dominant through weight
+			// (semibold vs normal) reinforced by that size step.
 			expect(recipe.variants!.size).toEqual({
 				sm: { fontSize: "@font-size.sm" },
 				md: { fontSize: "@font-size.md" },

--- a/theme/src/recipes/toast/useToastTitleRecipe.ts
+++ b/theme/src/recipes/toast/useToastTitleRecipe.ts
@@ -10,9 +10,10 @@ import { createUseRecipe } from "../../utils/createUseRecipe";
  *
  * Font size follows the `size` axis on the literal token — sm → sm, md → md,
  * lg → lg — rather than inheriting the toast root. The description carries the
- * same axis with the same tokens, so title and description are equal in size at
- * every step; the title stays dominant through weight (semibold vs normal)
- * alone. Defaults to `md` to match the toast.
+ * same axis one token below (sm → xs, md → sm, lg → md), so it sits a step
+ * under the title at every size; the title stays dominant through weight
+ * (semibold vs normal) reinforced by that size step. Defaults to `md` to match
+ * the toast.
  */
 export const useToastTitleRecipe = createUseRecipe("toast-title", {
 	base: {


### PR DESCRIPTION
## What
Corrects the toast title recipe docstring, which claimed the title and description are "equal in size at every step." Rewrites it to state the actual landed relationship: the description sits one token below the title (sm → xs, md → sm, lg → md).

## Why
The stale claim contradicted both the landed `useToastDescriptionRecipe` values and its own sibling docstring. It was found during the callout parity review (SF-17), where the same source had been copied; cleaning it up now stops the incorrect claim from being copied forward again. Docstring-only — no runtime or token change. Implements SF-32.

## How verified

    pnpm --filter @styleframe/theme typecheck
    # ✓ tsc --noEmit — clean

    pnpm --filter @styleframe/theme test
    # ✓ Test Files  307 passed (307)
    # ✓ Tests  3354 passed (3354)

## Notes
No changeset — comment-only change with no public behavior change. The description recipe docstring already reads correctly, so it was left untouched.
