### PR TITLE
ci: publish packages on changeset version PR merge

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -57,7 +57,7 @@ jobs:
                   version: pnpm ci:version
                   commit: "chore: update versions"
                   title: "chore: update versions"
-                  # publish: pnpm exec changeset publish
+                  publish: pnpm exec changeset publish
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## What

Enable the `publish` step in the existing `Changesets` workflow so that merging the
version PR (`changeset-release/main`) into `main` publishes the affected packages to
npm. Previously the workflow only opened/updated the version PR; the publish line was
commented out, so nothing ever shipped.

## Why

Completes the release-automation half of the changesets flow: on push to `main`,
`changesets/action` either opens/updates the version PR (when changesets are present)
or runs `changeset publish` (when the version PR has merged and versions are already
bumped). Implements SF-49.

Trigger path:

1. A PR with changesets merges to `main`.
2. `changesets/action` sees pending changesets → opens/updates `changeset-release/main`
   with `pnpm ci:version` (`changeset version` + lockfile refresh).
3. That version PR merges to `main` → no changesets remain → the action runs
   `pnpm exec changeset publish`, pushing `engine/*`, `theme`, and `tooling/*` to npm.

The build already runs in the prior "Build packages for release" step
(`pnpm run ci:prepublish` → `build:nodocs`), so the publish command is
`changeset publish` directly rather than `ci:publish` (which would rebuild).

Auth is already wired: `NPM_TOKEN` / `NODE_AUTH_TOKEN` (set from the `NPM_TOKEN`
secret, with `registry-url` configured on `setup-node`) for the npm registry, and the
default `GITHUB_TOKEN` for the version PR.

## How verified

    pnpm lint:actions
    # actionlint — no output, clean

One-line diff (enable the previously commented publish step):

    -                  # publish: pnpm exec changeset publish
    +                  publish: pnpm exec changeset publish

## Notes

- Extends the existing `.github/workflows/changesets.yml` rather than adding a new
  `release.yml` — the single `changesets/action` step already handles both the version
  PR and the publish, so duplicating it would race on the same branch.
- No changeset in this PR: only a workflow file changed, no publishable package.
- **One human dependency:** the `NPM_TOKEN` repo secret must be provisioned (an npm
  automation token with publish rights to the styleframe npm scope). The workflow
  references it but publishing will fail until it exists.
