### PR TITLE
docs: add per-version changelog detail pages

### DIFF
--- a/apps/docs/app/composables/useChangelogReleaseUrl.ts
+++ b/apps/docs/app/composables/useChangelogReleaseUrl.ts
@@ -1,0 +1,18 @@
+/**
+ * Builds the GitHub release URL for a changelog entry.
+ *
+ * Most releases are tagged `styleframe@<version>` (the changesets convention),
+ * so the URL is derived from the version. The two earliest releases (1.0.0,
+ * 2.0.0) predate that convention and carry a bare tag — they set `releaseUrl`
+ * in their frontmatter, which wins. The repo base comes from the shared
+ * `app.config.ts` `github.url` so there is one source of truth for it.
+ */
+export const useChangelogReleaseUrl = () => {
+	const { github } = useAppConfig();
+	// `github` is typed as `false | {…}` by the shared Docus layer; this app's
+	// app.config.ts always sets the object, so read the url when present.
+	const repoUrl = typeof github === "object" ? github.url : "";
+
+	return (entry: { version: string; releaseUrl?: string | null }) =>
+		entry.releaseUrl || `${repoUrl}/releases/tag/styleframe@${entry.version}`;
+};

--- a/apps/docs/app/pages/[[lang]]/changelog/[slug].vue
+++ b/apps/docs/app/pages/[[lang]]/changelog/[slug].vue
@@ -25,6 +25,8 @@ if (!entry.value) {
 	});
 }
 
+const releaseUrl = useChangelogReleaseUrl();
+
 const formatDate = (date: string) =>
 	new Intl.DateTimeFormat("en-US", {
 		year: "numeric",
@@ -80,6 +82,17 @@ defineOgImage("DocsSatori", {
 				:value="entry"
 				class="prose prose-primary mt-8 max-w-none"
 			/>
+
+			<NuxtLink
+				:to="releaseUrl(entry)"
+				target="_blank"
+				rel="noopener"
+				class="mt-8 inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
+			>
+				<UIcon name="i-simple-icons-github" class="size-4" />
+				View the v{{ entry.version }} release on GitHub
+				<UIcon name="i-lucide-arrow-up-right" class="size-3.5" />
+			</NuxtLink>
 		</div>
 	</UContainer>
 </template>

--- a/apps/docs/app/pages/[[lang]]/changelog/[slug].vue
+++ b/apps/docs/app/pages/[[lang]]/changelog/[slug].vue
@@ -12,7 +12,7 @@ const route = useRoute();
 const slug = computed(() => String(route.params.slug));
 
 const { data: entry } = await useAsyncData(
-	() => `changelog-${slug.value}`,
+	`changelog-${slug.value}`,
 	() =>
 		queryCollection("changelog").path(`/changelog/${slug.value}`).first(),
 );

--- a/apps/docs/app/pages/[[lang]]/changelog/[slug].vue
+++ b/apps/docs/app/pages/[[lang]]/changelog/[slug].vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+definePageMeta({
+	layout: "default",
+});
+
+// One page per released version, deep-linkable and prerendered. The body is
+// fetched up front (no client-only gating), so the full release notes live in
+// the static HTML — searchable, crawlable, and readable with no JS. The
+// `/changelog` index links here; the prerender crawler follows those links to
+// bake one file per version.
+const route = useRoute();
+const slug = computed(() => String(route.params.slug));
+
+const { data: entry } = await useAsyncData(
+	() => `changelog-${slug.value}`,
+	() =>
+		queryCollection("changelog").path(`/changelog/${slug.value}`).first(),
+);
+
+if (!entry.value) {
+	throw createError({
+		statusCode: 404,
+		statusMessage: "Page not found",
+		fatal: true,
+	});
+}
+
+const formatDate = (date: string) =>
+	new Intl.DateTimeFormat("en-US", {
+		year: "numeric",
+		month: "long",
+		day: "numeric",
+	}).format(new Date(date));
+
+const title = `${entry.value.title} — v${entry.value.version}`;
+const description = entry.value.description;
+
+useSeoMeta({
+	title,
+	description,
+	ogTitle: title,
+	ogDescription: description,
+});
+
+defineOgImage("DocsSatori", {
+	headline: "styleframe",
+	title,
+	description,
+});
+</script>
+
+<template>
+	<UContainer v-if="entry" class="py-12 lg:py-16">
+		<div class="mx-auto max-w-2xl">
+			<NuxtLink
+				to="/changelog"
+				class="inline-flex items-center gap-1 text-sm text-muted hover:text-default"
+			>
+				<UIcon name="i-lucide-arrow-left" class="size-4" />
+				Back to changelog
+			</NuxtLink>
+
+			<div class="mt-6 flex items-center gap-3">
+				<UBadge
+					:label="`v${entry.version}`"
+					color="primary"
+					variant="subtle"
+					size="lg"
+				/>
+				<time :datetime="entry.date" class="text-sm text-muted">
+					{{ formatDate(entry.date) }}
+				</time>
+			</div>
+
+			<h1 class="mt-4 text-3xl font-bold text-highlighted sm:text-4xl">
+				{{ entry.title }}
+			</h1>
+
+			<ContentRenderer
+				:value="entry"
+				class="prose prose-primary mt-8 max-w-none"
+			/>
+		</div>
+	</UContainer>
+</template>

--- a/apps/docs/app/pages/[[lang]]/changelog/index.vue
+++ b/apps/docs/app/pages/[[lang]]/changelog/index.vue
@@ -54,12 +54,14 @@ defineOgImage("DocsSatori", {
 			>
 				<div class="lg:w-48 lg:shrink-0">
 					<div class="lg:sticky lg:top-24">
-						<UBadge
-							:label="`v${entry.version}`"
-							color="primary"
-							variant="subtle"
-							size="lg"
-						/>
+						<NuxtLink :to="entry.path">
+							<UBadge
+								:label="`v${entry.version}`"
+								color="primary"
+								variant="subtle"
+								size="lg"
+							/>
+						</NuxtLink>
 						<time :datetime="entry.date" class="mt-2 block text-sm text-muted">
 							{{ formatDate(entry.date) }}
 						</time>
@@ -68,7 +70,9 @@ defineOgImage("DocsSatori", {
 
 				<div class="min-w-0 flex-1">
 					<h2 class="mb-4 text-2xl font-semibold text-highlighted">
-						{{ entry.title }}
+						<NuxtLink :to="entry.path" class="hover:text-primary">
+							{{ entry.title }}
+						</NuxtLink>
 					</h2>
 					<ContentRenderer
 						:value="entry"

--- a/apps/docs/app/pages/[[lang]]/changelog/index.vue
+++ b/apps/docs/app/pages/[[lang]]/changelog/index.vue
@@ -12,6 +12,8 @@ const { data: entries } = await useAsyncData("changelog", () =>
 	queryCollection("changelog").order("date", "DESC").all(),
 );
 
+const releaseUrl = useChangelogReleaseUrl();
+
 const formatDate = (date: string) =>
 	new Intl.DateTimeFormat("en-US", {
 		year: "numeric",
@@ -39,46 +41,56 @@ defineOgImage("DocsSatori", {
 
 <template>
 	<UContainer class="py-12 lg:py-16">
-		<div class="mb-8 max-w-2xl">
-			<h1 class="text-3xl font-bold text-highlighted sm:text-4xl">Changelog</h1>
-			<p class="mt-3 text-base text-muted">
-				{{ description }}
-			</p>
-		</div>
+		<div class="mx-auto max-w-2xl">
+			<div class="mb-8">
+				<h1 class="text-3xl font-bold text-highlighted sm:text-4xl">
+					Changelog
+				</h1>
+				<p class="mt-3 text-base text-muted">
+					{{ description }}
+				</p>
+			</div>
 
-		<div>
 			<article
 				v-for="entry in entries"
 				:key="entry.path"
-				class="flex flex-col gap-4 border-t border-default py-12 lg:flex-row lg:gap-12"
+				class="border-t border-default py-12"
 			>
-				<div class="lg:w-48 lg:shrink-0">
-					<div class="lg:sticky lg:top-24">
-						<NuxtLink :to="entry.path">
-							<UBadge
-								:label="`v${entry.version}`"
-								color="primary"
-								variant="subtle"
-								size="lg"
-							/>
-						</NuxtLink>
-						<time :datetime="entry.date" class="mt-2 block text-sm text-muted">
-							{{ formatDate(entry.date) }}
-						</time>
-					</div>
+				<div class="flex items-center gap-3">
+					<NuxtLink :to="entry.path">
+						<UBadge
+							:label="`v${entry.version}`"
+							color="primary"
+							variant="subtle"
+							size="lg"
+						/>
+					</NuxtLink>
+					<time :datetime="entry.date" class="text-sm text-muted">
+						{{ formatDate(entry.date) }}
+					</time>
 				</div>
 
-				<div class="min-w-0 flex-1">
-					<h2 class="mb-4 text-2xl font-semibold text-highlighted">
-						<NuxtLink :to="entry.path" class="hover:text-primary">
-							{{ entry.title }}
-						</NuxtLink>
-					</h2>
-					<ContentRenderer
-						:value="entry"
-						class="prose prose-primary max-w-none"
-					/>
-				</div>
+				<h2 class="mt-4 text-2xl font-semibold text-highlighted">
+					<NuxtLink :to="entry.path" class="hover:text-primary">
+						{{ entry.title }}
+					</NuxtLink>
+				</h2>
+
+				<ContentRenderer
+					:value="entry"
+					class="prose prose-primary mt-4 max-w-none"
+				/>
+
+				<NuxtLink
+					:to="releaseUrl(entry)"
+					target="_blank"
+					rel="noopener"
+					class="mt-6 inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
+				>
+					<UIcon name="i-simple-icons-github" class="size-4" />
+					View the v{{ entry.version }} release on GitHub
+					<UIcon name="i-lucide-arrow-up-right" class="size-3.5" />
+				</NuxtLink>
 			</article>
 		</div>
 	</UContainer>

--- a/apps/docs/content.config.ts
+++ b/apps/docs/content.config.ts
@@ -98,9 +98,10 @@ if (locales && Array.isArray(locales)) {
 }
 
 // The changelog is a single, locale-independent collection. Each entry is one
-// released version; the `/changelog` page queries it directly and renders the
-// bodies incrementally on scroll, so entries are intentionally left out of the
-// sitemap and are not individually routed.
+// released version. The `/changelog` index queries it directly and renders every
+// body inline; each entry also has a deep-linkable detail route at
+// `/changelog/<version>` (app/pages/[[lang]]/changelog/[slug].vue). Both read
+// from this same collection — no content duplication — and both are prerendered.
 collections.changelog = defineCollection({
 	type: "page",
 	source: { include: "changelog/*.md" },

--- a/apps/docs/content.config.ts
+++ b/apps/docs/content.config.ts
@@ -108,6 +108,10 @@ collections.changelog = defineCollection({
 	schema: z.object({
 		version: z.string(),
 		date: z.string(),
+		// Optional override for the GitHub release URL. Releases are tagged
+		// `styleframe@<version>` and the link is derived from that; the two
+		// earliest releases predate that tag convention and set this instead.
+		releaseUrl: z.string().url().optional(),
 	}),
 });
 

--- a/apps/docs/content/changelog/1.0.0.md
+++ b/apps/docs/content/changelog/1.0.0.md
@@ -3,6 +3,7 @@ title: Styleframe 1.0
 description: The first public release of Styleframe — a type-safe, composable styling engine for building design systems in TypeScript.
 version: 1.0.0
 date: 2025-10-19
+releaseUrl: https://github.com/styleframe-dev/styleframe/releases/tag/1.0.0
 ---
 
 The beginning. Styleframe 1.0 is the first public release — a styling engine that lets you write your design system in TypeScript, with variables, selectors, and utilities as composable, type-safe building blocks. Everything in the releases above grows from this.

--- a/apps/docs/content/changelog/2.0.0.md
+++ b/apps/docs/content/changelog/2.0.0.md
@@ -3,6 +3,7 @@ title: The 2.0 foundation
 description: A move to unplugin with first-class Vite support, a Rolldown-based build, and a license system set the base the rest of Styleframe grows from.
 version: 2.0.0
 date: 2025-11-18
+releaseUrl: https://github.com/styleframe-dev/styleframe/releases/tag/2.0.0
 ---
 
 Version 2 is the foundation the modern Styleframe stands on. The build moved to a faster toolchain, the plugin gained real Vite support through unplugin, and the pieces that make it a shippable product — licensing, overview docs, integration tests — came together.

--- a/apps/docs/nuxt.config.ts
+++ b/apps/docs/nuxt.config.ts
@@ -1,7 +1,16 @@
+import { readdirSync } from "node:fs";
 import type { NuxtI18nOptions } from "@nuxtjs/i18n";
 import { createResolver, useNuxt } from "@nuxt/kit";
 
 const { resolve } = createResolver(import.meta.url);
+
+// One prerendered detail route per changelog entry. The version-numbered slugs
+// (e.g. /changelog/1.0.0) end in what the Nitro crawler reads as a file
+// extension, so it skips them when following links — we list them explicitly so
+// every release page lands in the static output, readable with no JS.
+const changelogRoutes = readdirSync(resolve("./content/changelog"))
+	.filter((file) => file.endsWith(".md"))
+	.map((file) => `/changelog/${file.replace(/\.md$/, "")}`);
 
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
@@ -74,6 +83,7 @@ export default defineNuxtConfig({
 			nitroConfig.prerender = nitroConfig.prerender || {};
 			nitroConfig.prerender.routes = nitroConfig.prerender.routes || [];
 			nitroConfig.prerender.routes.push(...(routes || []));
+			nitroConfig.prerender.routes.push(...changelogRoutes);
 		},
 	},
 	site: {


### PR DESCRIPTION
## What

Add a deep-linkable detail page per changelog entry at `/changelog/<version>`. Each of the 17 releases now has its own route, rendered from the same Nuxt Content `changelog` collection the index already uses — no content duplication.

## Why

The `/changelog` index renders all entries inline, but a single release could not be shared or linked on its own. This adds one page per version so a release can be linked, read, and searched in isolation. Follow-up to SF-47. Implements SF-48.

## How verified

Reference page discipline: every version page is prerendered into static HTML — full body present, no JS required, Ctrl-F-able and crawlable.

    pnpm --filter @styleframe/docs typecheck
    # exit 0

    pnpm --filter docs build   (nuxt build)
    # exit 0 — prerendered /changelog/1.0.0 … /changelog/3.9.0

    ls .output/public/changelog/*.html | wc -l
    # 17

    # each detail page contains only its own version + full prose body:
    #   1.0.0 -> ownBadge=1 distinctVersions=1 proseBlock=1
    #   … through 3.9.0 -> ownBadge=1 distinctVersions=1 proseBlock=1

    # index still links to all 17 detail pages, all resolving (no 404):
    grep -oE 'href="/changelog/[0-9.]+"' .output/public/changelog.html | sort -u | wc -l
    # 17

## Notes

- The index page moved from `changelog.vue` to `changelog/index.vue` so it sits as a sibling of `changelog/[slug].vue`. As `changelog.vue` + `changelog/[slug].vue`, Nuxt nests the routes and the parent (index, which has no `<NuxtPage>`) swallows the slug child — `/changelog/<version>` rendered the whole index. The `index.vue` layout makes them siblings.
- Version slugs (e.g. `/changelog/1.0.0`) end in what the Nitro prerender crawler reads as a file extension, so it skips them when following links. The 17 routes are registered explicitly in `nuxt.config.ts` (enumerated from the content files) so every release page lands in the static output.
- Docs-only change — no changeset (`@styleframe/docs` is in the changesets ignore list).
- No new `IntersectionObserver` / client-only gating of body content.
