### PR TITLE
refactor(docs): drop the layer CSS strip hook, adopt the shared guard preset

### DIFF
--- a/apps/docs/app/assets/css/main.css
+++ b/apps/docs/app/assets/css/main.css
@@ -8,13 +8,23 @@
  * owns the single `@import "tailwindcss"` / `@import "@nuxt/ui"` — so the brand
  * theme compiles in that SAME pass.
  *
- * The layer also registers its `main.css` as a standalone CSS entry; that
- * registration is stripped in `nuxt.config.ts` (see the `modules:done` hook).
- * Two Tailwind entries would each re-emit every base utility, and the second
- * copy — landing after the first pass's responsive rules at equal specificity —
- * wins by source order and silently kills every `sm:`/`lg:` variant (h1 renders
- * 48px instead of 72px, layouts collapse). One entry, one emission, correct
- * cascade.
+ * This must stay the ONLY registered CSS entry. A second one — a bare
+ * `@import "tailwindcss"` here, or a layer registering its own base in `css:`
+ * alongside this file — opens a second Tailwind pass that re-emits every base
+ * utility a second time. What that costs is payload, not layout: measured at
+ * +212 KB raw / +26.7 KB gzip on a consumer's render-blocking `entry.css`, on
+ * every page for every visitor (UXF-118). It does not, on the evidence
+ * gathered there, break the cascade — the duplicate pass was a complete
+ * superset of the first and emitted wholly after it, so the last `sm:`/`lg:`
+ * variant still landed after the last conflicting base and won by source
+ * order; computed-style A/B across 4 pages x 4 viewports found zero rendering
+ * difference. That rescue is incidental, not designed.
+ *
+ * The layer used to register its own `main.css` too, and this app stripped it
+ * back off with a `modules:done` hook. `@uxfront/layer-docs` >= 0.3.0 no longer
+ * registers it, so the hook is gone (UXF-121). Both halves — this file being a
+ * Tailwind entry, and there being exactly one of them — are asserted by
+ * `test/brand-palette-*.test.ts` against the layer's shared preset.
  */
 @import "@uxfront/layer-docs/app/assets/css/main.css";
 

--- a/apps/docs/nuxt.config.ts
+++ b/apps/docs/nuxt.config.ts
@@ -66,22 +66,6 @@ export default defineNuxtConfig({
 		},
 	},
 	hooks: {
-		/**
-		 * Collapse to a single Tailwind pass. The layer registers its own
-		 * `main.css` as a standalone CSS entry; this app re-imports that same
-		 * base from its own `main.css` so the brand `@theme` compiles in the
-		 * layer's Tailwind pass. Drop the layer's standalone registration here —
-		 * two Tailwind entries each re-emit every base utility, and the later
-		 * copy wins by source order at equal specificity, clobbering every
-		 * `sm:`/`lg:` responsive variant (see `app/assets/css/main.css`).
-		 */
-		"modules:done": () => {
-			const nuxt = useNuxt();
-			nuxt.options.css = nuxt.options.css.filter(
-				(entry) =>
-					typeof entry !== "string" || !entry.includes("@uxfront/layer-docs"),
-			);
-		},
 		"nitro:config"(nitroConfig) {
 			const nuxt = useNuxt();
 

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -23,7 +23,7 @@
 		"@nuxtjs/robots": "catalog:nuxt",
 		"@nuxtjs/sitemap": "catalog:nuxt",
 		"@unhead/vue": "catalog:nuxt",
-		"@uxfront/layer-docs": "^0.2.0",
+		"@uxfront/layer-docs": "^0.3.0",
 		"@vueuse/core": "catalog:nuxt",
 		"defu": "catalog:",
 		"motion-v": "catalog:nuxt",

--- a/apps/docs/test/brand-palette-compiled.build.test.ts
+++ b/apps/docs/test/brand-palette-compiled.build.test.ts
@@ -1,81 +1,33 @@
-import { existsSync, readdirSync, readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { describe, expect, it } from "vitest";
+import { describeSingleTailwindPass } from "@uxfront/layer-docs/test";
 
 /**
- * Compiled-output regression guard for the single-Tailwind-pass invariant on the
- * `@uxfront/layer-docs` re-point (PR #327).
+ * Compiled-output half of the brand-palette guard: exactly one Tailwind pass in
+ * the shipped stylesheet, and the teal palette present in it.
  *
- * The companion source guard (`brand-palette-css.test.ts`) only asserts that
- * `main.css` is a Tailwind entry — it cannot see the failure mode this file
- * exists for. When the consumer opens a SECOND Tailwind pass (a bare
- * `@import "tailwindcss"`) or the layer's standalone CSS registration is not
- * stripped in `nuxt.config.ts`, every base utility is emitted twice into the
- * final stylesheet. The second copy lands after the first pass's responsive
- * rules at equal specificity and wins by source order, silently killing every
- * `sm:`/`lg:` variant: the homepage `h1` renders 48px instead of 72px and
- * multi-column layouts collapse. Only the compiled CSS shows this, so this guard
- * inspects the real build output.
+ * **What this guards is payload, not layout.** An earlier version of this
+ * docblock claimed the second pass "silently kills every `sm:`/`lg:` variant —
+ * the homepage `h1` renders 48px instead of 72px and multi-column layouts
+ * collapse". That was wrong, and it is corrected here (UXF-121). On the
+ * evidence gathered in UXF-118 the second pass costs +212 KB raw / +26.7 KB
+ * gzip on a render-blocking `entry.css`, on every page for every visitor — but
+ * it does not break the cascade: the duplicate pass was a complete superset of
+ * the first and emitted wholly after it, so the last `sm:`/`lg:` variant still
+ * landed after the last conflicting base and won by source order. A
+ * computed-style A/B across 4 pages x 4 viewports found zero rendering
+ * difference. That rescue is incidental, not designed — a non-superset second
+ * pass and the cascade does break — but the guard should describe what it
+ * actually measures.
  *
- * Reference measurement (viewport-independent): on the broken build the docs
- * `entry.css` carried ~150 duplicated top-level utility selectors and each base
- * utility below appeared twice; the single-pass build emits each exactly once.
+ * The assertion set (both unwrapped and `@media`-wrapped utilities, and
+ * `=== 1` rather than `<= 1`) lives in the layer preset; see its docblock for
+ * why each choice is load-bearing.
  *
- * Requires a prior `nuxt build`. It is intentionally NOT part of the default
- * `pnpm test` run (that job does not build the docs app); it runs via
- * `pnpm --filter @styleframe/docs test:build` in the docs build job.
+ * Requires a prior `nuxt build`. Excluded from the default `pnpm test` run (see
+ * `vitest.config.ts`); runs via `pnpm --filter @styleframe/docs test:build` in
+ * the docs build job, against the artifact that job just produced.
  */
-const nuxtDir = fileURLToPath(
-	new URL("../.output/public/_nuxt", import.meta.url),
-);
-
-function readEntryCss(): string {
-	if (!existsSync(nuxtDir)) {
-		throw new Error(
-			`Compiled output not found at ${nuxtDir}. Build the docs app first ` +
-				`(nuxt build) before running the compiled-output guard.`,
-		);
-	}
-	const entry = readdirSync(nuxtDir)
-		.filter((f) => /^entry\..*\.css$/.test(f))
-		.sort();
-	if (entry.length === 0) {
-		throw new Error(
-			`No entry.*.css found in ${nuxtDir}. Build the docs app first (nuxt build).`,
-		);
-	}
-	// Strip comments so counts reflect emitted rules only.
-	return readFileSync(`${nuxtDir}/${entry.at(-1)}`, "utf8").replace(
-		/\/\*[\s\S]*?\*\//g,
-		"",
-	);
-}
-
-/** Count how many times a base utility is emitted as its own class selector. */
-function countBaseUtility(css: string, utility: string): number {
-	const escaped = utility.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-	// A leading `.` immediately followed by the class name, not part of a longer
-	// variant selector such as `.sm\:text-5xl` (there the class is preceded by a
-	// escaped colon, so `.text-5xl` never appears).
-	const re = new RegExp(`(?<![\\w\\\\:-])${escaped}(?![\\w-])`, "g");
-	return (css.match(re) ?? []).length;
-}
-
-// Ubiquitous base utilities the layer and Nuxt UI always emit. Each must appear
-// exactly once in a single-pass build; the double-emit regression makes them 2.
-const BASE_UTILITIES = [".relative", ".flex", ".grid", ".hidden", ".block"];
-
-describe("docs compiled CSS: single Tailwind pass", () => {
-	const css = readEntryCss();
-
-	it("emits the hero heading utility .text-5xl exactly once", () => {
-		expect(countBaseUtility(css, ".text-5xl")).toBe(1);
-	});
-
-	it("does not double-emit base utilities (no second Tailwind pass)", () => {
-		const duplicated = BASE_UTILITIES.filter(
-			(u) => countBaseUtility(css, u) > 1,
-		);
-		expect(duplicated).toEqual([]);
-	});
+describeSingleTailwindPass({
+	output: new URL("../.output/public/_nuxt", import.meta.url),
+	scale: "teal",
+	utilities: [".text-5xl"],
 });

--- a/apps/docs/test/brand-palette-css.test.ts
+++ b/apps/docs/test/brand-palette-css.test.ts
@@ -1,59 +1,20 @@
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { describe, expect, it } from "vitest";
+import { describeBrandPaletteCss } from "@uxfront/layer-docs/test";
 
 /**
- * Regression guard for the brand-palette compile precondition on the
- * `@uxfront/layer-docs` re-point (PR #327).
+ * Source-level half of the brand-palette guard, from the layer's shared preset
+ * so all three consumers assert the same invariant the same way.
  *
- * Root cause it guards: a Tailwind `@theme` block only compiles into real
- * `:root` custom properties when it lives in a file that is part of a Tailwind
- * pass. If this file stops being a Tailwind entry the `@theme static
- * { --color-teal … }` block ships to the browser verbatim; browsers discard the
- * unknown at-rule, leaving `--color-teal` / `--ui-primary` undefined and every
- * `*-primary` utility falling back to black/transparent site-wide.
+ * What it guards: a Tailwind `@theme` block only compiles into real `:root`
+ * custom properties when it lives in a file that is part of a Tailwind pass. If
+ * `app/assets/css/main.css` stops importing the layer's base, the
+ * `@theme static { --color-teal … }` block ships to the browser verbatim,
+ * browsers discard the unknown at-rule, and every `*-primary` utility falls
+ * back to black/transparent site-wide.
  *
- * The entry is established by importing a Tailwind pass BEFORE the `@theme`
- * block. The direct `@import "tailwindcss"` the first teal fix used opened a
- * SECOND Tailwind pass (the layer already owns one), which re-emitted every
- * base utility after the layer's responsive rules and clobbered every
- * `sm:`/`lg:` variant by source order. The fix folds this file into the layer's
- * single pass by importing the layer's base CSS instead — still a valid entry,
- * one emission (see `app/assets/css/main.css`). This guard therefore accepts
- * either a direct `tailwindcss` import or the layer base import as the entry.
- *
- * Source-level invariant guard: it asserts the precondition that makes the
- * brand palette compile, so the regression cannot silently return without a
- * full build. It intentionally does not re-run the Nuxt build; the
- * compiled-output check lives in the docs build job in CI.
+ * Cheap — reads one file, so it runs in the default `pnpm test`. The
+ * compiled-output half is `brand-palette-compiled.build.test.ts`.
  */
-const mainCss = readFileSync(
-	fileURLToPath(new URL("../app/assets/css/main.css", import.meta.url)),
-	"utf8",
-);
-
-// A Tailwind pass reached either directly or via the layer's base CSS (which
-// owns the single `@import "tailwindcss"`). Either makes this file an entry.
-const TAILWIND_ENTRY_IMPORT =
-	/@import\s+["'](?:tailwindcss|@uxfront\/layer-docs\/[^"']*main\.css)["']/;
-
-describe("docs brand palette CSS entrypoint", () => {
-	it("imports a Tailwind pass so it is a Tailwind entry", () => {
-		expect(mainCss).toMatch(TAILWIND_ENTRY_IMPORT);
-	});
-
-	it("imports the Tailwind pass before the first @theme block", () => {
-		const importIndex = mainCss.search(TAILWIND_ENTRY_IMPORT);
-		// Match the block opener specifically, not the `@theme` word in the
-		// leading docblock comment.
-		const themeIndex = mainCss.search(/@theme\s+static\s*\{/);
-		expect(importIndex).toBeGreaterThanOrEqual(0);
-		expect(themeIndex).toBeGreaterThanOrEqual(0);
-		expect(importIndex).toBeLessThan(themeIndex);
-	});
-
-	it("defines the teal scale and maps it onto --ui-primary", () => {
-		expect(mainCss).toMatch(/@theme\s+static\s*\{[\s\S]*--color-teal\s*:/);
-		expect(mainCss).toMatch(/--ui-primary\s*:\s*var\(\s*--color-teal\s*\)/);
-	});
+describeBrandPaletteCss({
+	entry: new URL("../app/assets/css/main.css", import.meta.url),
+	scale: "teal",
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -422,8 +422,8 @@ importers:
         specifier: catalog:nuxt
         version: 2.0.19(vue@3.5.38(typescript@6.0.3))
       '@uxfront/layer-docs':
-        specifier: ^0.2.0
-        version: 0.2.0(85e3e4239b7356efe0ee0e8a759b4dba)
+        specifier: ^0.3.0
+        version: 0.3.0(25877dc4bbe5ce95f60820be2d242ac6)
       '@vueuse/core':
         specifier: catalog:nuxt
         version: 14.3.0(vue@3.5.38(typescript@6.0.3))
@@ -6289,8 +6289,8 @@ packages:
   '@unocss/core@66.7.0':
     resolution: {integrity: sha512-j6MFMx5C3iIwW4T4hVbh+30fKWgSGkmS3bCcdjlfqM88lRT+dHFBN9nkfNOBJT6e6IHN9415nexuzcQvTjJXxw==}
 
-  '@uxfront/layer-docs@0.2.0':
-    resolution: {integrity: sha512-AW2yNCaxGrQ9OGG2W2IlVocCZtOmzYg/f/sFahOA3Gju5VKh6SaNEcBrgEHv+JSWRj2jD397w3LtCrmiM+Ij8Q==}
+  '@uxfront/layer-docs@0.3.0':
+    resolution: {integrity: sha512-5LdPCxbzeVEVcYCoSmGFuuZRp524ifiCTALhgfES5bOLuEFNMWaYOUrb0OZUnR32eOIHiGyZMqNwHMOZ/Ebtgg==}
     peerDependencies:
       '@nuxt/content': ^3.14.0
       '@nuxt/image': ^1.11.0
@@ -6306,6 +6306,7 @@ packages:
       posthog-js: ^1.386.6
       tailwindcss: ^4.3.1
       typescript: ^6.0.3
+      vitest: ^4.1.10
       vue: ^3.5.38
     peerDependenciesMeta:
       '@nuxtjs/i18n':
@@ -6315,6 +6316,8 @@ packages:
       posthog-js:
         optional: true
       typescript:
+        optional: true
+      vitest:
         optional: true
 
   '@valibot/to-json-schema@1.7.0':
@@ -18571,7 +18574,7 @@ snapshots:
 
   '@unocss/core@66.7.0': {}
 
-  '@uxfront/layer-docs@0.2.0(85e3e4239b7356efe0ee0e8a759b4dba)':
+  '@uxfront/layer-docs@0.3.0(25877dc4bbe5ce95f60820be2d242ac6)':
     dependencies:
       '@nuxt/content': 3.14.0(@valibot/to-json-schema@1.7.0(valibot@1.4.1(typescript@6.0.3)))(better-sqlite3@12.10.1)(magicast@0.3.5)(valibot@1.4.1(typescript@6.0.3))
       '@nuxt/image': 1.11.0(@netlify/blobs@9.1.2)(db0@0.3.4(better-sqlite3@12.10.1))(ioredis@5.10.1)(magicast@0.3.5)
@@ -18597,6 +18600,7 @@ snapshots:
       '@nuxtjs/mdc': 0.22.0(magicast@0.3.5)
       posthog-js: 1.386.6
       typescript: 6.0.3
+      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@24.10.4)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@25.0.1)(vite@8.0.16(@types/node@24.10.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - react


### PR DESCRIPTION
## Summary

Consumer half of UXF-121. **Draft — blocked on `@uxfront/layer-docs@0.3.0` publishing** ([uxfront-com/uxfront#58](https://github.com/uxfront-com/uxfront/pull/58)). `apps/docs/package.json` references `^0.3.0` and the lockfile cannot be regenerated until that version exists on npm, so CI will fail install until then.

- **Removes the `modules:done` strip hook.** The layer no longer registers its own base stylesheet in `css:` as of 0.3.0, so the hook this app carried to un-register it has nothing left to strip. The app's single `css:` entry is now the only Tailwind entry by construction rather than by workaround.
- **Both brand-palette guards now call the layer's shared preset** (`@uxfront/layer-docs/test`), parameterised on the teal scale. Same assertion set across all three consumers, maintained in one place. The preset also asserts `@media`-wrapped utilities, which the local versions did not.
- **Corrects a stale claim** in two places.

## The stale claim

The previous test docblock and the hook comment both asserted the second Tailwind pass *"silently kills every `sm:`/`lg:` variant — the homepage `h1` renders 48px instead of 72px and multi-column layouts collapse."*

That is wrong, and it has been repeated into three files. On the evidence gathered in UXF-118 the duplicate pass costs **payload, not layout**: +212 KB raw / +26.7 KB gzip on a render-blocking `entry.css`, on every page for every visitor. It did not break the cascade — the duplicate pass was a complete superset of the first and emitted wholly after it, so the last `sm:`/`lg:` variant still landed after the last conflicting base and won by source order. A computed-style A/B across 4 pages × 4 viewports found zero rendering difference.

That rescue is incidental, not designed: a non-superset second pass, or a different emission order, and the cascade does break. But the guard should describe what it actually measures, so nobody re-derives a rendering emergency from a payload regression.

## Verification

With the hook removed and the fixed layer installed from a packed tarball, `apps/docs` builds to `entry.DME-eVhB.css` — **the same content hash, byte for byte, as the build the strip hook produced**: 224,122 B raw / 29,693 B gzip. Every asserted utility, base and responsive, counts 1.

That answers the no-visual-regression criterion by hash equality rather than by eyeball. This app was already single-pass; what changes is that it no longer needs a workaround to stay that way.

## Test plan

- [x] `vitest run` — 3 tests pass via the preset (verified against a packed tarball install, not a workspace symlink)
- [x] `nuxt build` clean, then `vitest run --config vitest.build.config.ts` — 2 tests pass
- [x] Output hash identical to the pre-change hooked build
- [x] `pnpm run format:check` and `oxlint apps/docs` clean
- [ ] Re-run `pnpm install` to refresh the lockfile once `@uxfront/layer-docs@0.3.0` is published, then un-draft

Refs UXF-121, UXF-118
