### PR TITLE
fix(docs): point "Edit this page" at apps/docs via github.rootDir

### DIFF
--- a/apps/docs/app/app.config.ts
+++ b/apps/docs/app/app.config.ts
@@ -67,6 +67,12 @@ export default defineAppConfig({
 	github: {
 		url: "https://github.com/styleframe-dev/styleframe",
 		branch: "main",
+		// Path from the repository root to this Nuxt app. The layer builds the
+		// "Edit this page" href as
+		// `{url}/edit/{branch}/{rootDir}/content/{stem}.{extension}`; with
+		// `rootDir` unset the segment is dropped and every link 404s, because the
+		// content lives at `apps/docs/content/`, not `content/`.
+		rootDir: "apps/docs",
 	},
 	footer: {
 		credits: `Copyright © ${new Date().getFullYear()} styleframe`,


### PR DESCRIPTION
## Description

The docs theme layer builds the "Edit this page" href as
`{url}/edit/{branch}/{rootDir}/content/{stem}.{extension}` and filters out falsy
segments. `github.rootDir` was unset, so the segment was dropped and every link
resolved to `https://github.com/styleframe-dev/styleframe/edit/main/content/...`
— a 404, because the docs content lives at `apps/docs/content/`.

Setting `rootDir: "apps/docs"` restores the correct target.

Found while auditing the same bug in the inkline consumer of `@uxfront/layer-docs`
(both repos had it). Fixed per-consumer rather than defaulted in the layer, because
the layer cannot know a consumer's directory layout — inferring it from the git root
would be a separate layer change.

## Related issue

Relates to UXF-169.

## Type of change

- [x] 🐞 Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My commits follow Conventional Commits with a package scope (e.g. `feat(theme): …`)
- [ ] I ran `pnpm build:nodocs && pnpm lint && pnpm typecheck && pnpm test` and everything passes
- [x] I added a changeset (`pnpm changeset`) for changes to publishable packages, or this change only touches docs/storybook/app/playground/tests
- [x] I added or updated tests where relevant
- [x] I updated documentation where relevant
- [x] I did **not** edit generated files (`dist/`, `.styleframe/`)
- [x] My PR targets `main` and stays focused in scope

## Notes

One-line config change in `apps/docs`; no publishable package touched, so no changeset.
Full local suite not run — CI covers it.

Verified in the sibling inkline repo by prerendering the docs and reading the emitted
href, which changed from `/edit/main/content/docs/...` to
`/edit/main/apps/website/content/docs/...`. The path shape is identical here.

Separately noted, not changed: `toc.bottom.edit` in the same file points at
`.../edit/main/docs/content`, which is also stale — but nothing in the current layer
reads that key, so it is dead config rather than a live 404.
